### PR TITLE
Fix/infinite_retries

### DIFF
--- a/.dev/vali.pgsql
+++ b/.dev/vali.pgsql
@@ -12,7 +12,7 @@ zero_score_tasks AS (
     SELECT DISTINCT t.task_id
     FROM tasks_last_12h t
     JOIN task_nodes tn ON t.task_id = tn.task_id
-    WHERE t.n_eval_attempts = 4
+    WHERE t.n_eval_attempts = 4 -- MAX_EVAL_ATTEMPTS in validator/core/constants.py
     GROUP BY t.task_id
     HAVING MAX(tn.quality_score) = 0 AND MIN(tn.quality_score) = 0
 ),
@@ -65,10 +65,10 @@ ORDER BY ts.task_id;
 --------------------------------
 
 -- Count tasks for all possible statuses
-SELECT 
+SELECT
     status,
     COUNT(*) AS count
-FROM tasks 
+FROM tasks
 WHERE status IN (
     'pending',
     'preparing_data',
@@ -146,15 +146,15 @@ UPDATE tasks SET termination_at = NOW() WHERE status = 'training' AND task_id IN
 UPDATE tasks SET status = 'preevaluation' WHERE task_id IN ('TASK_UUID');
 
 -- Move all tasks in training to failure status
-UPDATE tasks 
+UPDATE tasks
 SET status = 'failure'
 WHERE status IN ('training', 'preevaluation', 'looking_for_nodes');
 
 -- Only eval the task in last line, others wait
-UPDATE tasks 
-SET 
+UPDATE tasks
+SET
     status = 'training',
     termination_at = NOW() + INTERVAL '1 hour'
-WHERE 
-    status = 'preevaluation' 
+WHERE
+    status = 'preevaluation'
     AND task_id != 'TASK_UUID';

--- a/validator/core/constants.py
+++ b/validator/core/constants.py
@@ -112,7 +112,7 @@ TASK_TIME_DELAY = 15  # number of minutes we wait to retry an organic request
 # how many times in total do we attempt to delay an organic request looking for miners
 MAX_DELAY_TIMES = 6
 # Maximum number of times we retry a task after node training failure
-MAX_EVAL_ATTEMPTS = 3
+MAX_EVAL_ATTEMPTS = 4
 
 
 # scoring stuff  - NOTE: Will want to slowly make more exponential now we have auditing

--- a/validator/core/constants.py
+++ b/validator/core/constants.py
@@ -111,7 +111,7 @@ MAX_IMAGE_COMPETITION_HOURS = 2
 TASK_TIME_DELAY = 15  # number of minutes we wait to retry an organic request
 # how many times in total do we attempt to delay an organic request looking for miners
 MAX_DELAY_TIMES = 6
-# Maximum number of times we retry a task after node training failure
+# Maximum number of evaluation attempts when all scores are zero (including the first one)
 MAX_EVAL_ATTEMPTS = 4
 
 

--- a/validator/db/sql/tasks.py
+++ b/validator/db/sql/tasks.py
@@ -47,6 +47,7 @@ base_task_fields = {
     cst.ASSIGNED_MINERS,
     cst.TASK_TYPE,
     cst.RESULT_MODEL_NAME,
+    cst.N_EVAL_ATTEMPTS,
 }
 
 text_specific_fields = [

--- a/validator/evaluation/scoring.py
+++ b/validator/evaluation/scoring.py
@@ -743,7 +743,7 @@ async def evaluate_and_score(task: TextRawTask | ImageRawTask, gpu_ids: list[int
     task_results = adjust_miner_scores_to_be_relative_to_other_comps(task_results)
     await _update_scores(task, task_results, config.psql_db)
     all_scores_zero = all(result.score == 0.0 for result in task_results)
-    if all_scores_zero and task.n_eval_attempts < cts.MAX_EVAL_ATTEMPTS:
+    if all_scores_zero and task.n_eval_attempts < cts.MAX_EVAL_ATTEMPTS - 1:
         task.status = TaskStatus.PREEVALUATION
         add_context_tag("status", task.status.value)
         logger.info(f"All scores are zero for task {task.task_id}, setting status to PREEVALUATION to re-evaluate")


### PR DESCRIPTION
### Main fix
in `tasks.py`, we didn't add N_EVAL_ATTEMPTS in `base_task_fields` which is now used in `update_task` after the diffusion merge.

I would prefer that we set these lists dynamically to avoid having to add manually whenever we have a new migration.

### Secondary updates
Also with N_EVAL_ATTEMPTS just so numbers are consistent, it now refers to:
`# Maximum number of evaluation attempts when all scores are zero (including the first one)`