### PR TITLE
optimize eval

### DIFF
--- a/validator/cycle/main.py
+++ b/validator/cycle/main.py
@@ -1,10 +1,9 @@
 from dotenv import load_dotenv
 
 
-load_dotenv(".vali.env")
+load_dotenv(".vali.env", override=True)
 
 import asyncio
-
 
 from validator.core.config import load_config
 from validator.core.refresh_nodes import refresh_nodes_periodically


### PR DESCRIPTION
### Before
Previously, each group of `PREEVALUATION` tasks were put in a queue for evaluation, once the queue is fully consumed, the producer queries the DB for the new set of tasks.
### Issue
e.g. 4 GPU:worker, 10 `PREEVALUATION` tasks, (1 large task takes 10 hours to eval).
After 9 of the tasks complete eval, the remaining bottleneck will be the single large task (while 3 GPUs are idle)
### Solution
Once the queue becomes small enough, refill it with newly queried tasks from the DB.
- Handle duplicates since, adding a task to the queue doesn't change its status from `PREEVALUATION`.
- We only want to move status to `EVALUATING` when we effectively start `_evaluate_task`, since it will show us GPU utilization
### Pending testing