### PR TITLE
Support remote postgres 

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -58,8 +58,15 @@ tasks:
 
   postgres:
     cmds:
-      - export $(cat .vali.env | grep -v '^#' | xargs)  && PGPASSWORD=$POSTGRES_PASSWORD psql -U $POSTGRES_USER -d $POSTGRES_DB -h $POSTGRES_HOST
-
+      - |
+        export $(cat .vali.env | grep -v '^#' | xargs)
+        if [ -n "$DATABASE_URL" ]; then
+          echo "Connecting using DATABASE_URL"
+          psql "$DATABASE_URL"
+        else
+          echo "Connecting using individual parameters"
+          PGPASSWORD=$POSTGRES_PASSWORD psql -U $POSTGRES_USER -d $POSTGRES_DB -h $POSTGRES_HOST
+        fi
 
   install:
     cmds:
@@ -76,3 +83,15 @@ tasks:
     cmds:
       - pm2 delete auditor-autoupdates || true
       - pm2 start "python utils/run_auditor_autoupdate.py" --name auditor-autoupdates
+
+  db-dump:
+    cmds:
+      - export $(cat .vali.env | grep -v '^#' | xargs) && docker run --rm --network=host -v $(pwd):/backup postgres:17 pg_dump --dbname="${DATABASE_URL:-postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}}" -F c -f /backup/god-db-backup.dump
+
+  db-restore:
+    cmds:
+      - echo "Restoring database. Make sure your database connection parameters are correct in .vali.env"
+      - |
+        export $(cat .vali.env | grep -v '^#' | xargs)
+        docker run --rm --network=host -v $(pwd):/backup postgres:17 bash -c "pg_restore --dbname=\"${DATABASE_URL:-postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}}\" --clean --if-exists -x -O /backup/god-db-backup.dump || echo 'Restore completed with some errors, which may be safely ignored'"
+

--- a/core/constants.py
+++ b/core/constants.py
@@ -14,6 +14,8 @@ try:
 except (TypeError, ValueError):
     NETUID = DEFAULT_NETUID
 
+IS_PROD_ENV = NETUID == DEFAULT_NETUID
+
 MINER_DOCKER_IMAGE = "weightswandering/tuning_miner:latest"
 MINER_DOCKER_IMAGE_DIFFUSION = "diagonalge/miner-diffusion-flux:latest"
 VALIDATOR_DOCKER_IMAGE = "weightswandering/tuning_vali:latest"

--- a/core/create_config.py
+++ b/core/create_config.py
@@ -93,11 +93,21 @@ def generate_validator_config(dev: bool = False) -> Dict[str, Any]:
     wallet_name = input("💼 Enter wallet name (default: default): ") or "default"
     hotkey_name = input("🔑 Enter hotkey name (default: default): ") or "default"
     netuid = 241 if subtensor_network.strip() == "test" else 56
-    postgres_user = "user"
-    postgres_password = generate_secure_password() if not postgres_password else postgres_password
-    postgres_db = "god-db"
-    postgres_host = "localhost"
-    postgres_port = "5432"
+    database_url = input("🗄️ If using a remote database, enter the full database url (default: None): ") or None
+    if database_url:
+        postgres_profile = "no-local-postgres"
+        postgres_user = None
+        postgres_password = None
+        postgres_db = None
+        postgres_host = None
+        postgres_port = None
+    else:
+        postgres_profile = "default"  # will start local postgres
+        postgres_user = "user"
+        postgres_password = generate_secure_password() if not postgres_password else postgres_password
+        postgres_db = "god_db"
+        postgres_host = "localhost"
+        postgres_port = "5432"
 
     validator_port = input("👀 Enter an exposed port to run the validator on (default: 9001): ") or "9001"
 
@@ -138,6 +148,8 @@ def generate_validator_config(dev: bool = False) -> Dict[str, Any]:
         ),
         refresh_nodes=(parse_bool_input("Refresh nodes?", default=True) if dev else True),
         localhost=parse_bool_input("Use localhost?", default=True) if dev else False,
+        database_url=database_url,
+        postgres_profile=postgres_profile,
     )
     return vars(config)
 

--- a/core/models/config_models.py
+++ b/core/models/config_models.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass
@@ -7,7 +6,7 @@ class BaseConfig:
     wallet_name: str
     hotkey_name: str
     subtensor_network: str
-    subtensor_address: Optional[str]
+    subtensor_address: str | None = None
     netuid: int
     env: str
 
@@ -24,11 +23,11 @@ class MinerConfig(BaseConfig):
 
 @dataclass
 class ValidatorConfig(BaseConfig):
-    postgres_user: Optional[str]
-    postgres_password: Optional[str]
-    postgres_db: Optional[str]
-    postgres_host: Optional[str]
-    postgres_port: Optional[str]
+    postgres_user: str | None = None
+    postgres_password: str | None = None
+    postgres_db: str | None = None
+    postgres_host: str | None = None
+    postgres_port: str | None = None
     s3_compatible_endpoint: str
     s3_compatible_access_key: str
     s3_compatible_secret_key: str
@@ -38,13 +37,13 @@ class ValidatorConfig(BaseConfig):
     set_metagraph_weights: bool
     validator_port: str
     gpu_ids: str
-    gpu_server: Optional[str] = None
+    gpu_server: str | None = None
     localhost: bool = False
     env_file: str = ".vali.env"
     hf_datasets_trust_remote_code = True
     s3_region: str = "us-east-1"
     refresh_nodes: bool = True
-    database_url: Optional[str] = None
+    database_url: str | None = None
     postgres_profile: str = "default"
 
 

--- a/core/models/config_models.py
+++ b/core/models/config_models.py
@@ -24,11 +24,11 @@ class MinerConfig(BaseConfig):
 
 @dataclass
 class ValidatorConfig(BaseConfig):
-    postgres_user: str
-    postgres_password: str
-    postgres_db: str
-    postgres_host: str
-    postgres_port: str
+    postgres_user: Optional[str]
+    postgres_password: Optional[str]
+    postgres_db: Optional[str]
+    postgres_host: Optional[str]
+    postgres_port: Optional[str]
     s3_compatible_endpoint: str
     s3_compatible_access_key: str
     s3_compatible_secret_key: str
@@ -44,6 +44,8 @@ class ValidatorConfig(BaseConfig):
     hf_datasets_trust_remote_code = True
     s3_region: str = "us-east-1"
     refresh_nodes: bool = True
+    database_url: Optional[str] = None
+    postgres_profile: str = "default"
 
 
 @dataclass

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,15 +23,13 @@ services:
     volumes:
       - ./validator/db:/db
     command: --wait up
-    depends_on:
-      postgresql:
-        condition: service_healthy
     env_file:
       - .vali.env
     networks:
       - postgres_network
     environment:
-      DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgresql:5432/${POSTGRES_DB}?sslmode=disable
+      DATABASE_URL: ${DATABASE_URL:-postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgresql:5432/${POSTGRES_DB}?sslmode=disable}
+      DBMATE_WAIT_TIMEOUT: 60s
 
   redis:
     image: redis/redis-stack:latest

--- a/validator/cycle/process_tasks.py
+++ b/validator/cycle/process_tasks.py
@@ -6,6 +6,7 @@ import uuid
 
 from fiber.chain.models import Node
 
+from core.constants import IS_PROD_ENV
 import validator.core.constants as cst
 import validator.db.sql.nodes as nodes_sql
 import validator.db.sql.submissions_and_scoring as scores_sql
@@ -219,7 +220,10 @@ async def _let_miners_know_to_start_training(
 async def _find_and_select_miners_for_task(task: InstructTextRawTask | DpoRawTask | ImageRawTask, config: Config):
     with LogContext(task_id=str(task.task_id)):
         try:
-            nodes = await nodes_sql.get_eligible_nodes(config.psql_db)
+            if IS_PROD_ENV:
+                nodes = await nodes_sql.get_eligible_nodes(config.psql_db)
+            else:
+                nodes = await nodes_sql.get_all_nodes(config.psql_db)
             task = await _select_miner_pool_and_add_to_task(task, nodes, config)
             logger.info(f"After assigning miners here is the current task info {task}")
             await tasks_sql.update_task(task, config.psql_db)

--- a/validator/cycle/process_tasks.py
+++ b/validator/cycle/process_tasks.py
@@ -221,8 +221,10 @@ async def _find_and_select_miners_for_task(task: InstructTextRawTask | DpoRawTas
     with LogContext(task_id=str(task.task_id)):
         try:
             if IS_PROD_ENV:
+                logger.info("Filtering for only nodes that have scored on prod")
                 nodes = await nodes_sql.get_eligible_nodes(config.psql_db)
             else:
+                logger.info("THIS IS TESTNET SO WE DONT FILTER NODES")
                 nodes = await nodes_sql.get_all_nodes(config.psql_db)
             task = await _select_miner_pool_and_add_to_task(task, nodes, config)
             logger.info(f"After assigning miners here is the current task info {task}")

--- a/validator/db/database.py
+++ b/validator/db/database.py
@@ -24,7 +24,7 @@ def _get_connection_string_from_env() -> str:
     host = os.getenv("POSTGRES_HOST")
     port = os.getenv("POSTGRES_PORT")
     database = os.getenv("POSTGRES_DB")
-    postgres_url = os.getenv("POSTGRES_URL")
+    postgres_url = os.getenv("DATABASE_URL")
 
     if postgres_url:
         return postgres_url


### PR DESCRIPTION
The create_config changes should setup everyhting if setting up a valid from scratch via `task config`.

To move an existing vali to a remote db:


1. stop the validator cycle `pm2 delete all`
2. run `task db-dump`
3. prep the .vali.env: 
    -  set the DATABASE_URL env var to your full db URL
    - remove the existing POSTGRES env vars
    - set the POSTGRES_PROFILE var to anything but `default` (this will stop the local postgres container from starting)
4. run `task db-restore` to restore the db dump to the remote db
5. `docker compose down` to stop the existing containers including the local postgres
6. ` task autoupdates`