### PR TITLE
Samoline fix failing eval max pos embeddings

### DIFF
--- a/dockerfiles/validator.dockerfile
+++ b/dockerfiles/validator.dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 
 COPY validator/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install docker
 
 COPY . .
 


### PR DESCRIPTION
Fixed error in eval where we had fixed `sequence_len` in dataset loading sometimes causing input size to be larger than the model's `max_position_embedding`.

We now set `sequence_len` dynamically to fix that error while optimizing memory/speed