### PR TITLE
store model size in db for accurate weight computation

### DIFF
--- a/core/models/payload_models.py
+++ b/core/models/payload_models.py
@@ -1,8 +1,10 @@
 from datetime import datetime
+from typing import Union
 from uuid import UUID
 
 from fiber.logging_utils import get_logger
 from pydantic import BaseModel
+from pydantic import ConfigDict
 from pydantic import Field
 
 from core.models.utility_models import CustomDatasetType
@@ -48,6 +50,12 @@ class EvaluationResult(BaseModel):
     is_finetune: bool
     eval_loss: float
     perplexity: float
+
+
+class DockerEvaluationResults(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    results: dict[str, Union[EvaluationResult, Exception]]
+    base_model_params_count: int = 0
 
 
 class MinerTaskResponse(BaseModel):

--- a/validator/core/models.py
+++ b/validator/core/models.py
@@ -66,6 +66,7 @@ class RawTask(BaseModel):
     is_organic: bool
     task_id: UUID | None = None
     model_id: str
+    model_params_count: int = 0
     ds_id: str
     file_format: FileFormat = FileFormat.HF
     status: str

--- a/validator/db/migrations/20250120181000_add_model_params_count.sql
+++ b/validator/db/migrations/20250120181000_add_model_params_count.sql
@@ -1,0 +1,7 @@
+-- migrate:up
+ALTER TABLE tasks
+ADD COLUMN model_params_count BIGINT DEFAULT 0;
+
+-- migrate:down
+ALTER TABLE tasks
+DROP COLUMN model_params_count;

--- a/validator/evaluation/docker_evaluation.py
+++ b/validator/evaluation/docker_evaluation.py
@@ -10,6 +10,7 @@ from docker.models.containers import Container
 from pydantic import TypeAdapter
 
 from core import constants as cst
+from core.models.payload_models import DockerEvaluationResults
 from core.models.payload_models import EvaluationResult
 from core.models.utility_models import CustomDatasetType
 from core.models.utility_models import DatasetType
@@ -47,6 +48,22 @@ async def get_evaluation_results(container):
         return json.loads(eval_results_content)
 
 
+def process_evaluation_results(results: dict) -> DockerEvaluationResults:
+    model_params_count = results.pop("model_params_count", None)
+
+    processed_results = {}
+    for repo, result in results.items():
+        if isinstance(result, str) and not isinstance(result, dict):
+            processed_results[repo] = Exception(result)
+        else:
+            processed_results[repo] = TypeAdapter(EvaluationResult).validate_python(result)
+
+    return DockerEvaluationResults(
+        results=processed_results,
+        base_model_params_count=model_params_count
+    )
+
+
 async def run_evaluation_docker(
     dataset: str,
     models: list[str],
@@ -54,7 +71,7 @@ async def run_evaluation_docker(
     dataset_type: Union[DatasetType, CustomDatasetType],
     file_format: FileFormat,
     gpu_ids: list[int],
-) -> dict[str, Union[EvaluationResult, Exception]]:
+) -> DockerEvaluationResults:
     client = docker.from_env()
 
     if isinstance(dataset_type, DatasetType):
@@ -110,16 +127,8 @@ async def run_evaluation_docker(
         if result["StatusCode"] != 0:
             raise Exception(f"Container exited with status {result['StatusCode']}")
 
-        eval_results_dict = await get_evaluation_results(container)
-
-        processed_results = {}
-        for repo, result in eval_results_dict.items():
-            if isinstance(result, str) and not isinstance(result, dict):
-                processed_results[repo] = Exception(result)
-            else:
-                processed_results[repo] = TypeAdapter(EvaluationResult).validate_python(result)
-
-        return processed_results
+        eval_results = await get_evaluation_results(container)
+        return process_evaluation_results(eval_results)
 
     except Exception as e:
         logger.error(f"Failed to retrieve evaluation results: {str(e)}")

--- a/validator/evaluation/eval.py
+++ b/validator/evaluation/eval.py
@@ -213,6 +213,14 @@ def evaluate_finetuned_model(
     return evaluate_language_model_loss(evaluation_config, finetuned_model, tokenizer)
 
 
+def _count_model_parameters(model: AutoModelForCausalLM) -> int:
+    try:
+        return sum(p.numel() for p in model.parameters())
+    except Exception as e:
+        logger.error(f"Failed to count model parameters: {e}")
+        return 0
+
+
 def main():
     dataset = os.environ.get("DATASET")
     original_model = os.environ.get("ORIGINAL_MODEL")
@@ -231,6 +239,7 @@ def main():
         dataset_type = CustomDatasetType.model_validate_json(dataset_type_str)
 
     base_model = AutoModelForCausalLM.from_pretrained(original_model, token=os.environ.get("HUGGINGFACE_TOKEN"))
+    model_params_count = _count_model_parameters(base_model)
     tokenizer = AutoTokenizer.from_pretrained(original_model, token=os.environ.get("HUGGINGFACE_TOKEN"))
     if tokenizer.pad_token_id is None:
         tokenizer.pad_token = tokenizer.eos_token
@@ -238,7 +247,9 @@ def main():
 
     lora_repos = [m.strip() for m in models_str.split(",") if m.strip()]
 
-    results_dict = {}
+    results_dict = {
+        "model_params_count": model_params_count
+    }
     for repo in lora_repos:
         try:
             try:

--- a/validator/evaluation/scoring.py
+++ b/validator/evaluation/scoring.py
@@ -1,5 +1,4 @@
 import os
-import re
 from datetime import datetime
 from datetime import timedelta
 
@@ -44,9 +43,8 @@ def get_task_work_score(task: RawTask) -> float:
     assert task.model_id, "Model ID must be present"
 
     hours = task.hours_to_complete
-    model = task.model_id
-    model_size = re.search(r"(\d+)(?=[bB])", model)
-    model_size_value = min(8, int(model_size.group(1)) if model_size else 1)
+    # size in billions
+    model_size_value = min(8, task.model_params_count / 1_000_000_000) if task.model_params_count else 1
     return max(1, 2 * np.log(float(hours * model_size_value)))
 
 
@@ -334,8 +332,10 @@ async def _evaluate_submissions(
 
     logger.info("Starting synth evaluation")
     synthetic_data_filepath = await download_s3_file(task.synthetic_data)
-    synth_eval_results = await run_evaluation_docker(dataset=synthetic_data_filepath, **evaluation_params)
+    synth_results = await run_evaluation_docker(dataset=synthetic_data_filepath, **evaluation_params)
     os.remove(synthetic_data_filepath)
+    synth_eval_results = synth_results.results
+    task.model_params_count = synth_results.base_model_params_count
 
     finetuned_repos = []
     for repo in repos_to_evaluate:
@@ -354,10 +354,13 @@ async def _evaluate_submissions(
 
     if finetuned_repos:
         test_data_filepath = await download_s3_file(task.test_data)
-        test_eval_results = await run_evaluation_docker(
-            dataset=test_data_filepath, models=finetuned_repos, **{k: v for k, v in evaluation_params.items() if k != "models"}
+        test_results = await run_evaluation_docker(
+            dataset=test_data_filepath,
+            models=finetuned_repos,
+            **{k: v for k, v in evaluation_params.items() if k != "models"}
         )
         os.remove(test_data_filepath)
+        test_eval_results = test_results.results
 
         for repo in finetuned_repos:
             if isinstance(test_eval_results.get(repo), Exception):


### PR DESCRIPTION
calculates num model params within the docker eval (while it's already loaded in the memory)
And updates the tasks table with it

That model params count is later used in weights setting

Tested in local vali setup