### PR TITLE
add ability to save/query tasks' losses

### DIFF
--- a/core/models/utility_models.py
+++ b/core/models/utility_models.py
@@ -57,6 +57,8 @@ class WinningSubmission(BaseModel):
 class MinerTaskResult(BaseModel):
     hotkey: str
     quality_score: float
+    test_loss: float | None
+    synth_loss: float | None
 
 
 # NOTE: Confusing name with the class above

--- a/validator/db/constants.py
+++ b/validator/db/constants.py
@@ -62,6 +62,8 @@ CREATED_ON = "created_on"
 
 # Task Nodes Table Columns
 TASK_NODE_QUALITY_SCORE = "quality_score"
+TEST_LOSS = "test_loss"
+SYNTH_LOSS = "synth_loss"
 
 # Common Column Names (shared between tables)
 QUALITY_SCORE = "quality_score"  # Used in both submissions and task_nodes

--- a/validator/db/migrations/20250108000001_add_losses.sql
+++ b/validator/db/migrations/20250108000001_add_losses.sql
@@ -1,0 +1,9 @@
+-- migrate:up
+ALTER TABLE task_nodes
+ADD COLUMN test_loss FLOAT,
+ADD COLUMN synth_loss FLOAT;
+
+-- migrate:down
+ALTER TABLE task_nodes
+DROP COLUMN test_loss,
+DROP COLUMN synth_loss;

--- a/validator/db/sql/submissions_and_scoring.py
+++ b/validator/db/sql/submissions_and_scoring.py
@@ -100,19 +100,42 @@ async def submission_repo_is_unique(repo: str, psql_db: PSQLDB) -> bool:
         return result is None
 
 
-async def set_task_node_quality_score(task_id: UUID, hotkey: str, quality_score: float, psql_db: PSQLDB) -> None:
-    """Set quality score for a node's task submission"""
+async def set_task_node_quality_score(
+    task_id: UUID,
+    hotkey: str,
+    quality_score: float,
+    test_loss: float,
+    synth_loss: float,
+    psql_db: PSQLDB
+) -> None:
+    """Set quality score and losses for a node's task submission"""
     async with await psql_db.connection() as connection:
         connection: Connection
         query = f"""
             INSERT INTO {cst.TASK_NODES_TABLE} (
-                {cst.TASK_ID}, {cst.HOTKEY}, {cst.NETUID}, {cst.TASK_NODE_QUALITY_SCORE}
+                {cst.TASK_ID},
+                {cst.HOTKEY},
+                {cst.NETUID},
+                {cst.TASK_NODE_QUALITY_SCORE},
+                {cst.TEST_LOSS},
+                {cst.SYNTH_LOSS}
             )
-            VALUES ($1, $2, $3, $4)
+            VALUES ($1, $2, $3, $4, $5, $6)
             ON CONFLICT ({cst.TASK_ID}, {cst.HOTKEY}, {cst.NETUID}) DO UPDATE
-            SET {cst.TASK_NODE_QUALITY_SCORE} = $4
+            SET
+                {cst.TASK_NODE_QUALITY_SCORE} = $4,
+                {cst.TEST_LOSS} = $5,
+                {cst.SYNTH_LOSS} = $6
         """
-        await connection.execute(query, task_id, hotkey, NETUID, quality_score)
+        await connection.execute(
+            query,
+            task_id,
+            hotkey,
+            NETUID,
+            quality_score,
+            test_loss,
+            synth_loss
+        )
 
 
 async def get_task_node_quality_score(task_id: UUID, hotkey: str, psql_db: PSQLDB) -> Optional[float]:
@@ -129,35 +152,31 @@ async def get_task_node_quality_score(task_id: UUID, hotkey: str, psql_db: PSQLD
         return await connection.fetchval(query, task_id, hotkey, NETUID)
 
 
-async def get_all_quality_scores_for_task(task_id: UUID, psql_db: PSQLDB) -> Dict[str, float]:
-    """Get all quality scores for a task, keyed by hotkey"""
+async def get_all_scores_and_losses_for_task(task_id: UUID, psql_db: PSQLDB) -> list[dict]:
+    """Get all quality scores and losses for a task"""
     async with await psql_db.connection() as connection:
         connection: Connection
         query = f"""
-            SELECT {cst.HOTKEY}, {cst.TASK_NODE_QUALITY_SCORE}
+            SELECT
+                {cst.HOTKEY},
+                {cst.TASK_NODE_QUALITY_SCORE},
+                {cst.TEST_LOSS},
+                {cst.SYNTH_LOSS}
             FROM {cst.TASK_NODES_TABLE}
             WHERE {cst.TASK_ID} = $1
             AND {cst.NETUID} = $2
             AND {cst.TASK_NODE_QUALITY_SCORE} IS NOT NULL
         """
         rows = await connection.fetch(query, task_id, NETUID)
-        return {row[cst.HOTKEY]: row[cst.TASK_NODE_QUALITY_SCORE] for row in rows}
-
-
-async def set_multiple_task_node_quality_scores(task_id: UUID, quality_scores: Dict[str, float], psql_db: PSQLDB) -> None:
-    """Set multiple quality scores for task nodes"""
-    async with await psql_db.connection() as connection:
-        connection: Connection
-        async with connection.transaction():
-            query = f"""
-                INSERT INTO {cst.TASK_NODES_TABLE} (
-                    {cst.TASK_ID}, {cst.HOTKEY}, {cst.NETUID}, {cst.TASK_NODE_QUALITY_SCORE}
-                )
-                VALUES ($1, $2, $3, $4)
-                ON CONFLICT ({cst.TASK_ID}, {cst.HOTKEY}, {cst.NETUID}) DO UPDATE
-                SET {cst.TASK_NODE_QUALITY_SCORE} = EXCLUDED.{cst.TASK_NODE_QUALITY_SCORE}
-            """
-            await connection.executemany(query, [(task_id, hotkey, NETUID, score) for hotkey, score in quality_scores.items()])
+        return [
+            {
+                cst.HOTKEY: row[cst.HOTKEY],
+                cst.TASK_NODE_QUALITY_SCORE: row[cst.TASK_NODE_QUALITY_SCORE],
+                cst.TEST_LOSS: row[cst.TEST_LOSS],
+                cst.SYNTH_LOSS: row[cst.SYNTH_LOSS]
+            }
+            for row in rows
+        ]
 
 
 async def get_all_scores_for_hotkey(hotkey: str, psql_db: PSQLDB) -> List[Dict]:

--- a/validator/endpoints/tasks.py
+++ b/validator/endpoints/tasks.py
@@ -178,8 +178,8 @@ async def get_miner_breakdown(
     config: Config = Depends(get_config),
 ) -> TaskResultResponse:
     try:
-        scores = await submissions_and_scoring_sql.get_all_quality_scores_for_task(task_id, config.psql_db)
-        miner_results = [MinerTaskResult(hotkey=hotkey, quality_score=scores[hotkey]) for hotkey in scores]
+        results = await submissions_and_scoring_sql.get_all_scores_and_losses_for_task(task_id, config.psql_db)
+        miner_results = [MinerTaskResult(**result) for result in results]
     except Exception as e:
         logger.info(e)
         raise HTTPException(status_code=404, detail="Task not found.")

--- a/validator/evaluation/scoring.py
+++ b/validator/evaluation/scoring.py
@@ -382,7 +382,12 @@ async def _update_scores(task: RawTask, task_results: list[MinerResults], psql_d
                 continue
 
             await set_task_node_quality_score(
-                task_id=task.task_id, hotkey=result.hotkey, quality_score=float(result.score), psql_db=psql_db
+                task_id=task.task_id,
+                hotkey=result.hotkey,
+                quality_score=float(result.score),
+                test_loss=result.test_loss,
+                synth_loss=result.synth_loss,
+                psql_db=psql_db
             )
 
             if result.submission:


### PR DESCRIPTION
save synth/test losses along with scores
enable getting losses along with scores in the vali endpoint