### PR TITLE
Quick fix - improve miner docker cleanup

### DIFF
--- a/miner/logic/job_handler.py
+++ b/miner/logic/job_handler.py
@@ -159,9 +159,7 @@ def start_tuning_container(job: Job):
 
         if "container" in locals():
             try:
-                logger.info("Cleaning up HuggingFace cache...")
-                container.exec_run("rm -rf /root/.cache/huggingface/hub/*", user="root")
-            except Exception as e:
-                logger.warning(f"Failed to clean HuggingFace cache: {e}")
-            finally:
                 container.remove(force=True)
+                logger.info("Container removed")
+            except Exception as e:
+                logger.warning(f"Failed to remove container: {e}")


### PR DESCRIPTION
Removed a recurrent warning message that happens to miners.
1. The container is already stopped at this point so we can't run the command to clear the cache
2. We force remove the container which removes cache anyways, since cache isn't a mounted volume