### PR TITLE
improve dockerfile layer caching

### DIFF
--- a/dockerfiles/validator-diffusion.dockerfile
+++ b/dockerfiles/validator-diffusion.dockerfile
@@ -34,9 +34,11 @@ ENV BASE_MODEL_FILENAME=""
 ENV LORA_MODEL_FILENAMES=""
 
 WORKDIR /app
-COPY . .
 
+COPY validator/requirements.txt validator/requirements.txt
 RUN pip install -r validator/requirements.txt
+
+COPY . .
 
 RUN echo '#!/bin/bash\n\
 python /app/validator/evaluation/ComfyUI/main.py &\n\


### PR DESCRIPTION
Currently everytime a .py file is modified, the `RUN pip install` command from `validator-diffusion.dockerfile` is re-run. This prevents that layer from being cached, significantly reducing iteration time.

This PR moves the `COPY . .` step after `RUN pip install`, and does a separate `COPY validator/requirements.txt` operation.

With this change the dockerfile will be built in seconds after a change in the .py files. `docker push/pull` operations will also be much faster, since the `pip install` layer will not require re-uploading/downloading after every change.
