### PR TITLE
efficient model caching

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -23,6 +23,8 @@ CONTAINER_EVAL_RESULTS_PATH = "/aplp/evaluation_results.json"
 
 CONFIG_DIR = "core/config/"
 OUTPUT_DIR = "core/outputs/"
+CACHE_DIR = "~/.cache/huggingface"
+CACHE_DIR_HUB = os.path.expanduser("~/.cache/huggingface/hub")
 DIFFUSION_DATASET_DIR = "core/dataset/images"
 
 DIFFUSION_REPEATS = 10

--- a/validator/core/constants.py
+++ b/validator/core/constants.py
@@ -185,3 +185,9 @@ IMAGE_TASK_SCORE_WEIGHT = 1 - TEXT_TASK_SCORE_WEIGHT
 SEVEN_DAY_SCORE_WEIGHT = 0.25
 THREE_DAY_SCORE_WEIGHT = 0.4
 ONE_DAY_SCORE_WEIGHT = 0.35
+
+# HF models cache management
+CACHE_TAU_DAYS = 10  # Time constant (τ) for exponential decay in days
+CACHE_MAX_LOOKUP_DAYS = 30  # Maximum number of days to look back for usage data
+MAX_CACHE_SIZE_BYTES = 600 * 1024**3  # in bytes
+CACHE_CLEANUP_INTERVAL = 30 * 60  # in seconds

--- a/validator/cycle/process_tasks.py
+++ b/validator/cycle/process_tasks.py
@@ -335,20 +335,21 @@ async def cleanup_model_cache(psql_db: PSQLDB):
             for task in evaluating_tasks + preevaluation_tasks:
                 if task.model_id:
                     protected_models.add(str(task.model_id))
-            
+
             cache_stats = await tasks_sql.get_model_cache_stats(
                 psql_db,
                 tau_days=cst.CACHE_TAU_DAYS,
                 max_lookup_days=cst.CACHE_MAX_LOOKUP_DAYS
             )
-            
+
             # Set cache score to infinity for protected models to prevent deletion
+            logger.info(f"Protected models: {protected_models}")
             for model_id in protected_models:
                 if model_id not in cache_stats:
                     cache_stats[model_id] = {'cache_score': float('inf')}
                 else:
                     cache_stats[model_id]['cache_score'] = float('inf')
-            
+
             manage_models_cache(cache_stats, cst.MAX_CACHE_SIZE_BYTES)
         except Exception as e:
             logger.error(f"Error in cache cleanup: {e}", exc_info=True)

--- a/validator/cycle/process_tasks.py
+++ b/validator/cycle/process_tasks.py
@@ -16,8 +16,10 @@ from validator.core.config import Config
 from validator.core.models import ImageRawTask
 from validator.core.models import TextRawTask
 from validator.core.task_config_models import get_task_config
+from validator.db.database import PSQLDB
 from validator.evaluation.scoring import evaluate_and_score
 from validator.utils.cache_clear import clean_all_hf_datasets_cache
+from validator.utils.cache_clear import manage_models_cache
 from validator.utils.call_endpoint import process_non_stream_fiber
 from validator.utils.logging import LogContext
 from validator.utils.logging import add_context_tag
@@ -25,6 +27,8 @@ from validator.utils.logging import get_logger
 
 
 logger = get_logger(__name__)
+
+_cache_cleanup_lock = asyncio.Lock()
 
 
 def _weighted_random_shuffle(nodes: list[Node]):
@@ -317,6 +321,41 @@ async def move_tasks_to_preevaluation_loop(config: Config):
         await asyncio.sleep(60)
 
 
+async def cleanup_model_cache(psql_db: PSQLDB):
+    """Clean up model cache when it exceeds size limit."""
+    if _cache_cleanup_lock.locked():
+        return
+
+    async with _cache_cleanup_lock:
+        try:
+            logger.info("Cleaning up model cache")
+            evaluating_tasks = await tasks_sql.get_tasks_with_status(TaskStatus.EVALUATING, psql_db=psql_db)
+            preevaluation_tasks = await tasks_sql.get_tasks_with_status(TaskStatus.PREEVALUATION, psql_db=psql_db)
+            protected_models = set()
+            for task in evaluating_tasks + preevaluation_tasks:
+                if task.model_id:
+                    protected_models.add(str(task.model_id))
+            
+            cache_stats = await tasks_sql.get_model_cache_stats(
+                psql_db,
+                tau_days=cst.CACHE_TAU_DAYS,
+                max_lookup_days=cst.CACHE_MAX_LOOKUP_DAYS
+            )
+            
+            # Set cache score to infinity for protected models to prevent deletion
+            for model_id in protected_models:
+                if model_id not in cache_stats:
+                    cache_stats[model_id] = {'cache_score': float('inf')}
+                else:
+                    cache_stats[model_id]['cache_score'] = float('inf')
+            
+            manage_models_cache(cache_stats, cst.MAX_CACHE_SIZE_BYTES)
+        except Exception as e:
+            logger.error(f"Error in cache cleanup: {e}", exc_info=True)
+        finally:
+            await asyncio.sleep(cst.CACHE_CLEANUP_INTERVAL)
+
+
 async def evaluate_tasks_loop(config: Config):
     task_queue = asyncio.Queue()
     gpu_queue = asyncio.Queue()
@@ -359,6 +398,7 @@ async def evaluate_tasks_loop(config: Config):
                         await task_queue.put(task)
             else:
                 logger.info("No new tasks awaiting evaluation - waiting 30 seconds")
+            await cleanup_model_cache(config.psql_db)
         else:
             logger.info("Evaluation queue is full - waiting for 30 seconds")
         await asyncio.sleep(30)

--- a/validator/db/sql/tasks.py
+++ b/validator/db/sql/tasks.py
@@ -757,3 +757,63 @@ async def delete_image_text_pairs(task_id: UUID, psql_db: PSQLDB) -> None:
     async with await psql_db.connection() as connection:
         connection: Connection
         await connection.execute(query, task_id)
+
+
+async def get_model_cache_stats(psql_db: PSQLDB, tau_days: float = 10, max_lookup_days: float = 30) -> Dict[str, Dict]:
+    """Get cache statistics for models with time-weighted frequency calculation.
+
+    Args:
+        psql_db: Database connection
+        tau_days: Time constant (τ) for exponential decay in days
+        max_lookup_days: Maximum number of days to look back for usage data
+
+    Returns:
+        Dictionary mapping model_id to stats containing:
+        - time_weighted_freq: Time-weighted frequency of model usage
+        - size_params: Number of parameters in the model
+        - cache_score: Product of frequency and size
+    """
+    async with await psql_db.connection() as connection:
+        connection: Connection
+        query = """
+            WITH daily_counts AS (
+                SELECT
+                    model_id,
+                    DATE_TRUNC('day', created_at) as usage_date,
+                    COUNT(*) as daily_uses,
+                    MAX(model_params_count) as params_count
+                FROM tasks
+                WHERE created_at > NOW() - $2 * INTERVAL '1 day'
+                GROUP BY model_id, DATE_TRUNC('day', created_at)
+            ),
+            model_usage AS (
+                SELECT
+                    model_id,
+                    SUM(
+                        daily_uses * exp(
+                            -EXTRACT(EPOCH FROM (NOW() - usage_date)) /
+                            EXTRACT(EPOCH FROM ($1 * INTERVAL '1 day'))
+                        )
+                    ) as time_weighted_freq,
+                    MAX(params_count) as size_params
+                FROM daily_counts
+                GROUP BY model_id
+            )
+            SELECT
+                model_id,
+                time_weighted_freq,
+                size_params,
+                time_weighted_freq * size_params as cache_score
+            FROM model_usage
+            ORDER BY cache_score DESC
+        """
+        rows = await connection.fetch(query, tau_days, max_lookup_days)
+
+        return {
+            str(row['model_id']): {
+                'time_weighted_freq': float(row['time_weighted_freq'] or 0),
+                'size_params': int(row['size_params'] or 0),
+                'cache_score': float(row['cache_score'] or 0)
+            }
+            for row in rows
+        }

--- a/validator/evaluation/docker_evaluation.py
+++ b/validator/evaluation/docker_evaluation.py
@@ -8,6 +8,7 @@ from typing import Union
 
 import docker
 from docker.models.containers import Container
+from docker.types import Mount
 
 from core import constants as cst
 from core.models.payload_models import DockerEvaluationResults
@@ -105,6 +106,10 @@ async def run_evaluation_docker_text(
         dataset_dir: {
             "bind": "/workspace/input_data",
             "mode": "ro",
+        },
+        os.path.expanduser(cst.CACHE_DIR): {
+            "bind": "/root/.cache/huggingface",
+            "mode": "rw",
         }
     }
 
@@ -160,8 +165,27 @@ async def run_evaluation_docker_image(
 
     client = docker.from_env()
 
-    volume_bindings = {}
-    volume_bindings[dataset_dir] = {"bind": container_dataset_path, "mode": "ro"}
+    base_path = "/app/validator/evaluation/ComfyUI/models"
+    mounts = [
+        Mount(
+            target=container_dataset_path,
+            source=dataset_dir,
+            type='bind',
+            read_only=True
+        ),
+        Mount(
+            target=f"{base_path}/checkpoints",
+            source=cst.CACHE_DIR_HUB,
+            type='bind',
+            read_only=False
+        ),
+        Mount(
+            target=f"{base_path}/diffusers",
+            source=cst.CACHE_DIR_HUB,
+            type='bind',
+            read_only=False
+        )
+    ]
 
     environment = {
         "DATASET": container_dataset_path,
@@ -182,7 +206,7 @@ async def run_evaluation_docker_image(
         container = await asyncio.to_thread(
             client.containers.run,
             cst.VALIDATOR_DOCKER_IMAGE_DIFFUSION,
-            volumes=volume_bindings,
+            mounts=mounts,
             environment=environment,
             runtime="nvidia",
             device_requests=[docker.types.DeviceRequest(capabilities=[["gpu"]], device_ids=[str(gid) for gid in gpu_ids])],

--- a/validator/evaluation/eval_diffusion.py
+++ b/validator/evaluation/eval_diffusion.py
@@ -91,13 +91,12 @@ def is_safetensors_available(repo_id: str) -> tuple[bool, str | None]:
 def download_base_model(repo_id: str, safetensors_filename: str | None = None) -> str:
     if safetensors_filename:
         model_path = download_from_huggingface(repo_id, safetensors_filename, cst.CHECKPOINTS_SAVE_PATH)
+        model_name = os.path.basename(model_path)
     else:
-        model_name = repo_id.split("/")[-1]
+        model_name = f"models--{repo_id.replace('/', '--')}"
         save_dir = f"{cst.DIFFUSERS_PATH}/{model_name}"
         model_path = snapshot_download(repo_id=repo_id, local_dir=save_dir, repo_type="model")
-        return model_name, model_path
-
-    return safetensors_filename, model_path
+    return model_name, model_path
 
 
 def download_lora(repo_id: str) -> str:

--- a/validator/evaluation/utils.py
+++ b/validator/evaluation/utils.py
@@ -115,7 +115,7 @@ def base64_to_image(base64_string: str) -> Image.Image:
 def download_from_huggingface(repo_id: str, filename: str, local_dir: str) -> str:
     # Use a temp folder to ensure correct file placement
     try:
-        local_filename = os.path.basename(filename)
+        local_filename = f"models--{repo_id.replace('/', '--')}.safetensors"
         final_path = os.path.join(local_dir, local_filename)
         if os.path.exists(final_path):
             logger.info(f"File {filename} already exists. Skipping download.")

--- a/validator/utils/cache_clear.py
+++ b/validator/utils/cache_clear.py
@@ -2,7 +2,9 @@ import glob
 import os
 import shutil
 import tempfile
+from pathlib import Path
 
+from core import constants as cst
 from validator.utils.logging import get_logger
 
 
@@ -65,17 +67,6 @@ def delete_dataset_from_cache(dataset_name):
         logger.info(f"No files found for dataset '{dataset_name}'")
 
 
-def delete_model_from_cache(model_name):
-    cache_dir = os.path.expanduser("~/.cache/huggingface/hub")
-    model_path = os.path.join(cache_dir, model_name)
-
-    if os.path.exists(model_path):
-        shutil.rmtree(model_path)
-        logger.info(f"Deleted model '{model_name}' from cache.")
-    else:
-        logger.info(f"Model '{model_name}' not found in cache.")
-
-
 def clean_all_hf_datasets_cache():
     """Clean the entire Huggingface datasets cache directory."""
     try:
@@ -85,3 +76,136 @@ def clean_all_hf_datasets_cache():
             logger.info(f"Cleaned Huggingface datasets cache at {hf_cache_path}")
     except Exception as e:
         logger.error(f"Error cleaning Huggingface datasets cache: {e}")
+
+
+def remove_cache_models_except(models_to_keep: list[str]):
+    """Keep only specified models in HuggingFace cache, remove all others.
+
+    Args:
+        models_to_keep: List of model identifiers in format 'org/model-name' to preserve
+    """
+    keep_patterns = {
+        f"models--{name.lower().replace('/', '--')}"
+        for name in models_to_keep
+    }
+
+    # Handle directories
+    existing_models = {
+        orig_dir: orig_dir.lower()
+        for orig_dir in os.listdir(cst.CACHE_DIR_HUB)
+        if orig_dir.startswith('models--')
+    }
+
+    to_delete = {
+        orig_dir for orig_dir, lower_dir in existing_models.items()
+        if lower_dir not in keep_patterns
+    }
+
+    deleted_count = 0
+    for dir_name in to_delete:
+        try:
+            model_path = os.path.join(cst.CACHE_DIR_HUB, dir_name)
+            shutil.rmtree(model_path)
+            deleted_count += 1
+        except Exception as e:
+            logger.error(f"Error deleting cache for directory {dir_name}: {e}")
+    
+    # Handle safetensor files
+    safetensor_files = [
+        f for f in os.listdir(cst.CACHE_DIR_HUB) 
+        if f.endswith('.safetensors')
+    ]
+    
+    deleted_files = 0
+    for file_name in safetensor_files:
+        # Check if file belongs to a model we want to keep
+        if not any(file_name.lower().startswith(pattern) for pattern in keep_patterns):
+            try:
+                file_path = os.path.join(cst.CACHE_DIR_HUB, file_name)
+                os.remove(file_path)
+                deleted_files += 1
+            except Exception as e:
+                logger.error(f"Error deleting safetensor file {file_name}: {e}")
+
+    logger.info(
+        f"Cleaned cache: kept {len(models_to_keep)} models, "
+        f"removed {deleted_count} dirs and {deleted_files} safetensors files."
+    )
+
+
+def get_directory_size(path: str) -> int:
+    """Calculate total size of a directory in bytes.
+    Returns 0 if directory doesn't exist."""
+    try:
+        return sum(f.stat().st_size for f in Path(path).rglob('*') if f.is_file())
+    except (FileNotFoundError, PermissionError):
+        return 0
+
+
+def get_hf_model_cache_size(model_id: str) -> int:
+    """Get size of a specific model in HF cache (case insensitive).
+    Returns 0 if model not found."""
+    model_pattern = f"models--{model_id.lower().replace('/', '--')}"
+    total_size = 0
+
+    # Find and measure directory size (case insensitive)
+    if os.path.exists(cst.CACHE_DIR_HUB):
+        for dir_name in os.listdir(cst.CACHE_DIR_HUB):
+            if dir_name.lower() == model_pattern:
+                total_size += get_directory_size(os.path.join(cst.CACHE_DIR_HUB, dir_name))
+        
+        # Check for matching safetensor files
+        for file_name in os.listdir(cst.CACHE_DIR_HUB):
+            if file_name.endswith('.safetensors') and file_name.lower().startswith(model_pattern):
+                try:
+                    file_path = os.path.join(cst.CACHE_DIR_HUB, file_name)
+                    total_size += os.path.getsize(file_path)
+                except (OSError, FileNotFoundError):
+                    pass
+                    
+    return total_size
+
+
+def manage_models_cache(model_stats: dict[str, dict], max_size: int) -> None:
+    """Manage HF models cache based on model usage statistics."""
+    current_size = get_directory_size(cst.CACHE_DIR_HUB)
+    if current_size <= max_size:
+        return
+
+    logger.info(f"Cache size ({current_size / 1024**3:.2f}GB) exceeds limit ({max_size / 1024**3:.2f}GB). Starting cleanup...")
+    logger.info(f"Model stats: {model_stats}")
+
+    # First pass: keep only models in stats
+    remove_cache_models_except(list(model_stats.keys()))
+
+    current_size = get_directory_size(cst.CACHE_DIR_HUB)
+    if current_size <= max_size:
+        logger.info(f"Cache size now {current_size / 1024**3:.2f}GB after removing unused models.")
+        return
+
+    # Second pass: calculate which models to remove based on scores and sizes
+    sorted_models = sorted(
+        model_stats.items(),
+        key=lambda x: x[1]['cache_score']
+    )
+
+    size_to_free = current_size - max_size
+    cumulative_size = 0
+    models_to_remove = []
+
+    for model_id, stats in sorted_models:
+        model_size = get_hf_model_cache_size(model_id)
+        cumulative_size += model_size
+        models_to_remove.append(model_id)
+
+        if cumulative_size >= size_to_free:
+            break
+
+    models_to_keep = [
+        model_id for model_id in model_stats.keys()
+        if model_id not in models_to_remove
+    ]
+
+    remove_cache_models_except(models_to_keep)
+    final_size = get_directory_size(cst.CACHE_DIR_HUB)
+    logger.info(f"Cache cleanup complete. Final size: {final_size / 1024**3:.2f}GB")

--- a/validator/utils/cache_clear.py
+++ b/validator/utils/cache_clear.py
@@ -126,10 +126,7 @@ def remove_cache_models_except(models_to_keep: list[str]):
             except Exception as e:
                 logger.error(f"Error deleting safetensor file {file_name}: {e}")
 
-    logger.info(
-        f"Cleaned cache: kept {len(models_to_keep)} models, "
-        f"removed {deleted_count} dirs and {deleted_files} safetensors files."
-    )
+    logger.info(f"Cleaned cache: removed {deleted_count} dirs and {deleted_files} safetensors files.")
 
 
 def get_directory_size(path: str) -> int:
@@ -182,7 +179,9 @@ def manage_models_cache(model_stats: dict[str, dict], max_size: int) -> None:
     logger.info(f"Model stats: {model_stats}")
 
     # First pass: keep only models in stats
-    remove_cache_models_except(list(model_stats.keys()))
+    allowed_models = list(model_stats.keys())
+    logger.info(f"Cache cleanup: Will remove models with no cache score record ({len(allowed_models)} records)")
+    remove_cache_models_except(allowed_models)
 
     current_size = get_directory_size(cst.CACHE_DIR_HUB)
     if current_size <= max_size:
@@ -212,6 +211,7 @@ def manage_models_cache(model_stats: dict[str, dict], max_size: int) -> None:
         if model_id not in models_to_remove
     ]
 
+    logger.info(f"Cache cleanup: Will keep {len(models_to_keep)} models")
     remove_cache_models_except(models_to_keep)
     final_size = get_directory_size(cst.CACHE_DIR_HUB)
     logger.info(f"Cache cleanup complete. Final size: {final_size / 1024**3:.2f}GB")


### PR DESCRIPTION
### Goal
- Speed up vali 🚀
- Avoid HF bandwidth rate limits with frequent downloads
### Workflow
- After eval batch, check if models cache disk space exceeds threshold, clean cache by removing models with the lowest caching score
- Use async lock to only try to run the cache cleaning once every 30 minutes (parameterizable)
### Pending
- [x]  Needs model params size to compute cache score: Merge #247
- [ ]  Rebase and test
### Deriving caching scores to optimize speed
![Xnip2025-01-27_20-16-50](https://github.com/user-attachments/assets/87792e31-704d-45e4-9b6d-cf3f63ab886a)
![Xnip2025-01-27_20-16-58](https://github.com/user-attachments/assets/22005835-8290-4eaa-9178-543fb260121f)