### PR TITLE
Remove model family fitler

### DIFF
--- a/validator/tasks/synthetic_scheduler.py
+++ b/validator/tasks/synthetic_scheduler.py
@@ -26,12 +26,7 @@ async def _get_models(keypair: Keypair) -> AsyncGenerator[str, None]:
     if not isinstance(response, list):
         raise TypeError("Expected a list of responses from GET_ALL_MODELS_ENDPOINT")
     models: list[dict[str, Any]] = response
-    TEMP_MODEL_FAMILIES_ACCEPTED = ["qwen", "llama", "falcon", "mistral", "gemma", "gemini", "phi"]
-    model_ids = [
-        model.get(cst.GET_ALL_MODELS_ID, "")
-        for model in models
-        if any(family in model.get(cst.GET_ALL_MODELS_ID, "").lower() for family in TEMP_MODEL_FAMILIES_ACCEPTED)
-    ]
+    model_ids = [model.get(cst.GET_ALL_MODELS_ID, "") for model in models]
     random.shuffle(model_ids)
     for model_id in model_ids:
         yield model_id


### PR DESCRIPTION
The miners should be able to handle different families now, so we don't need the filter 