### PR TITLE
fix over-indexing

### DIFF
--- a/validator/db/migrations/20250429183400_fix_overindexing.sql
+++ b/validator/db/migrations/20250429183400_fix_overindexing.sql
@@ -1,0 +1,37 @@
+-- migrate:up
+-- Remove duplicate indices from dpo_tasks
+DROP INDEX IF EXISTS idx_dpo_task_id;
+DROP INDEX IF EXISTS idx_dpo_tasks_taskid;
+
+-- Remove duplicate indices from image_tasks
+DROP INDEX IF EXISTS idx_image_task_id;
+DROP INDEX IF EXISTS idx_image_tasks_taskid;
+
+-- Remove duplicate indices from instruct_text_tasks
+DROP INDEX IF EXISTS idx_instruct_text_tasks_taskid;
+DROP INDEX IF EXISTS idx_instruct_text_task_id;
+
+-- Remove duplicate indices from nodes
+DROP INDEX IF EXISTS idx_nodes_hotkey;
+
+-- Remove duplicate indices from submissions
+DROP INDEX IF EXISTS idx_submissions_taskid_hotkey;
+DROP INDEX IF EXISTS idx_submissions_hotkey;
+
+-- Remove duplicate indices from task_nodes
+DROP INDEX IF EXISTS idx_task_nodes_taskid_hotkey;
+DROP INDEX IF EXISTS idx_task_nodes_hotkey_netuid;
+
+-- Remove duplicate indices from tasks
+DROP INDEX IF EXISTS idx_tasks_created_at;
+
+-- migrate:down
+CREATE INDEX IF NOT EXISTS idx_dpo_task_id ON dpo_tasks(task_id);
+CREATE INDEX IF NOT EXISTS idx_image_task_id ON image_tasks(task_id);
+CREATE INDEX IF NOT EXISTS idx_instruct_text_task_id ON instruct_text_tasks(task_id);
+CREATE INDEX IF NOT EXISTS idx_nodes_hotkey ON nodes(hotkey);
+CREATE INDEX IF NOT EXISTS idx_submissions_taskid_hotkey ON submissions(task_id, hotkey);
+CREATE INDEX IF NOT EXISTS idx_submissions_hotkey ON submissions(hotkey);
+CREATE INDEX IF NOT EXISTS idx_task_nodes_taskid_hotkey ON task_nodes(task_id, hotkey);
+CREATE INDEX IF NOT EXISTS idx_task_nodes_hotkey_netuid ON task_nodes(hotkey, netuid);
+CREATE INDEX IF NOT EXISTS idx_tasks_created_at ON tasks(created_at);


### PR DESCRIPTION
We're over-indexing some of the tables, postgres auto assigns unique indices to primary keys, but in many spots we define extra indices on those pkeys, which adds overhead for insert, update, delete and vacuum ops

Additionally, we have sub-optimal redundancies in multi-column indices: https://www.postgresql.org/docs/current/indexes-multicolumn.html
> A multicolumn B-tree index can be used with query conditions that involve any subset of the index's columns, but the index is most efficient when there are constraints on the leading (leftmost) columns. The exact rule is that equality constraints on leading columns, plus any inequality constraints on the first column that does not have an equality constraint, will be used to limit the portion of the index that is scanned. Constraints on columns to the right of these columns are checked in the index, so they save visits to the table proper, but they do not reduce the portion of the index that has to be scanned. For example, given an index on (a, b, c) and a query condition WHERE a = 5 AND b >= 42 AND c < 77, the index would have to be scanned from the first entry with a = 5 and b = 42 up through the last entry with a = 5. Index entries with c >= 77 would be skipped, but they'd still have to be scanned through. This index could in principle be used for queries that have constraints on b and/or c with no constraint on a — but the entire index would have to be scanned, so in most cases the planner would prefer a sequential table scan over using the index.