### PR TITLE
Sample datasets based on rows instead of bytes

### DIFF
--- a/validator/core/constants.py
+++ b/validator/core/constants.py
@@ -67,21 +67,22 @@ _gpu_ids = os.getenv("GPU_IDS", "").strip()
 GPU_IDS = [int(id) for id in _gpu_ids.split(",")] if _gpu_ids else [0]
 
 
-# we sample datasets with these ranges equally
+# we sample datasets with these num_rows ranges equally
 DATASET_BINS_TO_SAMPLE = [
-    (20_000_000, 80_000_000),
-    (80_000_000, 250_000_000),
-    (250_000_000, 2_000_000_000),
+    # (5_000, 10_000), # we don't sample these for now as they are too small
+    (10_000, 25_000),
+    (25_000, 50_000),
+    (50_000, 500_000),
+    (500_000, float("inf")),
 ]
 
-# parquet file size bins to training hours range
+# dataset row bins to training hours range
 TEXT_DATASET_BINS_TO_TRAINING_HOURS_RANGE = {
-    (0, 30_000_000): (1, 1),  # 0-30MB needs 1 hour
-    (30_000_000, 60_000_000): (1, 3),  # 30MB-60MB needs 1-3 hours
-    (60_000_000, 100_000_000): (2, 5),  # 60MB-100MB needs 2-5 hours
-    (100_000_000, 500_000_000): (3, 6),  # 100MB-500MB needs 3-6 hours
-    (500_000_000, 1_000_000_000): (4, 9),  # 500MB-1GB needs 4-9 hours
-    (1_000_000_000, 10_000_000_000): (5, 12),  # 1GB-10GB needs 5-12 hours
+    (5_000, 10_000): (1, 2),  # 5k-10k rows needs 1-2 hours
+    (10_000, 25_000): (2, 4),  # 10k-25k rows needs 2-4 hours
+    (25_000, 50_000): (3, 6),  # 25k-50k rows needs 3-6 hours
+    (50_000, 500_000): (4, 8),  # 50k-500k rows needs 4-8 hours
+    (500_000, float("inf")): (5, 12),  # 500k+ rows needs 5-12 hours
 }
 
 SYNTH_MODEL = "chat-llama-3-2-3b"

--- a/validator/tasks/synthetic_scheduler.py
+++ b/validator/tasks/synthetic_scheduler.py
@@ -93,7 +93,7 @@ async def _get_columns_for_dataset(
 def _get_training_hours_from_num_rows(num_rows: int) -> tuple[int, int]:
     """Randomly select training hours for a given dataset size in bytes based on range bins."""
     min_hours, max_hours = 0, 0
-    for min_rows, max_rows in cst.TEXT_DATASET_BINS_TO_TRAINING_HOURS_RANGE.items():
+    for min_rows, max_rows in cst.TEXT_DATASET_BINS_TO_TRAINING_HOURS_RANGE.keys():
         if min_rows <= num_rows <= max_rows:
             min_hours, max_hours = cst.TEXT_DATASET_BINS_TO_TRAINING_HOURS_RANGE[(min_rows, max_rows)]
             break

--- a/validator/tasks/synthetic_scheduler.py
+++ b/validator/tasks/synthetic_scheduler.py
@@ -34,10 +34,10 @@ async def _get_models(keypair: Keypair) -> AsyncGenerator[str, None]:
             yield model_id
 
 
-async def _get_datasets_for_bin(min_bytes: int, max_bytes: int, keypair: Keypair) -> AsyncGenerator[Dataset, None]:
+async def _get_datasets_for_bin(min_rows: int, max_rows: int, keypair: Keypair) -> AsyncGenerator[Dataset, None]:
     """Get datasets for a specific size bin."""
     while True:
-        params = {"min_parquet_bytes": min_bytes, "max_parquet_bytes": max_bytes}
+        params = {"min_rows": min_rows, "max_rows": max_rows}
         try:
             response = await call_content_service(cst.GET_RANDOM_DATASETS_ENDPOINT, keypair, params)
             if not isinstance(response, list):
@@ -51,14 +51,14 @@ async def _get_datasets_for_bin(min_bytes: int, max_bytes: int, keypair: Keypair
                 yield dataset
 
         except Exception as e:
-            logger.warning(f"Failed to fetch datasets for bin {min_bytes}-{max_bytes} bytes: {e}")
+            logger.warning(f"Failed to fetch datasets for bin {min_rows}-{max_rows} rows: {e}")
             await asyncio.sleep(5)
 
 
 async def _get_datasets(keypair: Keypair) -> AsyncGenerator[Dataset, None]:
     """Round-robin generator that cycles through all dataset size bins."""
 
-    bin_generators = [_get_datasets_for_bin(min_bytes, max_bytes, keypair) for min_bytes, max_bytes in cst.DATASET_BINS_TO_SAMPLE]
+    bin_generators = [_get_datasets_for_bin(min_rows, max_rows, keypair) for min_rows, max_rows in cst.DATASET_BINS_TO_SAMPLE]
 
     while True:
         for generator in bin_generators:
@@ -90,20 +90,15 @@ async def _get_columns_for_dataset(
     return columns
 
 
-def _get_training_hours_from_bytes(bytes: int) -> tuple[int, int]:
+def _get_training_hours_from_num_rows(num_rows: int) -> tuple[int, int]:
     """Randomly select training hours for a given dataset size in bytes based on range bins."""
     min_hours, max_hours = 0, 0
-    for min_bytes, max_bytes in cst.TEXT_DATASET_BINS_TO_TRAINING_HOURS_RANGE.keys():
-        if min_bytes <= bytes <= max_bytes:
-            min_hours, max_hours = cst.TEXT_DATASET_BINS_TO_TRAINING_HOURS_RANGE[(min_bytes, max_bytes)]
+    for min_rows, max_rows in cst.TEXT_DATASET_BINS_TO_TRAINING_HOURS_RANGE.items():
+        if min_rows <= num_rows <= max_rows:
+            min_hours, max_hours = cst.TEXT_DATASET_BINS_TO_TRAINING_HOURS_RANGE[(min_rows, max_rows)]
             break
     if min_hours == 0 and max_hours == 0:
-        sorted_bins = list(cst.TEXT_DATASET_BINS_TO_TRAINING_HOURS_RANGE.keys())
-        if bytes > sorted_bins[-1][1]:  # if greater than the largest bin
-            max_hours_range = list(cst.TEXT_DATASET_BINS_TO_TRAINING_HOURS_RANGE.values())[-1]
-            return max_hours_range[1]  # max hours
-        else:
-            raise ValueError(f"No training hours range found for {bytes} bytes")
+        raise ValueError(f"No training hours range found for {num_rows} rows")
     return random.randint(min_hours, max_hours)
 
 
@@ -114,7 +109,7 @@ async def _create_synthetic_task(
 ):
     model_id = await anext(models)
     dataset = await anext(datasets)
-    number_of_hours = _get_training_hours_from_bytes(dataset.num_bytes_parquet_files)
+    number_of_hours = _get_training_hours_from_num_rows(dataset.num_rows)
     columns = await _get_columns_for_dataset(dataset.dataset_id, config.keypair)
     current_time = datetime.utcnow()
     end_timestamp = current_time + timedelta(hours=number_of_hours)


### PR DESCRIPTION
We tried using num bytes to sample datasets and assign training hours for synth tasks.
This replaces bytes with num rows which should be a better estimate of dataset/task size