### PR TITLE
Enable evaluating big models with multi-gpu

### DIFF
--- a/validator/core/constants.py
+++ b/validator/core/constants.py
@@ -127,6 +127,7 @@ TASK_TIME_DELAY = 15  # number of minutes we wait to retry an organic request
 MAX_DELAY_TIMES = 6
 # Maximum number of evaluation attempts when all scores are zero (including the first one)
 MAX_EVAL_ATTEMPTS = 4
+MODEL_SIZE_REQUIRING_2_GPUS = 20*10**9  # 20B params
 
 
 # scoring stuff  - NOTE: Will want to slowly make more exponential now we have auditing

--- a/validator/cycle/util_functions.py
+++ b/validator/cycle/util_functions.py
@@ -2,6 +2,7 @@ import asyncio
 
 from datasets import get_dataset_infos
 from fiber import Keypair
+from huggingface_hub import HfApi
 
 from core.models.payload_models import TrainRequestImage
 from core.models.payload_models import TrainRequestText
@@ -29,6 +30,16 @@ async def get_total_text_dataset_size(task: TextRawTask) -> int:
         dataset_infos = await loop.run_in_executor(None, get_dataset_infos, task.ds)
         size = sum(info.dataset_size for info in dataset_infos.values() if info.dataset_size)
     return int(size)
+
+
+async def get_model_num_params(model_id: str) -> int:
+    try:
+        api = HfApi()
+        model_info = api.model_info(model_id)
+        size = model_info.safetensors.total
+        return size
+    except Exception as e:
+        logger.error(f"Error getting model size for {model_id}: {e}")
 
 
 async def get_total_image_dataset_size(task: ImageRawTask) -> int:


### PR DESCRIPTION
- fetch model params count beforehand with HF
- enable multi-gpu management in the eval queue
  - avoid deadlock e.g.: 4 tasks with 2 gpus where each one has a single gpu and indefinitely awaits for an extra gpu
  - use locks in the gpu gathering phase to avoid race conditions. This way a task needing more than 1 gpu will be the only one gathering gpus (while other tasks are releasing gpus), until it gathers all it needs
- In the evaluation container: Load models and make inference across all available GPUs