### PR TITLE
Dev env proposal

### DIFF
--- a/utils/setup_dev_miners.py
+++ b/utils/setup_dev_miners.py
@@ -1,0 +1,104 @@
+import argparse
+import asyncio
+import os
+from logging import getLogger
+from typing import Optional
+
+import asyncpg
+from dotenv import load_dotenv
+from fiber.chain.models import Node
+
+
+logger = getLogger(__name__)
+
+
+async def inject_dev_miner(
+    hotkey: str,
+    coldkey: str,
+    ip: str = "localhost",
+    port: int = 7999,
+    netuid: int = 241,
+    db_name: Optional[str] = None,
+    db_user: Optional[str] = None,
+    db_password: Optional[str] = None,
+    db_host: Optional[str] = None,
+) -> None:
+    """Inject a development miner into the validator's database."""
+    if not all([db_name, db_user, db_password, db_host]):
+        load_dotenv(".vali.env")
+        db_name = os.getenv("POSTGRES_DB")
+        db_user = os.getenv("POSTGRES_USER")
+        db_password = os.getenv("POSTGRES_PASSWORD")
+        db_host = os.getenv("POSTGRES_HOST")
+        logger.info(f"Using database {db_name} on {db_host} with user {db_user} and password {db_password}")
+
+    conn = await asyncpg.connect(
+        database=db_name,
+        user=db_user,
+        password=db_password,
+        host=db_host,
+    )
+
+    node = Node(
+        hotkey=hotkey,
+        ip=ip,
+        port=port,
+        netuid=netuid,
+        node_id=0,
+        incentive=1.0,
+        stake=1000.0,
+        coldkey=coldkey,
+        trust=0.0,
+        vtrust=0.0,
+        last_updated=0,
+        ip_type=4,
+    )
+
+    await conn.execute(
+        """
+        INSERT INTO nodes (
+            hotkey, ip, port, netuid, node_id, incentive, stake, 
+            coldkey, ip_type, trust, vtrust, last_updated
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+        ON CONFLICT (hotkey, netuid) 
+        DO UPDATE SET 
+            ip = $2,
+            port = $3,
+            node_id = $5,
+            incentive = $6,
+            stake = $7,
+            coldkey = $8,
+            ip_type = $9,
+            trust = $10,
+            vtrust = $11,
+            last_updated = $12
+        """,
+        node.hotkey,
+        node.ip,
+        node.port,
+        node.netuid,
+        node.node_id,
+        node.incentive,
+        node.stake,
+        node.coldkey,
+        node.ip_type,
+        node.trust,
+        node.vtrust,
+        node.last_updated,
+    )
+
+    await conn.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Inject a development miner into the validator database.")
+    parser.add_argument("--hotkey", help="The hotkey for the miner")
+    parser.add_argument("--coldkey", help="The coldkey for the miner")
+    parser.add_argument("--ip", default="localhost", help="IP address (default: localhost)")
+    parser.add_argument("--port", type=int, default=7999, help="Port number (default: 7999)")
+    parser.add_argument("--netuid", type=int, default=241, help="Network UID (default: 241)")
+
+    args = parser.parse_args()
+
+    asyncio.run(inject_dev_miner(hotkey=args.hotkey, coldkey=args.coldkey, ip=args.ip, port=args.port, netuid=args.netuid))

--- a/utils/start_validator.sh
+++ b/utils/start_validator.sh
@@ -47,6 +47,9 @@ pm2 start \
     python -u -m validator.cycle.main" \
     --name validator_cycle
 
-pm2 start \
-    "python -m validator.core.weight_setting" \
-    --name weight_setter
+# no weight setting in dev
+if [ "${ENV,,}" != "dev" ]; then
+    pm2 start \
+        "python -m validator.core.weight_setting" \
+        --name weight_setter
+fi

--- a/validator/core/refresh_nodes.py
+++ b/validator/core/refresh_nodes.py
@@ -53,6 +53,8 @@ async def _get_and_store_nodes(config: Config) -> list[Node]:
 
 
 async def refresh_nodes_periodically(config: Config) -> None:
+    if not config.refresh_nodes:
+        return
     while True:
         try:
             logger.info("Attempting to refresh nodes with the metagraph")


### PR DESCRIPTION
We often want to test the vali and a miner locally without needing to register on testnet.

This starts using the existing ENV and REFRESH_NODES env vars which are currently set automatically to prod and True respectively. 
They are, however, not used in code and this actually disables refreshing nodes if REFRESH NODES is False.
If the ENV is dev it will also not start the weight setter with task validator. Therefore the vali does not interact with the metagraph.

To use the local miner which is also not on the metagraph we can use the new python script to inject its IP, hk and ck to the db so the vali will start sending tasks it's way.

Will add docs if we decide to go with this