### PR TITLE
clear cache using specific finepaths for eval and task prep

### DIFF
--- a/validator/evaluation/scoring.py
+++ b/validator/evaluation/scoring.py
@@ -1,4 +1,5 @@
 import re
+import os
 from datetime import datetime
 from datetime import timedelta
 
@@ -320,6 +321,7 @@ async def _evaluate_submissions(
     logger.info("Starting synth evaluation")
     synthetic_data_filepath = await download_s3_file(task.synthetic_data)
     synth_eval_results = await run_evaluation_docker(dataset=synthetic_data_filepath, **evaluation_params)
+    os.remove(synthetic_data_filepath)
 
     finetuned_repos = []
     for repo in repos_to_evaluate:
@@ -341,6 +343,7 @@ async def _evaluate_submissions(
         test_eval_results = await run_evaluation_docker(
             dataset=test_data_filepath, models=finetuned_repos, **{k: v for k, v in evaluation_params.items() if k != "models"}
         )
+        os.remove(test_data_filepath)
 
         for repo in finetuned_repos:
             if isinstance(test_eval_results.get(repo), Exception):

--- a/validator/tasks/task_prep.py
+++ b/validator/tasks/task_prep.py
@@ -189,7 +189,7 @@ async def prepare_task(dataset_name: str, columns_to_sample: List[str], keypair:
     if not synth_json_url and synthetic_data:
         raise Exception("Failed to upload synthetic data to MinIO storage")
 
-    os.remove(train_json_url)
+    os.remove(train_json_path)
     os.remove(test_json_path)
     if synth_json_path:
         os.remove(synth_json_path)

--- a/validator/tasks/task_prep.py
+++ b/validator/tasks/task_prep.py
@@ -189,6 +189,7 @@ async def prepare_task(dataset_name: str, columns_to_sample: List[str], keypair:
     if not synth_json_url and synthetic_data:
         raise Exception("Failed to upload synthetic data to MinIO storage")
 
+    os.remove(train_json_url)
     os.remove(test_json_path)
     if synth_json_path:
         os.remove(synth_json_path)

--- a/validator/utils/cache_clear.py
+++ b/validator/utils/cache_clear.py
@@ -26,7 +26,6 @@ def delete_dataset_from_cache(dataset_name):
     lock_pattern = os.path.join(cache_dir, f"*cache_huggingface_datasets_{dataset_name}*.lock")
 
     deleted = False
-    cleanup_temp_files()
 
     if os.path.exists(dataset_path):
         try:


### PR DESCRIPTION
* Avoid clearing /tmp cache globally
* Instead remove /tmp files after each usage when not needed anymore