### PR TITLE
Add sleep delay in task scheduling (#682)

### DIFF
--- a/validator/tournament/orchestrator.py
+++ b/validator/tournament/orchestrator.py
@@ -327,6 +327,7 @@ async def schedule_tasks_for_training(pending_training_tasks: list[TournamentTas
                 )
 
                 tasks_without_gpus.append(pending_training_tasks.pop())
+                await asyncio.sleep(1)  # TODO: put in constant or even remove
                 continue
 
             trainer_ip, gpu_ids = suitable_gpus_result


### PR DESCRIPTION
* Introduced a 1-second sleep in the task scheduling loop to manage task execution timing.
* Added a TODO comment to consider making the sleep duration a constant or removing it in the future.