### PR TITLE
Samoline expand synth generation

### DIFF
--- a/core/models/utility_models.py
+++ b/core/models/utility_models.py
@@ -76,5 +76,9 @@ class Message(BaseModel):
 
 
 class Prompts(BaseModel):
-    synth_data_creation_sys: str
-    synth_data_creation_prompt: str
+    synth_data_creation_from_distribution_sys: str
+    synth_data_creation_from_distribution_prompt: str
+    output_reformulation_sys: str
+    output_reformulation_prompt: str
+    input_generation_sys: str
+    input_generation_prompt: str

--- a/validator/core/cycle.py
+++ b/validator/core/cycle.py
@@ -43,8 +43,9 @@ async def _run_task_prep(task: Task, keypair: Keypair) -> Task:
         for i in [task.system, task.instruction, task.input, task.output]
         if i is not None
     ]
+    column_to_reformulate = task.output
     test_data, synth_data, train_data = await prepare_task(
-        dataset_name=task.ds_id, columns_to_sample=columns_to_sample, keypair=keypair
+        dataset_name=task.ds_id, columns_to_sample=columns_to_sample, column_to_reformulate=column_to_reformulate, keypair=keypair
     )
     task.hf_training_repo = train_data
     task.status = TaskStatus.LOOKING_FOR_NODES
@@ -172,7 +173,7 @@ async def _let_miners_know_to_start_training(
         task_id=str(task.task_id),
         hours_to_complete=task.hours_to_complete,
     )
-    logger.info(f"We are tellingminers to start training there are  {len(nodes)}")
+    logger.info(f"We are telling miners to start training there are {len(nodes)}")
 
     for node in nodes:
         response = await process_non_stream_fiber(

--- a/validator/evaluation/eval.py
+++ b/validator/evaluation/eval.py
@@ -35,7 +35,7 @@ def _load_and_update_evaluation_config(
     with open(config_path, "r") as file:
         config_dict = yaml.safe_load(file)
 
-    dataset_entry = create_dataset_entry( # TODO: double-check works outta the box
+    dataset_entry = create_dataset_entry(
         dataset=dataset_name,
         dataset_type=dataset_type,
         file_format=file_format,

--- a/validator/prompts.yml
+++ b/validator/prompts.yml
@@ -1,4 +1,4 @@
-synth_data_creation_sys: >
+synth_data_creation_from_distribution_sys: >
   You are an expert in creating synthetic data for testing and training.
   You will be given a few examples of a datasets and a schema for that dataset.
   You will create a single, valid data point that adheres to the schema.
@@ -41,8 +41,42 @@ synth_data_creation_sys: >
   {"question": "Generate an approximately twenty-word sentence that describes all this data: The Crimson Oak eatType pub; The Crimson Oak food American; The Crimson Oak priceRange cheap; The Crimson Oak customer rating 4 out of 5; The Crimson Oak near Riverside Park",
   "answer": "The Crimson Oak is a cheap American pub near Riverside Park with a 4 out of 5 customer rating."}
 
-synth_data_creation_prompt: >
+synth_data_creation_from_distribution_prompt: >
   Create a single, valid data point that adheres to the schema provided.
   Schema:
   {schema}
   Data Point:
+
+output_reformulation_sys: >
+  You are an expert in analyzing and reformulating data. You will receive a data sample
+  and need to reformulate the specified field while maintaining semantic equivalence.
+  You will also analyze the overall topic and nature of the data sample and provide a brief description (1 sentence).
+  You will return only the requested json, with no other text or whitespace.
+
+output_reformulation_prompt: >
+  Given this data sample:
+  {data}
+
+  1. Reformulate the {output_field} field while maintaining its meaning
+  2. Provide a brief description of what this overall data sample is about
+
+  Return your response in JSON format:
+  {{"reformulated_output": "your reformulation", "description": "your topic description"}}
+
+input_generation_sys: >
+  You are an expert in generating synthetic data. You will receive:
+  - A field already fixed
+  - A schema to strictly adhere to for the generated data point in JSON format
+  - A description of the topic and nature of the data sample to populate
+  You will generate matching remaining fields of the schema that are semantically consistent with the given field.
+  You will create a single, valid data point that adheres to the schema, which should include
+  the fixed field with its corresponding fixed value unchanged.
+  You will return only the requested json, with no other text or whitespace.
+
+input_generation_prompt: >
+  Generate remaining fields for the following schema: {schema}
+  The {output_field} field is fixed to: {output}
+  Description of the data sample to populate: {description}
+
+  Generate the remaining fields, ensuring they are consistent with the given {output_field} field and the overall description.
+  Return your response in JSON format with the {output_field} field included.

--- a/validator/synth/synth.py
+++ b/validator/synth/synth.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import random
 from typing import List
 
 import yaml
@@ -53,14 +54,44 @@ def load_and_sample_dataset(dataset_name: str, columns_to_sample: List[str]) -> 
     return sampled_data_list
 
 
-def create_messages_from_row(row: dict, prompts: Prompts) -> List[Message]:
+def create_messages_for_distribution_replication(row: dict, prompts: Prompts) -> List[Message]:
     messages = []
-    system_message = Message(
-        role=Role.SYSTEM, content=prompts.synth_data_creation_sys)
+    system_message = Message(role=Role.SYSTEM, content=prompts.synth_data_creation_from_distribution_sys)
     messages.append(system_message)
     schema = json.dumps({key: value for key, value in row.items()})
-    user_message = Message(
-        role=Role.USER, content=prompts.synth_data_creation_prompt.format(schema=schema))
+    user_message = Message(role=Role.USER, content=prompts.synth_data_creation_from_distribution_prompt.format(schema=schema))
+    messages.append(user_message)
+    return messages
+
+
+def create_messages_for_output_reformulation(row: dict, output_field: str, prompts: Prompts) -> List[Message]:
+    messages = []
+    system_message = Message(role=Role.SYSTEM, content=prompts.output_reformulation_sys)
+    messages.append(system_message)
+    user_message = Message(role=Role.USER, content=prompts.output_reformulation_prompt.format(
+        data=json.dumps(row),
+        output_field=output_field
+    ))
+    messages.append(user_message)
+    return messages
+
+
+def create_messages_for_input_generation(
+    reformulated_output: str,
+    description: str,
+    output_field: str,
+    schema: dict,
+    prompts: Prompts
+) -> List[Message]:
+    messages = []
+    system_message = Message(role=Role.SYSTEM, content=prompts.input_generation_sys)
+    messages.append(system_message)
+    user_message = Message(role=Role.USER, content=prompts.input_generation_prompt.format(
+        schema=json.dumps(schema),
+        output_field=output_field,
+        output=reformulated_output,
+        description=description
+    ))
     messages.append(user_message)
     return messages
 
@@ -69,90 +100,105 @@ def check_the_synthetic_data(synthetic_data_point: dict, original_data_columns: 
     return set(synthetic_data_point.keys()) == set(original_data_columns)
 
 
-async def generate_synthetic_dataset(sampled_data: List[dict], keypair: Keypair) -> List[dict]:
+async def generate_from_distribution(row: dict, prompts: Prompts, keypair: Keypair) -> str:
+    messages = create_messages_for_distribution_replication(row, prompts)
+    payload = {
+        "messages": [message.model_dump() for message in messages],
+        "model": SYNTH_MODEL,
+        "temperature": SYNTH_MODEL_TEMPERATURE,
+        "stream": False,
+    }
+
+    synthetic_data_point = await post_to_nineteen_ai(payload, keypair)
+    json_synthetic_data_point = (
+        json.loads(synthetic_data_point) if isinstance(synthetic_data_point, str)
+        else synthetic_data_point
+    )
+    return json_synthetic_data_point
+
+async def generate_from_output(row: dict, output_field: str, prompts: Prompts, keypair: Keypair) -> str:
+    # Step 1: Reformulate output and get description
+    messages = create_messages_for_output_reformulation(row, output_field, prompts)
+    payload = {
+        "messages": [message.model_dump() for message in messages],
+        "model": SYNTH_MODEL,
+        "temperature": SYNTH_MODEL_TEMPERATURE,
+        "stream": False,
+    }
+
+    result = await post_to_nineteen_ai(payload, keypair)
+    result_dict = json.loads(result) if isinstance(result, str) else result
+    reformulated_output = result_dict["reformulated_output"]
+    description = result_dict["description"]
+
+    # Step 2: Generate inputs based on reformulated output
+    schema = {k: type(v).__name__ for k, v in row.items()}
+    messages = create_messages_for_input_generation(reformulated_output, description, output_field, schema, prompts)
+    payload = {
+        "messages": [message.model_dump() for message in messages],
+        "model": SYNTH_MODEL,
+        "temperature": SYNTH_MODEL_TEMPERATURE,
+        "stream": False,
+    }
+    result = await post_to_nineteen_ai(payload, keypair)
+    generated_inputs = json.loads(result) if isinstance(result, str) else result
+    generated_inputs[output_field] = reformulated_output # Double check the output is unchanged
+
+    return generated_inputs
+
+
+async def generate_synthetic_dataset(sampled_data: List[dict], column_to_reformulate: str | None, keypair: Keypair) -> List[dict]:
     prompts = load_prompts()
     logger.info("Creating synthetic dataset")  # Task id would be nice here
     synthetic_dataset = []
     json_errors = 0
     generic_errors = 0
-
     consecutive_errors = 0
     max_consecutive_errors = 3
 
-    async def process_row(row):
-        nonlocal consecutive_errors
+    async def process_row(row, column_to_reformulate):
+        # When column_to_reformulate is provided, randomly choose between methods
+        use_output_method = random.choice([True, False]) if column_to_reformulate else False
 
-        nonlocal json_errors
-        nonlocal generic_errors
+        if use_output_method and column_to_reformulate:
+            json_synthetic_data_point = await generate_from_output(row, column_to_reformulate, prompts, keypair)
+        else:
+            json_synthetic_data_point = await generate_from_distribution(row, prompts, keypair)
 
-        messages = create_messages_from_row(row, prompts)
-        payload = {
-            "messages": [message.model_dump() for message in messages],
-            "model": SYNTH_MODEL,
-            "temperature": SYNTH_MODEL_TEMPERATURE,
-            "stream": False,
-        }
-        try:
+        if check_the_synthetic_data(json_synthetic_data_point, row.keys()):
+            return json_synthetic_data_point
+        else:
+            raise ValueError(
+                f"Generated data point has incorrect schema. Expected keys: {set(row.keys())}, "
+                f"got: {set(json_synthetic_data_point.keys())}"
+            )
 
-            synthetic_data_point = await post_to_nineteen_ai(payload, keypair)
-            logger.info(synthetic_data_point)
+    for i in range(0, len(sampled_data), SYNTH_GEN_BATCH_SIZE):
+        batch = sampled_data[i: i + SYNTH_GEN_BATCH_SIZE]
+        tasks = [process_row(row, column_to_reformulate) for row in batch]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
 
-            try:
-                if isinstance(synthetic_data_point, str):
-                    json_synthetic_data_point = json.loads(
-                        synthetic_data_point)
-                elif synthetic_data_point is not None:
-                    json_synthetic_data_point = synthetic_data_point
+        batch_results = []
+        for result in results:
+            if isinstance(result, Exception):
+                if isinstance(result, json.JSONDecodeError):
+                    json_errors += 1
                 else:
-                    consecutive_errors += 1
-            except json.JSONDecodeError:
-
-                json_errors += 1
+                    generic_errors += 1
                 consecutive_errors += 1
-                return None
-
-            if check_the_synthetic_data(json_synthetic_data_point, row.keys()):
-                consecutive_errors = 0  # Reset counter on success
-                return json_synthetic_data_point
-            else:
-                consecutive_errors += 1
-
-        except Exception as e:
-            generic_errors += 1
-            consecutive_errors += 1
-
-        if consecutive_errors >= max_consecutive_errors:
-            logger.error(
-
-                f"Stopping process due to {consecutive_errors} consecutive errors with the synth production")
-
-            raise RuntimeError(
-                f"Process stopped after {consecutive_errors} consecutive errors")
-
-        return None
-
-    try:
-        for i in range(0, len(sampled_data), SYNTH_GEN_BATCH_SIZE):
-            batch = sampled_data[i: i + SYNTH_GEN_BATCH_SIZE]
-            tasks = [process_row(row) for row in batch]
-            results = await asyncio.gather(*tasks, return_exceptions=True)
-            for result in results:
-                if isinstance(result, RuntimeError):
-
-                    logger.error(
-                        "Maximum consecutive errors reached. Stopping synth dataset process.")
-
+                if consecutive_errors >= max_consecutive_errors:
+                    logger.error("Maximum consecutive errors reached. Stopping synth dataset process.")
                     return None
-            valid_results = [
-                r for r in results if r is not None and not isinstance(r, Exception)]
-            synthetic_dataset.extend(valid_results)
+            else:
+                consecutive_errors = 0  # Reset on success
+                batch_results.append(result)
+
+        synthetic_dataset.extend(batch_results)
 
 
-        logger.info(
-            f"Generated {len(synthetic_dataset)} synthetic data points"
-        )
+    logger.info(
+        f"Generated {len(synthetic_dataset)} synthetic data points"
+    )
 
 
-        return synthetic_dataset
-    except RuntimeError:
-        return None
+    return synthetic_dataset

--- a/validator/tasks/task_prep.py
+++ b/validator/tasks/task_prep.py
@@ -89,11 +89,10 @@ async def get_additional_synth_data(
     try:
         sampled_data_list = list(sampled_data)
     except Exception as e:
-
-        return None
-
         logger.info(
             f"There is an issue with this sample data for some reason {sampled_data} {e}")
+        return None
+
     synthetic_data = await generate_synthetic_dataset(
         sampled_data_list,
         column_to_reformulate=column_to_reformulate,

--- a/validator/tasks/task_prep.py
+++ b/validator/tasks/task_prep.py
@@ -70,7 +70,12 @@ def train_test_split(dataset_name: str, test_size: float = None) -> DatasetDict:
     return split_dataset
 
 
-async def get_additional_synth_data(dataset: Dataset, columns_to_sample: List[str], keypair: Keypair) -> List[dict]:
+async def get_additional_synth_data(
+    dataset: Dataset,
+    columns_to_sample: List[str],
+    column_to_reformulate: str | None,
+    keypair: Keypair
+) -> List[dict]:
     num_samples = min(
         cst.MAX_SYNTH_DATA_POINTS,
         int(len(dataset) * cst.ADDITIONAL_SYNTH_DATA_PERCENTAGE),
@@ -89,7 +94,11 @@ async def get_additional_synth_data(dataset: Dataset, columns_to_sample: List[st
 
         logger.info(
             f"There is an issue with this sample data for some reason {sampled_data} {e}")
-    synthetic_data = await generate_synthetic_dataset(sampled_data_list, keypair=keypair)
+    synthetic_data = await generate_synthetic_dataset(
+        sampled_data_list,
+        column_to_reformulate=column_to_reformulate,
+        keypair=keypair
+    )
 
     return synthetic_data
 
@@ -110,7 +119,12 @@ def assign_some_of_the_train_to_synth(train_dataset: Dataset):
     return train_dataset, synthetic_data
 
 
-async def prepare_task(dataset_name: str, columns_to_sample: List[str], keypair: Keypair) -> tuple[str, str, str]:
+async def prepare_task(
+    dataset_name: str,
+    columns_to_sample: List[str],
+    column_to_reformulate: str | None,
+    keypair: Keypair
+) -> tuple[str, str, str]:
 
     logger.info(f"Preparing {dataset_name}")
     dataset_dict = train_test_split(dataset_name)
@@ -122,7 +136,7 @@ async def prepare_task(dataset_name: str, columns_to_sample: List[str], keypair:
         if cst.GET_SYNTH_DATA:
             logger.info("Generating additional synthetic data")
 
-            synthetic_data = await get_additional_synth_data(test_dataset, columns_to_sample, keypair=keypair)
+            synthetic_data = await get_additional_synth_data(test_dataset, columns_to_sample, column_to_reformulate, keypair)
 
             synthetic_dataset = Dataset.from_list(synthetic_data)
             logger.info("First 2 examples from original test dataset:")


### PR DESCRIPTION
Expanded the synthetic generation process to allow a mix of the previous and the new method described below:

- completion tasks: Uses previous synth generation
- finetuning tasks: Mixes previous approach with new one, which reformulates the output and gets the output, before generating inputs with correctness constraints
- experiments showed it improves robustness to cheating by overfitting test set
- Refactored synth.py for more code modularity