### PR TITLE
Store model params size in DB

### DIFF
--- a/.dev/vali.pgsql
+++ b/.dev/vali.pgsql
@@ -9,7 +9,7 @@ zero_score_tasks AS (
     SELECT DISTINCT t.task_id
     FROM tasks_last_12h t
     JOIN task_nodes tn ON t.task_id = tn.task_id
-    WHERE t.n_eval_attempts = 3
+    WHERE t.n_eval_attempts = 4 -- Equal to MAX_EVAL_ATTEMPTS in validator/core/constants.py
     GROUP BY t.task_id
     HAVING MAX(tn.quality_score) = 0 AND MIN(tn.quality_score) = 0
 ),

--- a/validator/core/constants.py
+++ b/validator/core/constants.py
@@ -101,7 +101,7 @@ TASK_TIME_DELAY = 15  # number of minutes we wait to retry an organic request
 # how many times in total do we attempt to delay an organic request looking for miners
 MAX_DELAY_TIMES = 6
 # Maximum number of times we retry a task after node training failure
-MAX_EVAL_ATTEMPTS = 3
+MAX_EVAL_ATTEMPTS = 4
 
 
 # scoring stuff  - NOTE: Will want to slowly make more exponential now we have auditing

--- a/validator/evaluation/scoring.py
+++ b/validator/evaluation/scoring.py
@@ -640,7 +640,7 @@ async def evaluate_and_score(task: RawTask, gpu_ids: list[int], config: Config) 
     task_results = adjust_miner_scores_to_be_relative_to_other_comps(task_results)
     await _update_scores(task, task_results, config.psql_db)
     all_scores_zero = all(result.score == 0.0 for result in task_results)
-    if all_scores_zero and task.n_eval_attempts < cts.MAX_EVAL_ATTEMPTS:
+    if all_scores_zero and task.n_eval_attempts < cts.MAX_EVAL_ATTEMPTS - 1:
         task.status = TaskStatus.PREEVALUATION
         add_context_tag("status", task.status.value)
         logger.info(f"All scores are zero for task {task.task_id}, setting status to PREEVALUATION to re-evaluate")


### PR DESCRIPTION
Calculates num model params within the docker eval (while it's already loaded in the memory) and updates the tasks table with it

After merging this, we'll make another PR to upload model size to S3 and query it back from auditors for weights comparison