### PR TITLE
Ds size bins

### DIFF
--- a/validator/core/constants.py
+++ b/validator/core/constants.py
@@ -69,9 +69,9 @@ GPU_IDS = [int(id) for id in _gpu_ids.split(",")] if _gpu_ids else [0]
 
 # we sample datasets with these ranges equally
 DATASET_BINS_TO_SAMPLE = [
-    (0, 30_000_000),
-    (30_000_000, 60_000_000),
-    (60_000_000, 2_000_000_000),
+    (0, 80_000_000),
+    (80_000_000, 250_000_000),
+    (250_000_000, 2_000_000_000),
 ]
 
 # parquet file size bins to training hours range

--- a/validator/core/constants.py
+++ b/validator/core/constants.py
@@ -67,6 +67,24 @@ _gpu_ids = os.getenv("GPU_IDS", "").strip()
 GPU_IDS = [int(id) for id in _gpu_ids.split(",")] if _gpu_ids else [0]
 
 
+# we sample datasets with these ranges equally
+DATASET_BINS_TO_SAMPLE = [
+    (0, 30_000_000),
+    (30_000_000, 60_000_000),
+    (60_000_000, 2_000_000_000),
+]
+
+# parquet file size bins to training hours range
+TEXT_DATASET_BINS_TO_TRAINING_HOURS_RANGE = {
+    (0, 30_000_000): (1, 1),  # 0-30MB needs 1 hour
+    (30_000_000, 60_000_000): (1, 2),  # 30MB-60MB needs 1-2 hours
+    (60_000_000, 100_000_000): (2, 3),  # 60MB-100MB needs 2-4 hours
+    (100_000_000, 500_000_000): (3, 4),  # 100MB-500MB needs 3-4 hours
+    (500_000_000, 1_000_000_000): (4, 8),  # 500MB-1GB needs 4-8 hours
+    (1_000_000_000, 10_000_000_000): (8, 12),  # 1GB-10GB needs 8-12 hours
+}
+
+
 SYNTH_MODEL = "chat-llama-3-2-3b"
 PROMPT_GEN_ENDPOINT = "https://api.nineteen.ai/v1/chat/completions"
 GRADIENTS_ENDPOINT = "https://api.gradients.io/validator-signup"

--- a/validator/core/constants.py
+++ b/validator/core/constants.py
@@ -77,13 +77,12 @@ DATASET_BINS_TO_SAMPLE = [
 # parquet file size bins to training hours range
 TEXT_DATASET_BINS_TO_TRAINING_HOURS_RANGE = {
     (0, 30_000_000): (1, 1),  # 0-30MB needs 1 hour
-    (30_000_000, 60_000_000): (1, 2),  # 30MB-60MB needs 1-2 hours
-    (60_000_000, 100_000_000): (2, 3),  # 60MB-100MB needs 2-4 hours
-    (100_000_000, 500_000_000): (3, 4),  # 100MB-500MB needs 3-4 hours
-    (500_000_000, 1_000_000_000): (4, 8),  # 500MB-1GB needs 4-8 hours
-    (1_000_000_000, 10_000_000_000): (8, 12),  # 1GB-10GB needs 8-12 hours
+    (30_000_000, 60_000_000): (1, 3),  # 30MB-60MB needs 1-3 hours
+    (60_000_000, 100_000_000): (2, 5),  # 60MB-100MB needs 2-5 hours
+    (100_000_000, 500_000_000): (3, 6),  # 100MB-500MB needs 3-6 hours
+    (500_000_000, 1_000_000_000): (4, 9),  # 500MB-1GB needs 4-9 hours
+    (1_000_000_000, 10_000_000_000): (5, 12),  # 1GB-10GB needs 5-12 hours
 }
-
 
 SYNTH_MODEL = "chat-llama-3-2-3b"
 PROMPT_GEN_ENDPOINT = "https://api.nineteen.ai/v1/chat/completions"

--- a/validator/core/models.py
+++ b/validator/core/models.py
@@ -272,4 +272,4 @@ class TaskWithHotkeyDetails(Task):
 class Dataset(BaseModel):
     dataset_id: str
     num_rows: int
-    num_parquet_bytes: int
+    num_bytes_parquet_files: int

--- a/validator/core/models.py
+++ b/validator/core/models.py
@@ -267,3 +267,9 @@ class HotkeyDetails(BaseModel):
 
 class TaskWithHotkeyDetails(Task):
     hotkey_details: list[HotkeyDetails]
+
+
+class Dataset(BaseModel):
+    dataset_id: str
+    num_rows: int
+    num_parquet_bytes: int

--- a/validator/tasks/synthetic_scheduler.py
+++ b/validator/tasks/synthetic_scheduler.py
@@ -98,8 +98,10 @@ def _get_training_hours_from_bytes(bytes: int) -> tuple[int, int]:
             min_hours, max_hours = cst.TEXT_DATASET_BINS_TO_TRAINING_HOURS_RANGE[(min_bytes, max_bytes)]
             break
     if min_hours == 0 and max_hours == 0:
-        if bytes > cst.TEXT_DATASET_BINS_TO_TRAINING_HOURS_RANGE.keys()[-1][1]:  # if greater than the largest bin
-            return cst.TEXT_DATASET_BINS_TO_TRAINING_HOURS_RANGE.values()[-1][-1]  # max hours
+        sorted_bins = list(cst.TEXT_DATASET_BINS_TO_TRAINING_HOURS_RANGE.keys())
+        if bytes > sorted_bins[-1][1]:  # if greater than the largest bin
+            max_hours_range = list(cst.TEXT_DATASET_BINS_TO_TRAINING_HOURS_RANGE.values())[-1]
+            return max_hours_range[1]  # max hours
         else:
             raise ValueError(f"No training hours range found for {bytes} bytes")
     return random.randint(min_hours, max_hours)
@@ -112,7 +114,7 @@ async def _create_synthetic_task(
 ):
     model_id = await anext(models)
     dataset = await anext(datasets)
-    number_of_hours = _get_training_hours_from_bytes(dataset.size_bytes)
+    number_of_hours = _get_training_hours_from_bytes(dataset.num_bytes_parquet_files)
     columns = await _get_columns_for_dataset(dataset.dataset_id, config.keypair)
     current_time = datetime.utcnow()
     end_timestamp = current_time + timedelta(hours=number_of_hours)

--- a/validator/tasks/synthetic_scheduler.py
+++ b/validator/tasks/synthetic_scheduler.py
@@ -11,6 +11,7 @@ import validator.core.constants as cst
 from core.models.payload_models import DatasetColumnsResponse
 from core.models.utility_models import TaskStatus
 from validator.core.config import Config
+from validator.core.models import Dataset
 from validator.core.models import RawTask
 from validator.db.sql.tasks import add_task
 from validator.db.sql.tasks import get_tasks_with_status
@@ -33,23 +34,51 @@ async def _get_models(keypair: Keypair) -> AsyncGenerator[str, None]:
             yield model_id
 
 
-async def _get_datasets(keypair: Keypair) -> AsyncGenerator[str, None]:
+async def _get_datasets_for_bin(min_bytes: int, max_bytes: int, keypair: Keypair) -> AsyncGenerator[Dataset, None]:
+    """Get datasets for a specific size bin."""
     while True:
-        response = await call_content_service(cst.GET_RANDOM_DATASETS_ENDPOINT, keypair)
-        if not isinstance(response, list):
-            raise TypeError("Expected a list of responses from GET_ALL_DATASETS_ENDPOINT")
+        params = {"min_parquet_bytes": min_bytes, "max_parquet_bytes": max_bytes}
+        try:
+            response = await call_content_service(cst.GET_RANDOM_DATASETS_ENDPOINT, keypair, params)
+            if not isinstance(response, list):
+                raise TypeError("Expected a list of responses from GET_ALL_DATASETS_ENDPOINT")
 
-        datasets: list[dict[str, Any]] = response
-        dataset_ids = [ds.get(cst.GET_ALL_DATASETS_ID, "") for ds in datasets]
-        random.shuffle(dataset_ids)
+            dataset_dicts: list[dict[str, Any]] = response
+            datasets = [Dataset.model_validate(ds) for ds in dataset_dicts]
+            random.shuffle(datasets)
 
-        for ds_id in dataset_ids:
-            yield ds_id
+            for dataset in datasets:
+                yield dataset
+
+        except Exception as e:
+            logger.warning(f"Failed to fetch datasets for bin {min_bytes}-{max_bytes} bytes: {e}")
+            await asyncio.sleep(5)
 
 
-async def _get_columns_for_dataset(dataset_id: str, keypair: Keypair) -> DatasetColumnsResponse:
+async def _get_datasets(keypair: Keypair) -> AsyncGenerator[Dataset, None]:
+    """Round-robin generator that cycles through all dataset size bins."""
+
+    bin_generators = [_get_datasets_for_bin(min_bytes, max_bytes, keypair) for min_bytes, max_bytes in cst.DATASET_BINS_TO_SAMPLE]
+
+    while True:
+        for generator in bin_generators:
+            try:
+                dataset = await anext(generator)
+                yield dataset
+            except StopAsyncIteration:
+                continue
+            except Exception as e:
+                logger.warning(f"Error getting next dataset from bin: {e}")
+                continue
+
+
+async def _get_columns_for_dataset(
+    dataset_id: str,
+    keypair: Keypair,
+) -> DatasetColumnsResponse:
     url = cst.GET_COLUMNS_FOR_DATASET_ENDPOINT.replace("{dataset}", dataset_id)
     logger.info(f"Getting columns for dataset {dataset_id}")
+
     response = await call_content_service(url, keypair)
     if not isinstance(response, dict):
         raise TypeError(f"Expected dictionary response, got {type(response)}")
@@ -61,21 +90,36 @@ async def _get_columns_for_dataset(dataset_id: str, keypair: Keypair) -> Dataset
     return columns
 
 
+def _get_training_hours_from_bytes(bytes: int) -> tuple[int, int]:
+    """Randomly select training hours for a given dataset size in bytes based on range bins."""
+    min_hours, max_hours = 0, 0
+    for min_bytes, max_bytes in cst.TEXT_DATASET_BINS_TO_TRAINING_HOURS_RANGE.keys():
+        if min_bytes <= bytes <= max_bytes:
+            min_hours, max_hours = cst.TEXT_DATASET_BINS_TO_TRAINING_HOURS_RANGE[(min_bytes, max_bytes)]
+            break
+    if min_hours == 0 and max_hours == 0:
+        if bytes > cst.TEXT_DATASET_BINS_TO_TRAINING_HOURS_RANGE.keys()[-1][1]:  # if greater than the largest bin
+            return cst.TEXT_DATASET_BINS_TO_TRAINING_HOURS_RANGE.values()[-1][-1]  # max hours
+        else:
+            raise ValueError(f"No training hours range found for {bytes} bytes")
+    return random.randint(min_hours, max_hours)
+
+
 async def _create_synthetic_task(
     config: Config,
     models: AsyncGenerator[str, None],
-    datasets: AsyncGenerator[str, None],
+    datasets: AsyncGenerator[Dataset, None],
 ):
-    number_of_hours = random.randint(cst.MIN_COMPETITION_HOURS, cst.MAX_COMPETITION_HOURS)
     model_id = await anext(models)
-    dataset_id = await anext(datasets)
-    columns = await _get_columns_for_dataset(dataset_id, config.keypair)
+    dataset = await anext(datasets)
+    number_of_hours = _get_training_hours_from_bytes(dataset.size_bytes)
+    columns = await _get_columns_for_dataset(dataset.dataset_id, config.keypair)
     current_time = datetime.utcnow()
     end_timestamp = current_time + timedelta(hours=number_of_hours)
 
     task = RawTask(
         model_id=model_id,
-        ds_id=dataset_id,
+        ds_id=dataset.dataset_id,
         field_system=None,
         field_instruction=columns.field_instruction,
         field_input=columns.field_input,
@@ -95,7 +139,7 @@ async def _create_synthetic_task(
 async def _add_new_task_to_network_if_not_enough(
     config: Config,
     models: AsyncGenerator[str, None],
-    datasets: AsyncGenerator[str, None],
+    datasets: AsyncGenerator[Dataset, None],
 ):
     current_training_tasks = await get_tasks_with_status(TaskStatus.TRAINING, config.psql_db)
     current_preeval_tasks = await get_tasks_with_status(TaskStatus.PREEVALUATION, config.psql_db)


### PR DESCRIPTION
Replaces #278 

Needs promoting the content service to work (promoted :heavy_check_mark:)

Instead of getting a list of random datasets, we now get 3 lists of datasets with different sizes. Then in synth we sample from them them round-robin. 
Also, since we get the parquet file size from the content service, we use it to set the training hours. For this we have a new map which maps the dataset size range to the training hours rage