### PR TITLE
no chat in final

### DIFF
--- a/validator/tournament/task_creator.py
+++ b/validator/tournament/task_creator.py
@@ -374,8 +374,6 @@ async def _create_final_text_task_by_type(
     if task_type == TaskType.INSTRUCTTEXTTASK:
         models_to_use = big_models if use_big_model else small_models
         return await create_synthetic_instruct_text_task(config, models_to_use, instruct_datasets)
-    elif task_type == TaskType.CHATTASK:
-        return await create_synthetic_chat_task(config, models_to_use, instruct_datasets)
     elif task_type == TaskType.DPOTASK:
         return await create_synthetic_dpo_task(config, small_models, dpo_datasets)
     elif task_type == TaskType.GRPOTASK:
@@ -525,16 +523,6 @@ async def _create_historical_text_boss_round_tasks(
         if task:
             tasks.append(task)
 
-    if TaskType.CHATTASK.value not in existing_task_types:
-        task = await _create_single_historical_text_task(
-            TaskType.CHATTASK,
-            tournament_id,
-            round_id,
-            pair_id,
-            config
-        )
-        if task:
-            tasks.append(task)
     
     if TaskType.DPOTASK.value not in existing_task_types:
         task = await _create_single_historical_text_task(


### PR DESCRIPTION

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR removes chat-related functionality from the final tournament tasks. Specifically, it removes the ability to create synthetic chat tasks and historical text boss round tasks of type `CHATTASK`. This suggests that chat tasks will no longer be included in the final version of the tournament.

⏱️ Estimated Review Time: 0h 15m

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `validator/tournament/task_creator.py` |
</details>



<!-- RECURSEML_SUMMARY:END -->

<!-- RECURSEML_ANALYSIS:START -->
## Review by RecurseML

 _🔍 Review performed on [b9bbc4d..2116a8a](https://github.com/rayonlabs/G.O.D/compare/b9bbc4dd6d5ab0e5cf7fd8ee5a7fbf42f615df13...2116a8ab83e2519e95899943e49ccdaf71b0d866)_

✨ No bugs found, your code is sparkling clean

<details>
<summary>✅ Files analyzed, no issues (1)</summary>

  • `validator/tournament/task_creator.py`
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)
<!-- RECURSEML_ANALYSIS:END -->