### PR TITLE
speed up - avoid OOM with max BS

### DIFF
--- a/validator/evaluation/eval.py
+++ b/validator/evaluation/eval.py
@@ -97,8 +97,8 @@ def _evaluate_with_optimal_batch_size(
     tokenizer: AutoTokenizer,
     device: torch.device,
     evaluation_config: DictDefault,
-) -> tuple[list[float], int]:
-    @find_executable_batch_size()
+) -> tuple[list[dict[str, float]], int]:
+    @find_executable_batch_size(starting_batch_size=32)
     def process_with_batch_size(batch_size):
         dataloader = DataLoader(
             eval_dataset,
@@ -106,7 +106,7 @@ def _evaluate_with_optimal_batch_size(
             collate_fn=lambda batch: _collate_evaluation_batch(batch, tokenizer),
             shuffle=False,
         )
-        batch_losses = []
+        batch_results = []
         num_batches = 0
         consecutive_nans = 0
         max_consecutive_nans = evaluation_config.get("max_consecutive_nans")
@@ -118,6 +118,7 @@ def _evaluate_with_optimal_batch_size(
         with torch.no_grad():
             for batch_idx, batch in enumerate(dataloader):
                 batch_loss = _compute_batch_loss(language_model, batch, device)
+                samples_in_batch = batch["input_ids"].size(0)
 
                 if time_logger.should_log():
                     progress = (batch_idx + 1) / total_batches * 100
@@ -130,14 +131,14 @@ def _evaluate_with_optimal_batch_size(
                     consecutive_nans += 1
                     if consecutive_nans >= max_consecutive_nans:
                         logger.error(f"Stopping evaluation early: {max_consecutive_nans} consecutive NaN losses detected")
-                        return [float("nan")], 1
+                        return [{"loss": float("nan"), "sample_count": 0}], 1
                 else:
                     consecutive_nans = 0
 
-                batch_losses.append(batch_loss)
+                batch_results.append({"loss": batch_loss, "sample_count": samples_in_batch})
                 num_batches += 1
 
-        return batch_losses, num_batches
+        return batch_results, num_batches
 
     return process_with_batch_size()
 
@@ -163,15 +164,15 @@ def _compute_batch_loss(language_model: AutoModelForCausalLM, batch: dict, devic
 
 
 def _calculate_evaluation_metrics(
-    total_losses: list[float],
+    batch_results: list[dict[str, float]],
     num_batches: int,
     evaluation_config: DictDefault,
 ) -> dict[str, float]:
-    valid_losses = [loss for loss in total_losses if not torch.isnan(torch.tensor(loss))]
-    nan_count = len(total_losses) - len(valid_losses)
+    valid_results = [result for result in batch_results if not torch.isnan(torch.tensor(result["loss"]))]
+    nan_count = len(batch_results) - len(valid_results)
     nan_percentage = (nan_count / num_batches) * 100 if num_batches > 0 else 0
 
-    if not valid_losses:
+    if not valid_results:
         logger.error("No valid losses were found during evaluation.")
         return {
             "eval_loss": float("inf"),
@@ -185,8 +186,12 @@ def _calculate_evaluation_metrics(
             "perplexity": float("inf"),
         }
 
-    average_loss = sum(valid_losses) / len(valid_losses)
-    logger.info(f"Average loss: {average_loss} (calculated from {len(valid_losses)} valid batches)")
+    # Calculate weighted average based on sample count
+    total_samples = sum(result["sample_count"] for result in valid_results)
+    weighted_loss_sum = sum(result["loss"] * result["sample_count"] for result in valid_results)
+    average_loss = weighted_loss_sum / total_samples if total_samples > 0 else float("inf")
+
+    logger.info(f"Average loss: {average_loss} (calculated from {len(valid_results)} valid batches, {total_samples} samples)")
 
     if nan_count > 0:
         logger.warning(f"Skipped {nan_count} batches with nan values ({nan_percentage:.2f}% of total)")
@@ -209,11 +214,12 @@ def evaluate_language_model_loss(
     _log_dataset_and_model_info(eval_dataset, language_model, tokenizer)
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     language_model.to(device)
-    losses, num_batches = _evaluate_with_optimal_batch_size(
+
+    batch_results, num_batches = _evaluate_with_optimal_batch_size(
         eval_dataset, language_model, tokenizer, device, evaluation_config
     )
 
-    evaluation_results = _calculate_evaluation_metrics(losses, num_batches, evaluation_config)
+    evaluation_results = _calculate_evaluation_metrics(batch_results, num_batches, evaluation_config)
     logger.info(f"Final evaluation results: {evaluation_results}")
 
     return evaluation_results

--- a/validator/evaluation/eval.py
+++ b/validator/evaluation/eval.py
@@ -1,11 +1,11 @@
 import json
 import os
+import time
 from math import ceil
 from pathlib import Path
 from typing import Union
 
 import torch
-import torch.nn.functional as F
 import yaml
 from accelerate.utils import find_executable_batch_size
 from axolotl.utils.data import load_tokenized_prepared_datasets
@@ -17,10 +17,12 @@ from tenacity import retry_if_exception
 from tenacity import stop_after_attempt
 from tenacity import wait_exponential
 from torch.nn.utils.rnn import pad_sequence
-from torch.utils.data import DataLoader
 from torch.utils.data import Dataset
 from transformers import AutoModelForCausalLM
 from transformers import AutoTokenizer
+from transformers import Trainer
+from transformers import TrainerCallback
+from transformers import TrainingArguments
 
 from core.config.config_handler import create_dataset_entry
 from core.models.utility_models import CustomDatasetType
@@ -28,11 +30,31 @@ from core.models.utility_models import DatasetType
 from core.models.utility_models import FileFormat
 from validator.core import constants as cst
 from validator.evaluation.utils import model_is_a_finetune
-from validator.utils.logging import TimeBasedLogger
 from validator.utils.logging import get_logger
 
 
 logger = get_logger(__name__)
+
+
+class ProgressLoggerCallback(TrainerCallback):
+    """
+    A callback that logs the progress of the evaluation every log_interval_seconds seconds.
+    """
+    def __init__(self, log_interval_seconds):
+        self.step = 0
+        self.last_log_time = time.time()
+        self.log_interval_seconds = log_interval_seconds
+
+
+    def on_prediction_step(self, args, state, control, **kwargs):
+        self.step += 1
+        current_time = time.time()
+
+        if current_time - self.last_log_time >= self.log_interval_seconds:
+            self.last_log_time = current_time
+            logger.info(f"Evaluation step: {self.step}")
+
+        return control
 
 
 def _load_and_update_evaluation_config(
@@ -91,117 +113,6 @@ def _collate_evaluation_batch(batch: list[dict[str, list[int]]], tokenizer: Auto
     return {"input_ids": input_ids, "attention_mask": attention_mask, "labels": labels}
 
 
-def _evaluate_with_optimal_batch_size(
-    eval_dataset: Dataset,
-    language_model: AutoModelForCausalLM,
-    tokenizer: AutoTokenizer,
-    device: torch.device,
-    evaluation_config: DictDefault,
-) -> tuple[list[dict[str, float]], int]:
-    @find_executable_batch_size(starting_batch_size=32)
-    def process_with_batch_size(batch_size):
-        dataloader = DataLoader(
-            eval_dataset,
-            batch_size=batch_size,
-            collate_fn=lambda batch: _collate_evaluation_batch(batch, tokenizer),
-            shuffle=False,
-        )
-        batch_results = []
-        num_batches = 0
-        consecutive_nans = 0
-        max_consecutive_nans = evaluation_config.get("max_consecutive_nans")
-
-        total_batches = len(dataloader)
-        time_logger = TimeBasedLogger(interval_seconds=10.0)
-
-        language_model.eval()
-        with torch.no_grad():
-            for batch_idx, batch in enumerate(dataloader):
-                batch_loss = _compute_batch_loss(language_model, batch, device)
-                samples_in_batch = batch["input_ids"].size(0)
-
-                if time_logger.should_log():
-                    progress = (batch_idx + 1) / total_batches * 100
-                    logger.info(
-                        f"Processing batch {batch_idx + 1}/{total_batches} ({progress:.1f}%) - "
-                        f"Current loss: {batch_loss} (batch size: {batch_size})"
-                    )
-
-                if torch.isnan(torch.tensor(batch_loss)):
-                    consecutive_nans += 1
-                    if consecutive_nans >= max_consecutive_nans:
-                        logger.error(f"Stopping evaluation early: {max_consecutive_nans} consecutive NaN losses detected")
-                        return [{"loss": float("nan"), "sample_count": 0}], 1
-                else:
-                    consecutive_nans = 0
-
-                batch_results.append({"loss": batch_loss, "sample_count": samples_in_batch})
-                num_batches += 1
-
-        return batch_results, num_batches
-
-    return process_with_batch_size()
-
-
-def _compute_batch_loss(language_model: AutoModelForCausalLM, batch: dict, device: torch.device) -> float:
-    input_ids = batch["input_ids"].to(device)
-    attention_mask = batch["attention_mask"].to(device)
-    labels = batch["labels"].to(device)
-
-    outputs = language_model(input_ids=input_ids, attention_mask=attention_mask)
-    logits = outputs.logits
-
-    shift_logits = logits[..., :-1, :].contiguous()
-    shift_labels = labels[..., 1:].contiguous()
-
-    loss = F.cross_entropy(
-        shift_logits.view(-1, shift_logits.size(-1)),
-        shift_labels.view(-1),
-        ignore_index=-100,
-    )
-
-    return loss.item()
-
-
-def _calculate_evaluation_metrics(
-    batch_results: list[dict[str, float]],
-    num_batches: int,
-    evaluation_config: DictDefault,
-) -> dict[str, float]:
-    valid_results = [result for result in batch_results if not torch.isnan(torch.tensor(result["loss"]))]
-    nan_count = len(batch_results) - len(valid_results)
-    nan_percentage = (nan_count / num_batches) * 100 if num_batches > 0 else 0
-
-    if not valid_results:
-        logger.error("No valid losses were found during evaluation.")
-        return {
-            "eval_loss": float("inf"),
-            "perplexity": float("inf"),
-        }
-
-    if nan_percentage > evaluation_config.get("max_nan_percentage"):
-        logger.error(f"Too many nan values ({nan_percentage:.2f}% of batches)")
-        return {
-            "eval_loss": float("inf"),
-            "perplexity": float("inf"),
-        }
-
-    # Calculate weighted average based on sample count
-    total_samples = sum(result["sample_count"] for result in valid_results)
-    weighted_loss_sum = sum(result["loss"] * result["sample_count"] for result in valid_results)
-    average_loss = weighted_loss_sum / total_samples if total_samples > 0 else float("inf")
-
-    logger.info(f"Average loss: {average_loss} (calculated from {len(valid_results)} valid batches, {total_samples} samples)")
-
-    if nan_count > 0:
-        logger.warning(f"Skipped {nan_count} batches with nan values ({nan_percentage:.2f}% of total)")
-
-    return {
-        "eval_loss": average_loss,
-        "perplexity": torch.exp(torch.tensor(average_loss)).item(),
-    }
-
-
 def evaluate_language_model_loss(
     evaluation_config: DictDefault,
     language_model: AutoModelForCausalLM,
@@ -212,16 +123,37 @@ def evaluate_language_model_loss(
 
     eval_dataset = _load_evaluation_dataset(evaluation_config, tokenizer)
     _log_dataset_and_model_info(eval_dataset, language_model, tokenizer)
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    language_model.to(device)
 
-    batch_results, num_batches = _evaluate_with_optimal_batch_size(
-        eval_dataset, language_model, tokenizer, device, evaluation_config
-    )
+    def custom_data_collator(features):
+        return _collate_evaluation_batch(features, tokenizer)
 
-    evaluation_results = _calculate_evaluation_metrics(batch_results, num_batches, evaluation_config)
-    logger.info(f"Final evaluation results: {evaluation_results}")
+    @find_executable_batch_size(starting_batch_size=evaluation_config.starting_batch_size)
+    def evaluate_with_batch_size(batch_size):
+        training_args = TrainingArguments(
+            output_dir=evaluation_config.output_dir,
+            per_device_eval_batch_size=batch_size,
+            fp16=torch.cuda.is_available(),
+            report_to="none",
+        )
 
+        trainer = Trainer(
+            model=language_model,
+            args=training_args,
+            tokenizer=tokenizer,
+            eval_dataset=eval_dataset,
+            data_collator=custom_data_collator,
+            callbacks=[ProgressLoggerCallback(log_interval_seconds=evaluation_config.log_interval_seconds)]
+        )
+
+        eval_results = trainer.evaluate()
+        return eval_results
+
+    eval_results = evaluate_with_batch_size()
+    logger.info(f"Final evaluation results: {eval_results}")
+    evaluation_results = {
+        "eval_loss": eval_results["eval_loss"],
+        "perplexity": torch.exp(torch.tensor(eval_results["eval_loss"])).item(),
+    }
     return evaluation_results
 
 

--- a/validator/evaluation/eval.py
+++ b/validator/evaluation/eval.py
@@ -85,6 +85,7 @@ def _load_and_update_evaluation_config(
 def _load_evaluation_dataset(evaluation_config: DictDefault, tokenizer: AutoTokenizer) -> Dataset:
     prepared_path = Path(evaluation_config.output_dir) / "prepared"
     eval_dataset, _ = load_tokenized_prepared_datasets(tokenizer, evaluation_config, prepared_path)
+    eval_dataset = sorted(eval_dataset, key=lambda x: len(x["input_ids"]))
     logger.info(f"Loaded evaluation dataset with {len(eval_dataset)} samples")
     return eval_dataset
 

--- a/validator/evaluation/scoring.py
+++ b/validator/evaluation/scoring.py
@@ -378,47 +378,57 @@ async def _evaluate_submissions(
         assert task.synthetic_data is not None, "Synthetic data shouldn't be none for text tasks"
         assert task.test_data is not None, "Test data shouldn't be none for text tasks"
 
-        logger.info("Starting synth evaluation")
-        synthetic_data_filepath = await download_s3_file(task.synthetic_data)
-        synth_results = await run_evaluation_docker_text(dataset=synthetic_data_filepath, **evaluation_params)
+        logger.info("Starting test evaluation")
+        test_data_filepath = await download_s3_file(task.test_data)
+        test_results = await run_evaluation_docker_text(dataset=test_data_filepath, **evaluation_params)
         try:
-            os.remove(synthetic_data_filepath)
+            os.remove(test_data_filepath)
         except Exception as e:
-            logger.warning(f"Failed to remove synthetic data file {synthetic_data_filepath}: {e}")
-        synth_eval_results = synth_results.results
-        task.model_params_count = synth_results.base_model_params_count
+            logger.warning(f"Failed to remove test data file {test_data_filepath}: {e}")
+        test_eval_results = test_results.results
+        task.model_params_count = test_results.base_model_params_count
 
-        finetuned_repos = []
+        test_losses = []
         for repo in repos_to_evaluate:
-            if isinstance(synth_eval_results.get(repo), Exception):
-                results[repo] = synth_eval_results[repo]
+            if isinstance(test_eval_results.get(repo), Exception):
+                results[repo] = test_eval_results[repo]
                 continue
 
-            synth_result = synth_eval_results[repo]
-            if not synth_result.is_finetune:
+            test_result = test_eval_results[repo]
+            if not test_result.is_finetune:
                 results[repo] = (
                     EvaluationResultText(is_finetune=False, eval_loss=0.0, perplexity=0.0),
                     EvaluationResultText(is_finetune=False, eval_loss=0.0, perplexity=0.0),
                 )
             else:
-                finetuned_repos.append(repo)
-        if finetuned_repos:
-            test_data_filepath = await download_s3_file(task.test_data)
-            test_results = await run_evaluation_docker_text(
-                dataset=test_data_filepath,
-                models=finetuned_repos,
+                test_losses.append((repo, test_result.eval_loss))
+
+        test_losses.sort(key=lambda x: x[1])
+        top_4_repos = [repo for repo, _ in test_losses[:4]]
+        
+        for repo, _ in test_losses[4:]:
+            results[repo] = (
+                EvaluationResultText(is_finetune=False, eval_loss=0.0, perplexity=0.0),
+                test_eval_results[repo],
+            )
+
+        if top_4_repos:
+            logger.info(f"Evaluating synthetic data for top {len(top_4_repos)} models")
+            synthetic_data_filepath = await download_s3_file(task.synthetic_data)
+            synth_results = await run_evaluation_docker_text(
+                dataset=synthetic_data_filepath,
+                models=top_4_repos,
                 **{k: v for k, v in evaluation_params.items() if k != "models"},
             )
             try:
-                os.remove(test_data_filepath)
+                os.remove(synthetic_data_filepath)
             except Exception as e:
-                logger.warning(f"Failed to remove test data file {test_data_filepath}: {e}")
-            test_eval_results = test_results.results
-            task.model_params_count = test_results.base_model_params_count
+                logger.warning(f"Failed to remove synthetic data file {synthetic_data_filepath}: {e}")
+            synth_eval_results = synth_results.results
 
-            for repo in finetuned_repos:
-                if isinstance(test_eval_results.get(repo), Exception):
-                    results[repo] = test_eval_results[repo]
+            for repo in top_4_repos:
+                if isinstance(synth_eval_results.get(repo), Exception):
+                    results[repo] = synth_eval_results[repo]
                 else:
                     results[repo] = (synth_eval_results[repo], test_eval_results[repo])
 

--- a/validator/test_axolotl.yml
+++ b/validator/test_axolotl.yml
@@ -21,3 +21,5 @@ num_epochs: 1
 
 max_consecutive_nans: 5
 max_nan_percentage: 5
+starting_batch_size: 1
+log_interval_seconds: 10


### PR DESCRIPTION
for each sub, a maximal BS will be auto chosen to compute final loss, w/o OOM
1. tested and improved loss calculation to account for batch num samples to perform a weighted avg
2. reduced the starting BS to 32, since a single nan in a batch results in nan in the whole batch (tested manually)
this should speed up, especially with large test set
# Update
1. Rewrote the evaluation logic with HF `transformers`
2. Tested losses with different BSes, consistent results
3. Added a decorator to use optimal BS without OOM
4. Added time based logger as a callback to log every 10 seconds to avoid spamming logs during evaluation
5. Sped up evaluation by ~2.2x
6. Did experiments on BS and concluded an optimal BS of 1
![Evaluation Runtime vs Batch Size](https://github.com/user-attachments/assets/6c739920-c9b7-4916-a249-d5f063f25264)