### PR TITLE
remove entire ds cache after each batch prep_task

### DIFF
--- a/utils/run_validator_auto_update.py
+++ b/utils/run_validator_auto_update.py
@@ -1,6 +1,5 @@
 import argparse
 import os
-import shutil
 import subprocess
 import time
 
@@ -11,16 +10,6 @@ def pull_latest_docker_images():
 
 def should_update_local(local_commit: str, remote_commit: str) -> bool:
     return local_commit != remote_commit
-
-
-def clean_hf_datasets_cache():
-    try:
-        hf_cache_path = os.path.expanduser("~/.cache/huggingface/datasets/")
-        if os.path.exists(hf_cache_path):
-            shutil.rmtree(hf_cache_path)
-            print(f"Cleaned Huggingface datasets cache at {hf_cache_path}")
-    except Exception as e:
-        print(f"Error cleaning Huggingface datasets cache: {e}")
 
 
 def run_auto_updater():
@@ -44,7 +33,6 @@ def run_auto_updater():
             process = subprocess.Popen(reset_cmd.split(), stdout=subprocess.PIPE)
             output, error = process.communicate()
             if not error:
-                clean_hf_datasets_cache()
                 pull_latest_docker_images()
                 os.system("./utils/autoupdate_validator_steps.sh")
                 time.sleep(20)

--- a/validator/cycle/process_tasks.py
+++ b/validator/cycle/process_tasks.py
@@ -19,6 +19,7 @@ from validator.core.config import Config
 from validator.core.models import RawTask
 from validator.evaluation.scoring import evaluate_and_score
 from validator.tasks.task_prep import prepare_task
+from validator.utils.cache_clear import clean_all_hf_datasets_cache
 from validator.utils.call_endpoint import process_non_stream_fiber
 from validator.utils.logging import LogContext
 from validator.utils.logging import add_context_tag
@@ -224,6 +225,7 @@ async def _processing_pending_tasks(config: Config):
     pending_tasks = await tasks_sql.get_tasks_with_status(status=TaskStatus.PENDING, psql_db=config.psql_db)
     logger.info(f"Found {len(pending_tasks)} pending tasks! Will prep them all now...")
     await asyncio.gather(*[_prep_task(task, config) for task in pending_tasks[: cst.MAX_CONCURRENT_TASK_PREPS]])
+    clean_all_hf_datasets_cache()
 
 
 async def _start_training_task(task: RawTask, config: Config) -> None:

--- a/validator/utils/cache_clear.py
+++ b/validator/utils/cache_clear.py
@@ -73,3 +73,14 @@ def delete_model_from_cache(model_name):
         logger.info(f"Deleted model '{model_name}' from cache.")
     else:
         logger.info(f"Model '{model_name}' not found in cache.")
+
+
+def clean_all_hf_datasets_cache():
+    """Clean the entire Huggingface datasets cache directory."""
+    try:
+        hf_cache_path = os.path.expanduser("~/.cache/huggingface/datasets/")
+        if os.path.exists(hf_cache_path):
+            shutil.rmtree(hf_cache_path)
+            logger.info(f"Cleaned Huggingface datasets cache at {hf_cache_path}")
+    except Exception as e:
+        logger.error(f"Error cleaning Huggingface datasets cache: {e}")


### PR DESCRIPTION
Only spot where we download HF DSes is when we `_prep_task`s, once we upload DSes to S3 and save the links we can remove the cache.

When eval'ing we download from S3 in /tmp and remove files after evals. So it doesn't interfere with `_prep_task` HF DSes