### PR TITLE
Fix model cache cleaning loop

### DIFF
--- a/validator/core/constants.py
+++ b/validator/core/constants.py
@@ -207,8 +207,8 @@ ONE_DAY_SCORE_WEIGHT = 0.35
 # HF models cache management
 CACHE_TAU_DAYS = 10  # Time constant (τ) for exponential decay in days
 CACHE_MAX_LOOKUP_DAYS = 30  # Maximum number of days to look back for usage data
-MAX_CACHE_SIZE_BYTES = 600 * 1024**3  # in bytes
-CACHE_CLEANUP_INTERVAL = 60 * 60  # in seconds
+MAX_CACHE_SIZE_BYTES = 1000 * 1024**3  # in bytes
+CACHE_CLEANUP_INTERVAL = 8 * 60 * 60  # in seconds
 
 # Docker evaluation
 DOCKER_EVAL_HF_CACHE_DIR = "/root/.cache/huggingface"

--- a/validator/cycle/process_tasks.py
+++ b/validator/cycle/process_tasks.py
@@ -30,8 +30,6 @@ from validator.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
-_cache_cleanup_lock = asyncio.Lock()
-
 
 async def _weighted_random_shuffle(nodes: list[Node], psql_db: PSQLDB) -> list[Node]:
     """
@@ -371,12 +369,9 @@ async def move_tasks_to_preevaluation_loop(config: Config):
         await asyncio.sleep(60)
 
 
-async def cleanup_model_cache(psql_db: PSQLDB):
+async def cleanup_model_cache_loop(psql_db: PSQLDB):
     """Clean up model cache when it exceeds size limit."""
-    if _cache_cleanup_lock.locked():
-        return
-
-    async with _cache_cleanup_lock:
+    while True:
         try:
             logger.info("Cleaning up model cache")
             training_tasks = await tasks_sql.get_tasks_with_status(TaskStatus.TRAINING, psql_db=psql_db)
@@ -459,5 +454,5 @@ async def process_completed_tasks(config: Config) -> None:
     await asyncio.gather(
         move_tasks_to_preevaluation_loop(config),
         evaluate_tasks_loop(config),
-        cleanup_model_cache(config.psql_db)
+        cleanup_model_cache_loop(config.psql_db)
     )


### PR DESCRIPTION
need continuous loop, no need for lock

- Keep 1 Tera of cached models
- clean every 8 hours (previously, due to some commit, we only cleaned at every PR merge)