### PR TITLE
Samoline optimize eval

### DIFF
--- a/validator/evaluation/eval.py
+++ b/validator/evaluation/eval.py
@@ -89,10 +89,12 @@ def _process_evaluation_batches(
     language_model: AutoModelForCausalLM,
     eval_dataloader: DataLoader,
     device: torch.device,
+    evaluation_config: DictDefault,
 ) -> tuple[list[float], int]:
     batch_losses = []
     num_batches = 0
     consecutive_nans = 0
+    max_consecutive_nans = evaluation_config.get('max_consecutive_nans')
 
     language_model.eval()
     with torch.no_grad():
@@ -103,8 +105,8 @@ def _process_evaluation_batches(
 
             if torch.isnan(torch.tensor(batch_loss)):
                 consecutive_nans += 1
-                if consecutive_nans >= 5:
-                    logger.warning("Stopping evaluation early: 5 consecutive NaN losses detected")
+                if consecutive_nans >= max_consecutive_nans:
+                    logger.error(f"Stopping evaluation early: {max_consecutive_nans} consecutive NaN losses detected")
                     return [float('nan')], 1
             else:
                 consecutive_nans = 0
@@ -135,7 +137,11 @@ def _compute_batch_loss(language_model: AutoModelForCausalLM, batch: dict, devic
     return loss.item()
 
 
-def _calculate_evaluation_metrics(total_losses: list[float], num_batches: int) -> dict[str, float]:
+def _calculate_evaluation_metrics(
+    total_losses: list[float],
+    num_batches: int,
+    evaluation_config: DictDefault,
+) -> dict[str, float]:
     valid_losses = [loss for loss in total_losses if not torch.isnan(torch.tensor(loss))]
     nan_count = len(total_losses) - len(valid_losses)
     nan_percentage = (nan_count / num_batches) * 100 if num_batches > 0 else 0
@@ -147,7 +153,7 @@ def _calculate_evaluation_metrics(total_losses: list[float], num_batches: int) -
             "perplexity": float("inf"),
         }
 
-    if nan_percentage > 5:
+    if nan_percentage > evaluation_config.get('max_nan_percentage'):
         logger.error(f"Too many nan values ({nan_percentage:.2f}% of batches)")
         return {
             "eval_loss": float("inf"),
@@ -180,8 +186,8 @@ def evaluate_language_model_loss(
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     language_model.to(device)
-    losses, num_batches = _process_evaluation_batches(language_model, eval_dataloader, device)
-    evaluation_results = _calculate_evaluation_metrics(losses, num_batches)
+    losses, num_batches = _process_evaluation_batches(language_model, eval_dataloader, device, evaluation_config)
+    evaluation_results = _calculate_evaluation_metrics(losses, num_batches, evaluation_config)
     logger.info(f"Final evaluation results: {evaluation_results}")
 
     return evaluation_results

--- a/validator/test_axolotl.yml
+++ b/validator/test_axolotl.yml
@@ -18,3 +18,6 @@ pad_to_sequence_len: true
 gradient_accumulation_steps: 1
 micro_batch_size: 1
 num_epochs: 1
+
+max_consecutive_nans: 5
+max_nan_percentage: 5


### PR DESCRIPTION
Optimize the eval stage by:

1. deduplicate repos before passing to the docker eval: 
- doesn't disrupt behavior since we were already returning dict[repo, perf]
- handling of duplicates happens downstream and is agnostic of this refactor (interface and exchanged data are the same)
2. only evaluate repos that are not the exact original model, if exact model mark as not finetuned, rest of scoring is taken care of downstream
3. stop eval if 5 consecutive nans, return invalid eval metrics