### PR TITLE
Fix and test is_finetune check

### DIFF
--- a/validator/evaluation/utils.py
+++ b/validator/evaluation/utils.py
@@ -21,10 +21,10 @@ def model_is_a_finetune(original_repo: str, finetuned_model: AutoModelForCausalL
     finetuned_config = finetuned_model.config
 
     try:
-        if hasattr(finetuned_model, "name_or_path"):
-            finetuned_model_path = finetuned_model.name_or_path
+        if hasattr(finetuned_model, "architectures"):
+            finetuned_model_path = finetuned_model.architectures
         else:
-            finetuned_model_path = finetuned_model.config._name_or_path
+            finetuned_model_path = finetuned_model.config._architectures
 
         adapter_config = os.path.join(finetuned_model_path, "adapter_config.json")
         if os.path.exists(adapter_config):
@@ -33,7 +33,7 @@ def model_is_a_finetune(original_repo: str, finetuned_model: AutoModelForCausalL
         else:
             logger.info(f"Adapter config not found at {adapter_config}")
             has_lora_modules = False
-        base_model_match = finetuned_config._name_or_path == original_repo
+        base_model_match = finetuned_config._architectures == original_repo
     except Exception as e:
         logger.debug(f"There is an issue with checking the finetune path {e}")
         base_model_match = True
@@ -43,6 +43,9 @@ def model_is_a_finetune(original_repo: str, finetuned_model: AutoModelForCausalL
         "architectures",
         "hidden_size",
         "n_layer",
+        "intermediate_size",
+        "head_dim",
+        "hidden_act",
         "model_type",
         "num_hidden_layers",
         "num_attention_heads",

--- a/validator/evaluation/utils.py
+++ b/validator/evaluation/utils.py
@@ -22,18 +22,18 @@ def model_is_a_finetune(original_repo: str, finetuned_model: AutoModelForCausalL
 
     try:
         if hasattr(finetuned_model, "architectures"):
-            finetuned_model_path = finetuned_model.architectures
+            finetuned_architectures = finetuned_model.architectures
         else:
-            finetuned_model_path = finetuned_model.config._architectures
+            finetuned_architectures = finetuned_config._architectures
 
-        adapter_config = os.path.join(finetuned_model_path, "adapter_config.json")
+        adapter_config = os.path.join(finetuned_architectures, "adapter_config.json")
         if os.path.exists(adapter_config):
             has_lora_modules = True
             logger.info(f"Adapter config found: {adapter_config}")
         else:
             logger.info(f"Adapter config not found at {adapter_config}")
             has_lora_modules = False
-        base_model_match = finetuned_config._architectures == original_repo
+        base_model_match = finetuned_config._architectures == original_config._architectures
     except Exception as e:
         logger.debug(f"There is an issue with checking the finetune path {e}")
         base_model_match = True

--- a/validator/evaluation/utils.py
+++ b/validator/evaluation/utils.py
@@ -21,23 +21,10 @@ def model_is_a_finetune(original_repo: str, finetuned_model: AutoModelForCausalL
     finetuned_config = finetuned_model.config
 
     try:
-        if hasattr(finetuned_model, "architectures"):
-            finetuned_architectures = finetuned_model.architectures
-        else:
-            finetuned_architectures = finetuned_config._architectures
-
-        adapter_config = os.path.join(finetuned_architectures, "adapter_config.json")
-        if os.path.exists(adapter_config):
-            has_lora_modules = True
-            logger.info(f"Adapter config found: {adapter_config}")
-        else:
-            logger.info(f"Adapter config not found at {adapter_config}")
-            has_lora_modules = False
-        base_model_match = finetuned_config._architectures == original_config._architectures
+        architecture_classes_match = finetuned_config.architectures == original_config.architectures
     except Exception as e:
-        logger.debug(f"There is an issue with checking the finetune path {e}")
-        base_model_match = True
-        has_lora_modules = False
+        logger.debug(f"There is an issue with checking the architecture classes {e}")
+        architecture_classes_match = False
 
     attrs_to_compare = [
         "architectures",
@@ -62,9 +49,9 @@ def model_is_a_finetune(original_repo: str, finetuned_model: AutoModelForCausalL
                 break
 
     logger.info(
-        f"Architecture same: {architecture_same}, Base model match: {base_model_match}, Has lora modules: {has_lora_modules}"
+        f"Architecture same: {architecture_same}, Architecture classes match: {architecture_classes_match}"
     )
-    return architecture_same and (base_model_match or has_lora_modules)
+    return architecture_same and architecture_classes_match
 
 
 def get_default_dataset_config(dataset_name: str) -> str | None:


### PR DESCRIPTION
Update `model_is_a_finetune` where we check if a model is a finetuned version of the base model
- AutoModelForCausalLM don't have `architectures` field
- AutoConfig has `architectures` field but not `_architectures`
- the chunk that was checking for lora modules wasn’t working bcz finetuned_config.name_or_path isn’t a path in the os so `os.path.join(finetuned_config.name_or_path, "adapter_config.json")` won’t exist **but we don’t need this anymore** bcz we only reach that `except` block if we can’t find lora modules, this one is reserved for full finetunes