### PR TITLE
Add context tags to eval and docker logs

### DIFF
--- a/config/grafana-validator-general.json
+++ b/config/grafana-validator-general.json
@@ -1,71 +1,64 @@
 {
   "annotations": {
-    "list": [
-      {
-        "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "type": "dashboard"
-      }
-    ]
+    "list": [{
+      "builtIn": 1,
+      "datasource": {
+        "type": "grafana",
+        "uid": "-- Grafana --"
+      },
+      "enable": true,
+      "hide": true,
+      "iconColor": "rgba(0, 211, 255, 1)",
+      "name": "Annotations & Alerts",
+      "type": "dashboard"
+    }]
   },
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": 3,
   "links": [],
-  "panels": [
-    {
+  "panels": [{
+    "datasource": {
+      "type": "loki",
+      "uid": "P8E80F9AEF21F6940"
+    },
+    "gridPos": {
+      "h": 48,
+      "w": 24,
+      "x": 0,
+      "y": 36
+    },
+    "id": 2,
+    "options": {
+      "dedupStrategy": "none",
+      "enableLogDetails": true,
+      "prettifyLogMessage": false,
+      "showCommonLabels": false,
+      "showLabels": false,
+      "showTime": true,
+      "sortOrder": "Descending",
+      "wrapLogMessage": false
+    },
+    "targets": [{
       "datasource": {
         "type": "loki",
         "uid": "P8E80F9AEF21F6940"
       },
-      "gridPos": {
-        "h": 48,
-        "w": 24,
-        "x": 0,
-        "y": 36
-      },
-      "id": 2,
-      "options": {
-        "dedupStrategy": "none",
-        "enableLogDetails": true,
-        "prettifyLogMessage": false,
-        "showCommonLabels": false,
-        "showLabels": false,
-        "showTime": true,
-        "sortOrder": "Descending",
-        "wrapLogMessage": false
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "loki",
-            "uid": "P8E80F9AEF21F6940"
-          },
-          "editorMode": "builder",
-          "expr": "{service_name=~\"validator|validator_cycle\"} |= `$search_in_line` | ctx_task_id =~ `.*$task_id.*` | ctx_miner_hotkey =~ `.*$miner_hotkey.*` | label_format level=detected_level | line_format `{{.service_name }} - {{__line__}}`",
-          "legendFormat": "",
-          "queryType": "range",
-          "refId": "A"
-        }
-      ],
-      "title": "Validator Logs",
-      "type": "logs"
-    }
-  ],
+      "editorMode": "builder",
+      "expr": "{service_name=~\"validator|validator_cycle\"} |= `$search_in_line` | ctx_task_id =~ `.*$task_id.*` | ctx_miner_hotkey =~ `.*$miner_hotkey.*` | ctx_gpu_ids =~ `.*,$gpu_id,.*` | label_format level=detected_level | line_format `{{.service_name }} - {{__line__}}`",
+      "legendFormat": "",
+      "queryType": "range",
+      "refId": "A"
+    }],
+    "title": "Validator Logs",
+    "type": "logs"
+  }],
   "refresh": "5s",
   "schemaVersion": 39,
   "tags": [],
   "templating": {
-    "list": [
-      {
+    "list": [{
         "current": {
           "selected": false,
           "text": "",
@@ -102,6 +95,20 @@
         "hide": 0,
         "label": "Miner Hotkey",
         "name": "miner_hotkey",
+        "options": [],
+        "query": "",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "hide": 0,
+        "label": "GPU ID",
+        "name": "gpu_id",
         "options": [],
         "query": "",
         "skipUrlSync": false,

--- a/config/grafana-validator-general.json
+++ b/config/grafana-validator-general.json
@@ -46,7 +46,7 @@
         "uid": "P8E80F9AEF21F6940"
       },
       "editorMode": "builder",
-      "expr": "{service_name=~\"validator|validator_cycle\"} |= `$search_in_line` | ctx_task_id =~ `.*$task_id.*` | ctx_miner_hotkey =~ `.*$miner_hotkey.*` | ctx_gpu_ids =~ `.*,$gpu_id,.*` | label_format level=detected_level | line_format `{{.service_name }} - {{__line__}}`",
+      "expr": "{service_name=~\"validator|validator_cycle\"} |= `$search_in_line` | ctx_task_id =~ `.*$task_id.*` | ctx_miner_hotkey =~ `.*$miner_hotkey.*` | ctx_gpu_ids =~ `.*${gpu_id:+,$gpu_id,}.*` | label_format level=detected_level | line_format `{{.service_name }} - {{__line__}}`",
       "legendFormat": "",
       "queryType": "range",
       "refId": "A"

--- a/config/grafana-validator-general.json
+++ b/config/grafana-validator-general.json
@@ -50,7 +50,7 @@
             "uid": "P8E80F9AEF21F6940"
           },
           "editorMode": "builder",
-          "expr": "{service_name=~\"validator|validator_cycle\"} | ctx_task_id =~ `.*$task_id.*` | ctx_miner_hotkey =~ `.*$miner_hotkey.*` | label_format level=detected_level | line_format `{{.service_name }} - {{__line__}}`",
+          "expr": "{service_name=~\"validator|validator_cycle\"} |= `$search_in_line` | ctx_task_id =~ `.*$task_id.*` | ctx_miner_hotkey =~ `.*$miner_hotkey.*` | label_format level=detected_level | line_format `{{.service_name }} - {{__line__}}`",
           "legendFormat": "",
           "queryType": "range",
           "refId": "A"
@@ -65,6 +65,20 @@
   "tags": [],
   "templating": {
     "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "hide": 0,
+        "label": "Search",
+        "name": "search_in_line",
+        "options": [],
+        "query": "",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
       {
         "current": {
           "selected": false,

--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -9,7 +9,6 @@ services:
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:-admin}
       GF_INSTALL_PLUGINS: redis-datasource
     volumes:
-      - grafana:/var/lib/grafana
       - ./config/grafana-datasource.yaml:/etc/grafana/provisioning/datasources/otel.yaml
       - ./config/grafana-dashboards.yaml:/etc/grafana/provisioning/dashboards/dashboards.yaml
       - ./config/grafana-validator-general.json:/var/lib/grafana/dashboards/grafana-validator-general.json
@@ -75,7 +74,6 @@ services:
       - ./config/prometheus-config.yaml:/etc/prometheus/prometheus.yml
 
 volumes:
-  grafana:
   tempo:
   loki:
   prometheus:

--- a/utils/setup_grafana.sh
+++ b/utils/setup_grafana.sh
@@ -6,6 +6,8 @@ if [ -z "$GRAFANA_USERNAME" ]; then
   echo GRAFANA_USERNAME=$GRAFANA_USERNAME >> .vali.env
 fi
 
+GRAFANA_PASSWORD=$(grep GRAFANA_PASSWORD .vali.env | cut -d= -f2)
+
 if [ -z "$GRAFANA_PASSWORD" ]; then
   GRAFANA_PASSWORD=$(openssl rand -hex 16)
   sed -i '/GRAFANA_PASSWORD/d' .vali.env

--- a/validator/cycle/process_tasks.py
+++ b/validator/cycle/process_tasks.py
@@ -252,7 +252,8 @@ async def _process_ready_to_train_tasks(config: Config):
 
 
 async def _evaluate_task(task: RawTask, gpu_ids: list[int], config: Config):
-    with LogContext(task_id=str(task.task_id)):
+    gpu_ids_str = "," + ",".join(str(gpu_id) for gpu_id in gpu_ids) + ","
+    with LogContext(task_id=str(task.task_id), gpu_ids=gpu_ids_str):
         try:
             task.status = TaskStatus.EVALUATING
             add_context_tag("status", task.status.value)

--- a/validator/cycle/process_tasks.py
+++ b/validator/cycle/process_tasks.py
@@ -37,11 +37,7 @@ async def _get_total_dataset_size(repo_name: str, file_format: FileFormat) -> in
     else:
         loop = asyncio.get_running_loop()
         dataset_infos = await loop.run_in_executor(None, get_dataset_infos, repo_name)
-        size = sum(
-            info.dataset_size
-            for info in dataset_infos.values()
-            if info.dataset_size
-        )
+        size = sum(info.dataset_size for info in dataset_infos.values() if info.dataset_size)
     return int(size)
 
 
@@ -50,10 +46,7 @@ async def _run_task_prep(task: RawTask, keypair: Keypair) -> RawTask:
         i for i in [task.field_system, task.field_instruction, task.field_input, task.field_output] if i is not None
     ]
     test_data, synth_data, train_data = await prepare_task(
-        dataset_name=task.ds_id,
-        file_format=task.file_format,
-        columns_to_sample=columns_to_sample,
-        keypair=keypair
+        dataset_name=task.ds_id, file_format=task.file_format, columns_to_sample=columns_to_sample, keypair=keypair
     )
     task.training_data = train_data
     task.status = TaskStatus.LOOKING_FOR_NODES
@@ -62,7 +55,6 @@ async def _run_task_prep(task: RawTask, keypair: Keypair) -> RawTask:
     task.test_data = test_data
     logger.info("Data creation is complete - now time to find some miners")
     return task
-
 
 
 # TODO: Improve by batching these up
@@ -260,17 +252,18 @@ async def _process_ready_to_train_tasks(config: Config):
 
 
 async def _evaluate_task(task: RawTask, gpu_ids: list[int], config: Config):
-    try:
-        task.status = TaskStatus.EVALUATING
-        add_context_tag("status", task.status.value)
-        await tasks_sql.update_task(task, config.psql_db)
-        task = await evaluate_and_score(task, gpu_ids, config)
-        await tasks_sql.update_task(task, config.psql_db)
-    except Exception as e:
-        logger.error(f"Error evaluating task {task.task_id}: {e}", exc_info=True)
-        task.status = TaskStatus.FAILURE
-        add_context_tag("status", task.status.value)
-        await tasks_sql.update_task(task, config.psql_db)
+    with LogContext(task_id=str(task.task_id)):
+        try:
+            task.status = TaskStatus.EVALUATING
+            add_context_tag("status", task.status.value)
+            await tasks_sql.update_task(task, config.psql_db)
+            task = await evaluate_and_score(task, gpu_ids, config)
+            await tasks_sql.update_task(task, config.psql_db)
+        except Exception as e:
+            logger.error(f"Error evaluating task {task.task_id}: {e}", exc_info=True)
+            task.status = TaskStatus.FAILURE
+            add_context_tag("status", task.status.value)
+            await tasks_sql.update_task(task, config.psql_db)
 
 
 async def _move_back_to_looking_for_nodes(task: RawTask, config: Config):


### PR DESCRIPTION
Task id and miner hotkey tags in the eval pipeline and docker logs.
Improved grafana robustness. Previously the password was cached in the grafana volume. We don't use the volume anymore so pass changes are reflected. Also, the pass is not changed on each startup
Added a text search box to the grafana dash:
![image](https://github.com/user-attachments/assets/10d914c5-e82b-49a4-820a-c9b9cf3cb19a)
