### PR TITLE
Use latest axolotl for vali evaluation

### DIFF
--- a/dockerfiles/validator.dockerfile
+++ b/dockerfiles/validator.dockerfile
@@ -1,4 +1,4 @@
-FROM winglian/axolotl:main-20241101-py3.11-cu124-2.5.0
+FROM winglian/axolotl:main-20250307
 
 WORKDIR /app
 


### PR DESCRIPTION
Solves compatibility issues with the latest peft version.
We encountered these before when miners tried the latest axolotl version or jus the latest peft version. Our validator would fail to evaluate it.

This is tested to work with both model trained with the latest peft and also older models.