### PR TITLE
Add task type to offer and cleanup enums

### DIFF
--- a/core/models/payload_models.py
+++ b/core/models/payload_models.py
@@ -12,6 +12,7 @@ from core.models.utility_models import JobStatus
 from core.models.utility_models import MinerTaskResult
 from core.models.utility_models import TaskMinerResult
 from core.models.utility_models import TaskStatus
+from core.models.utility_models import TaskType
 from validator.core.models import AllNodeStats
 
 
@@ -23,6 +24,7 @@ class MinerTaskOffer(BaseModel):
     model: str
     hours_to_complete: int
     task_id: str
+    task_type: TaskType
 
 
 class TrainRequest(BaseModel):
@@ -78,7 +80,7 @@ class EvaluationRequestDiffusion(BaseModel):
 class DiffusionLosses(BaseModel):
     text_guided_losses: list[float]
     no_text_losses: list[float]
-    
+
 
 class EvaluationResultImage(BaseModel):
     eval_loss: DiffusionLosses | float

--- a/core/models/utility_models.py
+++ b/core/models/utility_models.py
@@ -123,3 +123,8 @@ class Prompts(BaseModel):
     # correctness-focused prompts (step 2/2)
     input_field_generation_sys: str
     input_field_generation_user: str
+
+
+class TaskType(str, Enum):
+    TEXTTASK = "TextTask"
+    IMAGETASK = "ImageTask"

--- a/miner/endpoints/tuning.py
+++ b/miner/endpoints/tuning.py
@@ -21,6 +21,7 @@ from core.models.payload_models import TrainRequestImage
 from core.models.payload_models import TrainRequestText
 from core.models.payload_models import TrainResponse
 from core.models.utility_models import FileFormat
+from core.models.utility_models import TaskType
 from core.utils import download_s3_file
 from miner.config import WorkerConfig
 from miner.dependencies import get_worker_config
@@ -138,12 +139,13 @@ async def task_offer(
         # You will want to optimise this as a miner
         global current_job_finish_time
         current_time = datetime.now()
-        if "llama" not in request.model.lower():
-            return MinerTaskResponse(message="I'm not yet optimised and only accept llama-type jobs", accepted=False)
+        if request.task_type == TaskType.TEXTTASK:
+            if "llama" not in request.model.lower():
+                return MinerTaskResponse(message="I'm not yet optimised and only accept llama-type jobs", accepted=False)
         if current_job_finish_time is None or current_time + timedelta(hours=1) > current_job_finish_time:
             if request.hours_to_complete < 13:
                 logger.info("Accepting the offer - ty snr")
-                return MinerTaskResponse(message="Yes", accepted=True)
+                return MinerTaskResponse(message=f"Yes. I can do {request.task_type} jobs", accepted=True)
             else:
                 logger.info("Rejecting offer")
                 return MinerTaskResponse(message="I only accept small jobs", accepted=False)

--- a/validator/core/models.py
+++ b/validator/core/models.py
@@ -1,6 +1,5 @@
 import json
 from datetime import datetime
-from enum import Enum
 from pathlib import Path
 from typing import Any
 from uuid import UUID
@@ -10,6 +9,7 @@ from pydantic import BaseModel
 from pydantic import Field
 
 from core.models.utility_models import FileFormat
+from core.models.utility_models import TaskType
 
 
 class TokenizerConfig(BaseModel):
@@ -61,11 +61,6 @@ class ModelData(BaseModel):
     parameter_count: int | None = None
 
     model_config = {"protected_namespaces": ()}
-
-
-class TaskType(Enum):
-    TEXTTASK = "TextTask"
-    IMAGETASK = "ImageTask"
 
 
 class RawTask(BaseModel):
@@ -164,6 +159,7 @@ class MiniTaskWithScoringOnly(BaseModel):
     # Turn off protected namespace for model
     model_config = {"protected_namespaces": ()}
 
+
 class TaskResults(BaseModel):
     task: MiniTaskWithScoringOnly
     node_scores: list[TaskNode]
@@ -205,7 +201,7 @@ class MinerResults(BaseModel):
 
 class MinerResultsText(MinerResults):
     task_type: TaskType = TaskType.TEXTTASK
-    
+
 
 class MinerResultsImage(MinerResults):
     task_type: TaskType = TaskType.IMAGETASK

--- a/validator/core/task_config_models.py
+++ b/validator/core/task_config_models.py
@@ -1,10 +1,10 @@
-from enum import Enum
 from typing import Callable
 from typing import Union
 
 from pydantic import BaseModel
 from pydantic import Field
 
+from core.models.utility_models import TaskType
 from validator.core import constants as cst
 from validator.core.models import ImageRawTask
 from validator.core.models import TextRawTask
@@ -17,11 +17,6 @@ from validator.cycle.util_functions import run_text_task_prep
 from validator.evaluation.docker_evaluation import run_evaluation_docker_image
 from validator.evaluation.docker_evaluation import run_evaluation_docker_text
 from validator.tasks.task_prep import get_additional_synth_data
-
-
-class TaskType(str, Enum):
-    IMAGE = "image"
-    TEXT = "text"
 
 
 # TODO
@@ -41,7 +36,7 @@ class TaskConfig(BaseModel):
 
 
 class ImageTaskConfig(TaskConfig):
-    task_type: TaskType = TaskType.IMAGE
+    task_type: TaskType = TaskType.IMAGETASK
     eval_container: Callable = run_evaluation_docker_image
     synth_data_function: Callable | None = None
     data_size_function: Callable = get_total_image_dataset_size
@@ -51,7 +46,7 @@ class ImageTaskConfig(TaskConfig):
 
 
 class TextTaskConfig(TaskConfig):
-    task_type: TaskType = TaskType.TEXT
+    task_type: TaskType = TaskType.TEXTTASK
     eval_container: Callable = run_evaluation_docker_text
     synth_data_function: Callable | None = get_additional_synth_data
     data_size_function: Callable = get_total_text_dataset_size

--- a/validator/db/sql/tasks.py
+++ b/validator/db/sql/tasks.py
@@ -9,12 +9,12 @@ from fiber.chain.models import Node
 import validator.db.constants as cst
 from core.constants import NETUID
 from core.models.utility_models import TaskStatus
+from core.models.utility_models import TaskType
 from validator.core.models import ImageRawTask
 from validator.core.models import ImageTask
 from validator.core.models import NetworkStats
 from validator.core.models import RawTask
 from validator.core.models import Task
-from validator.core.models import TaskType
 from validator.core.models import TextRawTask
 from validator.core.models import TextTask
 from validator.db.database import PSQLDB
@@ -67,15 +67,15 @@ async def add_task(task: TextRawTask | ImageRawTask, psql_db: PSQLDB) -> RawTask
         async with connection.transaction():
             query_tasks = f"""
                 INSERT INTO {cst.TASKS_TABLE}
-                ({cst.ACCOUNT_ID}, 
-                {cst.MODEL_ID}, 
-                {cst.DS}, 
-                {cst.STATUS}, 
+                ({cst.ACCOUNT_ID},
+                {cst.MODEL_ID},
+                {cst.DS},
+                {cst.STATUS},
                 {cst.IS_ORGANIC},
-                {cst.HOURS_TO_COMPLETE}, 
-                {cst.TEST_DATA}, 
+                {cst.HOURS_TO_COMPLETE},
+                {cst.TEST_DATA},
                 {cst.TRAINING_DATA},
-                {cst.CREATED_AT}, 
+                {cst.CREATED_AT},
                 {cst.TASK_TYPE})
                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
                 RETURNING *

--- a/validator/endpoints/tasks.py
+++ b/validator/endpoints/tasks.py
@@ -23,13 +23,13 @@ from core.models.utility_models import FileFormat
 from core.models.utility_models import MinerTaskResult
 from core.models.utility_models import TaskMinerResult
 from core.models.utility_models import TaskStatus
+from core.models.utility_models import TaskType
 from validator.core.config import Config
 from validator.core.constants import MAX_CONCURRENT_JOBS
 from validator.core.dependencies import get_api_key
 from validator.core.dependencies import get_config
 from validator.core.models import ImageTask
 from validator.core.models import NetworkStats
-from validator.core.models import TaskType
 from validator.core.models import TextRawTask
 from validator.core.models import TextTask
 from validator.db.sql import submissions_and_scoring as submissions_and_scoring_sql


### PR DESCRIPTION
Added the enum to common core models.
Removed a similar enum from task config so that we have a common TaskType everywhere.

The miners now receive a task type in the offer so they can decide