### PR TITLE
Use a separate endpoint for image task offers

### DIFF
--- a/validator/core/constants.py
+++ b/validator/core/constants.py
@@ -28,6 +28,7 @@ NULL_ACCOUNT_ID = "00000000-0000-0000-0000-000000000000"
 START_TRAINING_ENDPOINT = "/start_training/"
 START_TRAINING_IMAGE_ENDPOINT = "/start_training_image/"
 TASK_OFFER_ENDPOINT = "/task_offer/"
+TASK_OFFER_IMAGE_ENDPOINT = "/task_offer_image/"
 SUBMISSION_ENDPOINT = "/get_latest_model_submission/"
 
 # TODO update when live

--- a/validator/cycle/process_tasks.py
+++ b/validator/cycle/process_tasks.py
@@ -11,6 +11,7 @@ import validator.db.sql.tasks as tasks_sql
 from core.models.payload_models import MinerTaskOffer
 from core.models.payload_models import MinerTaskResponse
 from core.models.utility_models import TaskStatus
+from core.models.utility_models import TaskType
 from validator.core.config import Config
 from validator.core.models import ImageRawTask
 from validator.core.models import TextRawTask
@@ -28,7 +29,8 @@ logger = get_logger(__name__)
 
 # TODO: Improve by batching these up
 async def _make_offer(node: Node, request: MinerTaskOffer, config: Config) -> MinerTaskResponse:
-    response = await process_non_stream_fiber(cst.TASK_OFFER_ENDPOINT, config, node, request.model_dump(), timeout=3)
+    endpoint = cst.TASK_OFFER_IMAGE_ENDPOINT if request.task_type == TaskType.IMAGETASK else cst.TASK_OFFER_ENDPOINT
+    response = await process_non_stream_fiber(endpoint, config, node, request.model_dump(), timeout=3)
     logger.info(f"The response from make {request.task_type} offer for node {node.node_id} was {response}")
     if response is None:
         response = {}


### PR DESCRIPTION
This will make the introduction of image tasks smoother. If a miner has not updated their code to accept image tasks, it will simply not accept the offers and no harm done. 
