### PR TITLE
separated burn dynamics

### DIFF
--- a/core/models/tournament_models.py
+++ b/core/models/tournament_models.py
@@ -408,3 +408,43 @@ class BenchmarkTimeline(BaseModel):
 class BenchmarkTimelineResponse(BaseModel):
     """Response containing benchmark timelines for all tasks"""
     timelines: list[BenchmarkTimeline]
+
+
+class HotkeyTournamentParticipation(BaseModel):
+    """Tournament participation data for a specific hotkey"""
+    hotkey: str
+    participated_in_text: bool      # participated in the most recent text tournament
+    participated_in_image: bool     # participated in the most recent image tournament
+    text_proportion: float         # 0.0, 0.6, or 1.0 based on participation
+    image_proportion: float        # 0.0, 0.4, or 1.0 based on participation
+
+
+class HotkeyTaskParticipation(BaseModel):
+    """Weekly task participation data for a specific hotkey"""
+    hotkey: str
+    text_task_proportion: float    # proportion of text tasks (0.0 to 1.0)
+    image_task_proportion: float   # proportion of image tasks (0.0 to 1.0)
+    total_tasks: int               # total number of tasks in the period
+
+
+class TournamentBurnDataSeparated(BaseModel):
+    """Separated burn data by tournament type"""
+    text_performance_diff: float | None
+    image_performance_diff: float | None
+    text_burn_proportion: float
+    image_burn_proportion: float
+    text_tournament_weight: float
+    image_tournament_weight: float
+    text_regular_weight: float
+    image_regular_weight: float
+    burn_weight: float
+
+
+class NodeWeightsResult(BaseModel):
+    """Result of node weight calculations"""
+    node_ids: list[int]
+    node_weights: list[float]
+
+    def to_tuple(self) -> tuple[list[int], list[float]]:
+        """Convert to tuple format for compatibility with existing code"""
+        return self.node_ids, self.node_weights

--- a/tests/test_separated_burn_dynamics.py
+++ b/tests/test_separated_burn_dynamics.py
@@ -1,0 +1,390 @@
+"""
+Test separated burn dynamics functionality.
+
+This test file validates the new separated burn system that applies different
+burn rates based on tournament participation and weekly task participation.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from datetime import datetime, timezone
+
+from core.models.tournament_models import (
+    HotkeyTournamentParticipation,
+    HotkeyTaskParticipation,
+    TournamentBurnDataSeparated,
+    NodeWeightsResult,
+    TournamentData,
+    TournamentType
+)
+from validator.core.weight_setting import (
+    get_tournament_burn_details_separated,
+    apply_regular_weights_separated,
+    apply_tournament_weights_separated,
+    get_node_weights_from_period_scores_separated
+)
+from validator.core.models import PeriodScore
+from validator.db.sql.tournaments import (
+    get_tournament_participation_data,
+    get_weekly_task_participation_data
+)
+import validator.core.constants as cts
+
+
+class TestSeparatedBurnDynamics:
+    """Test cases for separated burn dynamics functionality."""
+
+    @pytest.fixture
+    def mock_psql_db(self):
+        """Mock database connection."""
+        return AsyncMock()
+
+    @pytest.fixture
+    def sample_tournament_participation(self):
+        """Sample tournament participation data."""
+        return [
+            HotkeyTournamentParticipation(
+                hotkey="hotkey1",
+                participated_in_text=True,
+                participated_in_image=False,
+                text_proportion=1.0,
+                image_proportion=0.0
+            ),
+            HotkeyTournamentParticipation(
+                hotkey="hotkey2",
+                participated_in_text=False,
+                participated_in_image=True,
+                text_proportion=0.0,
+                image_proportion=1.0
+            ),
+            HotkeyTournamentParticipation(
+                hotkey="hotkey3",
+                participated_in_text=True,
+                participated_in_image=True,
+                text_proportion=0.6,
+                image_proportion=0.4
+            )
+        ]
+
+    @pytest.fixture
+    def sample_weekly_participation(self):
+        """Sample weekly task participation data."""
+        return [
+            HotkeyTaskParticipation(
+                hotkey="hotkey1",
+                text_task_proportion=0.8,
+                image_task_proportion=0.2,
+                total_tasks=50
+            ),
+            HotkeyTaskParticipation(
+                hotkey="hotkey2",
+                text_task_proportion=0.3,
+                image_task_proportion=0.7,
+                total_tasks=30
+            ),
+            HotkeyTaskParticipation(
+                hotkey="hotkey3",
+                text_task_proportion=0.5,
+                image_task_proportion=0.5,
+                total_tasks=40
+            )
+        ]
+
+    @pytest.fixture
+    def sample_burn_data(self):
+        """Sample separated burn data."""
+        return TournamentBurnDataSeparated(
+            text_performance_diff=0.3,
+            image_performance_diff=0.1,
+            text_burn_proportion=0.3,
+            image_burn_proportion=0.1,
+            text_tournament_weight=0.35,
+            image_tournament_weight=0.36,
+            text_regular_weight=0.59,
+            image_regular_weight=0.52,
+            burn_weight=0.18
+        )
+
+    @pytest.fixture
+    def sample_period_scores(self):
+        """Sample period scores for testing."""
+        return [
+            PeriodScore(
+                hotkey="hotkey1",
+                normalised_score=0.8,
+                weight_multiplier=1.0,
+                average_score=0.75,
+                std_score=0.1,
+                period_tasks=10
+            ),
+            PeriodScore(
+                hotkey="hotkey2",
+                normalised_score=0.6,
+                weight_multiplier=1.0,
+                average_score=0.55,
+                std_score=0.12,
+                period_tasks=8
+            ),
+            PeriodScore(
+                hotkey="hotkey3",
+                normalised_score=0.9,
+                weight_multiplier=1.0,
+                average_score=0.85,
+                std_score=0.08,
+                period_tasks=12
+            )
+        ]
+
+    @pytest.mark.asyncio
+    async def test_tournament_participation_data_structure(self, sample_tournament_participation):
+        """Test that tournament participation data has correct structure."""
+        participation = sample_tournament_participation[0]
+
+        assert participation.hotkey == "hotkey1"
+        assert participation.participated_in_text is True
+        assert participation.participated_in_image is False
+        assert participation.text_proportion == 1.0
+        assert participation.image_proportion == 0.0
+
+        # Test both tournament participation
+        participation_both = sample_tournament_participation[2]
+        assert participation_both.participated_in_text is True
+        assert participation_both.participated_in_image is True
+        assert participation_both.text_proportion == cts.TOURNAMENT_TEXT_WEIGHT
+        assert participation_both.image_proportion == cts.TOURNAMENT_IMAGE_WEIGHT
+
+    @pytest.mark.asyncio
+    async def test_weekly_participation_data_structure(self, sample_weekly_participation):
+        """Test that weekly participation data has correct structure."""
+        participation = sample_weekly_participation[0]
+
+        assert participation.hotkey == "hotkey1"
+        assert participation.text_task_proportion == 0.8
+        assert participation.image_task_proportion == 0.2
+        assert participation.total_tasks == 50
+        # Verify proportions sum to 1.0
+        assert abs((participation.text_task_proportion + participation.image_task_proportion) - 1.0) < 0.001
+
+    def test_burn_data_separated_structure(self, sample_burn_data):
+        """Test that separated burn data has correct structure."""
+        assert sample_burn_data.text_performance_diff == 0.3
+        assert sample_burn_data.image_performance_diff == 0.1
+        assert sample_burn_data.text_burn_proportion == 0.3
+        assert sample_burn_data.image_burn_proportion == 0.1
+        assert sample_burn_data.text_tournament_weight == 0.35
+        assert sample_burn_data.image_tournament_weight == 0.36
+
+    def test_apply_regular_weights_separated(self, sample_period_scores, sample_weekly_participation, sample_burn_data):
+        """Test regular weight application with separated burn dynamics."""
+        # Setup
+        hotkey_to_node_id = {"hotkey1": 0, "hotkey2": 1, "hotkey3": 2}
+        all_node_weights = [0.0, 0.0, 0.0]
+        weekly_participation_map = {p.hotkey: p for p in sample_weekly_participation}
+        scale_factor = 0.95
+
+        # Apply weights
+        apply_regular_weights_separated(
+            sample_period_scores,
+            hotkey_to_node_id,
+            all_node_weights,
+            sample_burn_data,
+            weekly_participation_map,
+            scale_factor
+        )
+
+        # Verify weights were applied
+        assert all_node_weights[0] > 0  # hotkey1
+        assert all_node_weights[1] > 0  # hotkey2
+        assert all_node_weights[2] > 0  # hotkey3
+
+        # Verify proportional application based on weekly participation
+        # hotkey1 has 80% text tasks, should get more text regular weight
+        # hotkey2 has 70% image tasks, should get more image regular weight
+        assert all_node_weights[0] != all_node_weights[1]  # Different participation = different weights
+
+    def test_apply_tournament_weights_separated(self, sample_tournament_participation):
+        """Test tournament weight application with separated burn dynamics."""
+        # Setup
+        tournament_weights = {"hotkey1": 0.5, "hotkey2": 0.3, "hotkey3": 0.7}
+        hotkey_to_node_id = {"hotkey1": 0, "hotkey2": 1, "hotkey3": 2}
+        all_node_weights = [0.0, 0.0, 0.0]
+        tournament_participation_map = {p.hotkey: p for p in sample_tournament_participation}
+        scaled_text_tournament_weight = 0.35
+        scaled_image_tournament_weight = 0.36
+
+        # Apply weights
+        apply_tournament_weights_separated(
+            tournament_weights,
+            hotkey_to_node_id,
+            all_node_weights,
+            tournament_participation_map,
+            scaled_text_tournament_weight,
+            scaled_image_tournament_weight
+        )
+
+        # Verify weights were applied
+        assert all_node_weights[0] > 0  # hotkey1 (text only)
+        assert all_node_weights[1] > 0  # hotkey2 (image only)
+        assert all_node_weights[2] > 0  # hotkey3 (both)
+
+        # hotkey3 participated in both tournaments, should have highest weight
+        assert all_node_weights[2] > all_node_weights[0]
+        assert all_node_weights[2] > all_node_weights[1]
+
+    def test_node_weights_result_model(self):
+        """Test NodeWeightsResult model functionality."""
+        node_ids = [0, 1, 2]
+        node_weights = [0.5, 0.3, 0.7]
+
+        result = NodeWeightsResult(
+            node_ids=node_ids,
+            node_weights=node_weights
+        )
+
+        assert result.node_ids == node_ids
+        assert result.node_weights == node_weights
+
+        # Test tuple conversion for backward compatibility
+        tuple_result = result.to_tuple()
+        assert tuple_result == (node_ids, node_weights)
+        assert isinstance(tuple_result, tuple)
+
+    @pytest.mark.asyncio
+    async def test_separated_burn_calculation_logic(self, mock_psql_db):
+        """Test that separated burn calculation produces different results than combined."""
+        # Mock the dependencies
+        with pytest.mock.patch('validator.core.weight_setting.get_latest_completed_tournament') as mock_get_tournament, \
+             pytest.mock.patch('validator.core.weight_setting.check_boss_round_synthetic_tasks_complete') as mock_check_tasks, \
+             pytest.mock.patch('validator.core.weight_setting.calculate_performance_difference') as mock_calc_perf:
+
+            # Setup mocks - different performance for text vs image
+            mock_text_tournament = TournamentData(
+                tournament_id="text_123",
+                tournament_type=TournamentType.TEXT,
+                status="completed",
+                base_winner_hotkey="winner1",
+                winner_hotkey="winner1"
+            )
+            mock_image_tournament = TournamentData(
+                tournament_id="image_456",
+                tournament_type=TournamentType.IMAGE,
+                status="completed",
+                base_winner_hotkey="winner2",
+                winner_hotkey="winner2"
+            )
+
+            def mock_get_tournament_side_effect(psql_db, tournament_type):
+                if tournament_type == TournamentType.TEXT:
+                    return mock_text_tournament
+                else:
+                    return mock_image_tournament
+
+            mock_get_tournament.side_effect = mock_get_tournament_side_effect
+            mock_check_tasks.return_value = True
+
+            def mock_calc_perf_side_effect(tournament_id, psql_db):
+                if tournament_id == "text_123":
+                    return 0.4  # Higher performance diff for text
+                else:
+                    return 0.1  # Lower performance diff for image
+
+            mock_calc_perf.side_effect = mock_calc_perf_side_effect
+
+            # Run separated burn calculation
+            result = await get_tournament_burn_details_separated(mock_psql_db)
+
+            # Verify different burn rates were calculated
+            assert result.text_performance_diff == 0.4
+            assert result.image_performance_diff == 0.1
+            assert result.text_burn_proportion > result.image_burn_proportion
+            assert result.text_tournament_weight < result.image_tournament_weight  # Higher burn = lower weight
+
+    def test_participation_proportion_calculation(self):
+        """Test that participation proportions are calculated correctly."""
+        # Test text-only participation
+        text_only = HotkeyTournamentParticipation(
+            hotkey="text_miner",
+            participated_in_text=True,
+            participated_in_image=False,
+            text_proportion=1.0,
+            image_proportion=0.0
+        )
+        assert text_only.text_proportion == 1.0
+        assert text_only.image_proportion == 0.0
+
+        # Test both tournaments participation
+        both_tournaments = HotkeyTournamentParticipation(
+            hotkey="both_miner",
+            participated_in_text=True,
+            participated_in_image=True,
+            text_proportion=cts.TOURNAMENT_TEXT_WEIGHT,
+            image_proportion=cts.TOURNAMENT_IMAGE_WEIGHT
+        )
+        assert both_tournaments.text_proportion == cts.TOURNAMENT_TEXT_WEIGHT
+        assert both_tournaments.image_proportion == cts.TOURNAMENT_IMAGE_WEIGHT
+        # Verify proportions sum to 1.0
+        assert abs((both_tournaments.text_proportion + both_tournaments.image_proportion) - 1.0) < 0.001
+
+    def test_edge_case_no_participation(self):
+        """Test handling of hotkeys with no participation data."""
+        # Test weekly participation with zero tasks
+        zero_tasks = HotkeyTaskParticipation(
+            hotkey="inactive",
+            text_task_proportion=0.0,
+            image_task_proportion=0.0,
+            total_tasks=0
+        )
+        assert zero_tasks.total_tasks == 0
+        assert zero_tasks.text_task_proportion == 0.0
+        assert zero_tasks.image_task_proportion == 0.0
+
+    @pytest.mark.asyncio
+    async def test_integration_separated_weight_calculation(self, mock_psql_db):
+        """Integration test for the full separated weight calculation."""
+        # This would require mocking many dependencies, but demonstrates the integration point
+        with pytest.mock.patch('validator.core.weight_setting.fetch_nodes') as mock_fetch_nodes, \
+             pytest.mock.patch('validator.core.weight_setting.get_tournament_burn_details_separated') as mock_burn_data, \
+             pytest.mock.patch('validator.core.weight_setting.get_tournament_participation_data') as mock_tourn_part, \
+             pytest.mock.patch('validator.core.weight_setting.get_weekly_task_participation_data') as mock_weekly_part, \
+             pytest.mock.patch('validator.core.weight_setting.get_active_tournament_participants') as mock_participants:
+
+            # Setup basic mocks for integration test
+            mock_substrate = MagicMock()
+            mock_fetch_nodes.get_nodes_for_netuid.return_value = [
+                MagicMock(hotkey="hotkey1", node_id=0),
+                MagicMock(hotkey="hotkey2", node_id=1)
+            ]
+
+            mock_burn_data.return_value = TournamentBurnDataSeparated(
+                text_performance_diff=0.2,
+                image_performance_diff=0.1,
+                text_burn_proportion=0.2,
+                image_burn_proportion=0.1,
+                text_tournament_weight=0.4,
+                image_tournament_weight=0.36,
+                text_regular_weight=0.54,
+                image_regular_weight=0.52,
+                burn_weight=0.14
+            )
+
+            mock_tourn_part.return_value = []
+            mock_weekly_part.return_value = []
+            mock_participants.return_value = []
+
+            period_scores = [
+                PeriodScore(hotkey="hotkey1", normalised_score=0.8, weight_multiplier=1.0,
+                          average_score=0.75, std_score=0.1, period_tasks=10)
+            ]
+
+            # This should run without error and return a NodeWeightsResult
+            result = await get_node_weights_from_period_scores_separated(
+                mock_substrate, 1, period_scores, mock_psql_db
+            )
+
+            assert isinstance(result, NodeWeightsResult)
+            assert len(result.node_ids) == 2
+            assert len(result.node_weights) == 2
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/validator/core/weight_setting.py
+++ b/validator/core/weight_setting.py
@@ -11,7 +11,12 @@ from datetime import timezone
 from dotenv import load_dotenv
 
 from core.models.tournament_models import TournamentAuditData
+from core.models.tournament_models import HotkeyTaskParticipation
+from core.models.tournament_models import HotkeyTournamentParticipation
+from core.models.tournament_models import NodeWeightsResult
 from core.models.tournament_models import TournamentBurnData
+from core.models.tournament_models import TournamentBurnDataSeparated
+from core.models.tournament_models import TournamentData
 from core.models.tournament_models import TournamentPerformanceData
 from core.models.tournament_models import TournamentResultsWithWinners
 from core.models.tournament_models import TournamentType
@@ -25,6 +30,9 @@ from validator.db.sql.tournament_performance import get_previous_completed_tourn
 from validator.db.sql.tournaments import get_active_tournament_participants
 from validator.db.sql.tournaments import get_latest_completed_tournament
 from validator.db.sql.tournaments import get_tournament_full_results
+from validator.db.sql.tournaments import get_tournament_participation_data
+from validator.db.sql.tournaments import get_weekly_task_participation_data
+from validator.db.database import PSQLDB
 from validator.evaluation.tournament_scoring import get_tournament_weights_from_data
 from validator.tournament.performance_calculator import calculate_performance_difference
 
@@ -580,6 +588,278 @@ async def get_tournament_burn_details(psql_db) -> TournamentBurnData:
         tournament_weight=tournament_weight,
         regular_weight=regular_weight,
         burn_weight=burn_weight
+    )
+
+
+async def get_tournament_burn_details_separated(psql_db) -> TournamentBurnDataSeparated:
+    """
+    Calculate detailed tournament burn data with separate calculations for TEXT and IMAGE tournaments.
+
+    This function calculates separate burn proportions for TEXT and IMAGE tournaments,
+    then applies them based on each hotkey's tournament participation.
+
+    Returns:
+        TournamentBurnDataSeparated with separate performance metrics and weight distributions
+    """
+    logger.info("=== CALCULATING SEPARATED TOURNAMENT BURN DATA ===")
+
+    text_performance_diff = None
+    image_performance_diff = None
+
+    # Calculate performance differences for each tournament type separately
+    for tournament_type in [TournamentType.TEXT, TournamentType.IMAGE]:
+        logger.info(f"Processing {tournament_type} tournament type")
+        performance_diff = None
+
+        latest_tournament = await get_latest_completed_tournament(psql_db, tournament_type)
+        if latest_tournament:
+            logger.info(f"Found latest {tournament_type} tournament: {latest_tournament.tournament_id}")
+            synth_tasks_complete = await check_boss_round_synthetic_tasks_complete(latest_tournament.tournament_id, psql_db)
+            logger.info(f"Boss round synthetic tasks complete for {tournament_type}: {synth_tasks_complete}")
+
+            if synth_tasks_complete:
+                performance_diff = await calculate_performance_difference(latest_tournament.tournament_id, psql_db)
+                logger.info(f"Using latest {tournament_type} tournament {latest_tournament.tournament_id} performance: {performance_diff}")
+            else:
+                previous_tournament_id = await get_previous_completed_tournament(
+                    psql_db, tournament_type, latest_tournament.tournament_id
+                )
+                if previous_tournament_id:
+                    if await check_boss_round_synthetic_tasks_complete(previous_tournament_id, psql_db):
+                        performance_diff = await calculate_performance_difference(previous_tournament_id, psql_db)
+                        logger.info(f"Using previous {tournament_type} tournament {previous_tournament_id} performance: {performance_diff}")
+                    else:
+                        logger.info(f"Previous {tournament_type} tournament {previous_tournament_id} synthetic tasks not complete")
+                else:
+                    logger.info(f"No previous {tournament_type} tournament found")
+
+        # Handle cases where no performance data is available
+        if performance_diff is None and latest_tournament:
+            if latest_tournament.winner_hotkey == cts.EMISSION_BURN_HOTKEY:
+                logger.info(f"No synthetic task data available for {tournament_type} tournaments, burn account won - assuming worst performance (100% difference)")
+                performance_diff = 1.0
+            else:
+                logger.info(f"No synthetic task data available for {tournament_type} tournaments, assuming perfect performance (0% difference)")
+                performance_diff = 0.0
+
+        # Store performance differences
+        if tournament_type == TournamentType.TEXT:
+            text_performance_diff = performance_diff
+        elif tournament_type == TournamentType.IMAGE:
+            image_performance_diff = performance_diff
+
+    # Calculate separate burn proportions for each type
+    text_burn_proportion = calculate_burn_proportion(text_performance_diff) if text_performance_diff is not None else 1.0
+    image_burn_proportion = calculate_burn_proportion(image_performance_diff) if image_performance_diff is not None else 1.0
+
+    logger.info(f"Text burn proportion: {text_burn_proportion}, Image burn proportion: {image_burn_proportion}")
+
+    # Calculate separate weight redistributions
+    text_tournament_burn = cts.BASE_TOURNAMENT_WEIGHT * cts.TOURNAMENT_TEXT_WEIGHT * text_burn_proportion
+    image_tournament_burn = cts.BASE_TOURNAMENT_WEIGHT * cts.TOURNAMENT_IMAGE_WEIGHT * image_burn_proportion
+
+    text_tournament_weight = cts.BASE_TOURNAMENT_WEIGHT * cts.TOURNAMENT_TEXT_WEIGHT - text_tournament_burn
+    image_tournament_weight = cts.BASE_TOURNAMENT_WEIGHT * cts.TOURNAMENT_IMAGE_WEIGHT - image_tournament_burn
+
+    # Regular weight gets the burned tournament allocation based on participation proportions
+    total_tournament_burn = text_tournament_burn + image_tournament_burn
+    text_regular_weight = cts.BASE_REGULAR_WEIGHT + (text_tournament_burn * cts.LEGACY_PERFORM_DIFF_EMISSION_GAIN_PERCENT)
+    image_regular_weight = cts.BASE_REGULAR_WEIGHT + (image_tournament_burn * cts.LEGACY_PERFORM_DIFF_EMISSION_GAIN_PERCENT)
+
+    # Total burn weight (what goes to burn address)
+    burn_weight = (1 - cts.BASE_REGULAR_WEIGHT - cts.BASE_TOURNAMENT_WEIGHT) + (total_tournament_burn * (1 - cts.LEGACY_PERFORM_DIFF_EMISSION_GAIN_PERCENT))
+
+    logger.info(f"Separated weights - Text tournament: {text_tournament_weight}, Image tournament: {image_tournament_weight}")
+    logger.info(f"Separated regular - Text: {text_regular_weight}, Image: {image_regular_weight}")
+    logger.info(f"Total burn weight: {burn_weight}")
+
+    return TournamentBurnDataSeparated(
+        text_performance_diff=text_performance_diff,
+        image_performance_diff=image_performance_diff,
+        text_burn_proportion=text_burn_proportion,
+        image_burn_proportion=image_burn_proportion,
+        text_tournament_weight=text_tournament_weight,
+        image_tournament_weight=image_tournament_weight,
+        text_regular_weight=text_regular_weight,
+        image_regular_weight=image_regular_weight,
+        burn_weight=burn_weight
+    )
+
+
+def apply_regular_weights_separated(
+    node_results: list[PeriodScore],
+    hotkey_to_node_id: dict[str, int],
+    all_node_weights: list[float],
+    burn_data: TournamentBurnDataSeparated,
+    weekly_participation_map: dict[str, HotkeyTaskParticipation],
+    scale_factor: float
+) -> None:
+    """Apply regular weights with participation-based redistribution."""
+    logger.info("=== NODE WEIGHT CALCULATIONS WITH SEPARATED REDISTRIBUTION ===")
+
+    for node_result in node_results:
+        if node_result.normalised_score is not None:
+            node_id: int | None = hotkey_to_node_id.get(node_result.hotkey)
+            if node_id is not None:
+                # Get weekly participation for this hotkey
+                weekly_part: HotkeyTaskParticipation | None = weekly_participation_map.get(node_result.hotkey)
+
+                if weekly_part:
+                    # Calculate proportional regular weight based on weekly task participation
+                    text_regular_contribution: float = (burn_data.text_regular_weight * weekly_part.text_task_proportion) * scale_factor
+                    image_regular_contribution: float = (burn_data.image_regular_weight * weekly_part.image_task_proportion) * scale_factor
+                    total_regular_weight: float = text_regular_contribution + image_regular_contribution
+                else:
+                    # No weekly participation - use base regular weight
+                    total_regular_weight = cts.BASE_REGULAR_WEIGHT * scale_factor
+
+                contribution: float = node_result.normalised_score * node_result.weight_multiplier * total_regular_weight
+                all_node_weights[node_id] = all_node_weights[node_id] + contribution
+
+                logger.info(f"Node ID {node_id} (hotkey: {node_result.hotkey[:8]}...): "
+                           f"normalized_score={node_result.normalised_score:.6f}, "
+                           f"weight_multiplier={node_result.weight_multiplier:.6f}, "
+                           f"regular_weight={total_regular_weight:.6f}, "
+                           f"contribution={contribution:.6f}, "
+                           f"total_weight={all_node_weights[node_id]:.6f}")
+
+
+def apply_tournament_weights_separated(
+    tournament_weights: dict[str, float],
+    hotkey_to_node_id: dict[str, int],
+    all_node_weights: list[float],
+    tournament_participation_map: dict[str, HotkeyTournamentParticipation],
+    scaled_text_tournament_weight: float,
+    scaled_image_tournament_weight: float
+) -> None:
+    """Apply tournament weights with type-specific participation scaling."""
+    logger.info("=== TOURNAMENT WEIGHT CALCULATIONS ===")
+
+    if tournament_weights:
+        for hotkey, weight in tournament_weights.items():
+            node_id = hotkey_to_node_id.get(hotkey)
+            if node_id is not None:
+                # Get tournament participation for this hotkey to determine weights
+                tournament_part: HotkeyTournamentParticipation | None = tournament_participation_map.get(hotkey)
+
+                if tournament_part:
+                    # Apply proportional tournament weights based on participation
+                    text_contribution: float = weight * tournament_part.text_proportion * scaled_text_tournament_weight
+                    image_contribution: float = weight * tournament_part.image_proportion * scaled_image_tournament_weight
+                    total_tournament_contribution: float = text_contribution + image_contribution
+                else:
+                    # No tournament participation data - apply combined weight
+                    total_tournament_contribution = weight * (scaled_text_tournament_weight + scaled_image_tournament_weight)
+
+                all_node_weights[node_id] = all_node_weights[node_id] + total_tournament_contribution
+
+                if tournament_part:
+                    logger.info(f"Node ID {node_id} (hotkey: {hotkey[:8]}...): "
+                               f"tournament_weight={weight:.6f}, "
+                               f"text_contribution={text_contribution:.6f}, "
+                               f"image_contribution={image_contribution:.6f}, "
+                               f"total_tournament_contribution={total_tournament_contribution:.6f}, "
+                               f"total_weight={all_node_weights[node_id]:.6f}")
+
+
+async def get_node_weights_from_period_scores_separated(
+    substrate: SubstrateInterface,
+    netuid: int,
+    node_results: list[PeriodScore],
+    psql_db: PSQLDB
+) -> NodeWeightsResult:
+    """
+    Get node weights with separated burn dynamics based on tournament participation.
+
+    This applies different burn rates based on:
+    - Tournament participation (for burn calculation)
+    - Weekly task participation (for redistribution)
+    """
+    all_nodes: list[Node] = fetch_nodes.get_nodes_for_netuid(substrate, netuid)
+    hotkey_to_node_id: dict[str, int] = {node.hotkey: node.node_id for node in all_nodes}
+
+    all_node_ids: list[int] = [node.node_id for node in all_nodes]
+    all_node_weights: list[float] = [0.0 for _ in all_nodes]
+
+    logger.info("=== SEPARATED BURN CALCULATION ===")
+
+    # Get separated burn data
+    burn_data: TournamentBurnDataSeparated = await get_tournament_burn_details_separated(psql_db)
+
+    # Get participation data
+    tournament_participation: list[HotkeyTournamentParticipation] = await get_tournament_participation_data(psql_db)
+    weekly_participation: list[HotkeyTaskParticipation] = await get_weekly_task_participation_data(psql_db)
+
+    # Create lookup dictionaries
+    tournament_participation_map: dict[str, HotkeyTournamentParticipation] = {p.hotkey: p for p in tournament_participation}
+    weekly_participation_map: dict[str, HotkeyTaskParticipation] = {p.hotkey: p for p in weekly_participation}
+
+    logger.info(f"Tournament participation: {len(tournament_participation)} hotkeys")
+    logger.info(f"Weekly participation: {len(weekly_participation)} hotkeys")
+
+    # Calculate scaling
+    participants: list[str] = await get_active_tournament_participants(psql_db)
+    participation_total: float = len(participants) * cts.TOURNAMENT_PARTICIPATION_WEIGHT
+    scale_factor: float = 1.0 - participation_total if participation_total > 0 else 1.0
+
+    scaled_text_tournament_weight: float = burn_data.text_tournament_weight * scale_factor
+    scaled_image_tournament_weight: float = burn_data.image_tournament_weight * scale_factor
+    scaled_burn_weight: float = burn_data.burn_weight * scale_factor
+
+    # Apply weights using helper functions
+    apply_regular_weights_separated(
+        node_results, hotkey_to_node_id, all_node_weights, burn_data,
+        weekly_participation_map, scale_factor
+    )
+
+    # Get tournament weights and apply them
+    text_tournament: TournamentData | None = await get_latest_completed_tournament(psql_db, TournamentType.TEXT)
+    image_tournament: TournamentData | None = await get_latest_completed_tournament(psql_db, TournamentType.IMAGE)
+
+    # Build tournament data (reusing existing logic)
+    text_tournament_data: TournamentResultsWithWinners | None = None
+    if text_tournament:
+        tournament_results = await get_tournament_full_results(text_tournament.tournament_id, psql_db)
+        text_tournament_data = TournamentResultsWithWinners(
+            tournament_id=tournament_results.tournament_id,
+            rounds=tournament_results.rounds,
+            base_winner_hotkey=text_tournament.base_winner_hotkey,
+            winner_hotkey=text_tournament.winner_hotkey,
+        )
+
+    image_tournament_data: TournamentResultsWithWinners | None = None
+    if image_tournament:
+        tournament_results = await get_tournament_full_results(image_tournament.tournament_id, psql_db)
+        image_tournament_data = TournamentResultsWithWinners(
+            tournament_id=tournament_results.tournament_id,
+            rounds=tournament_results.rounds,
+            base_winner_hotkey=image_tournament.base_winner_hotkey,
+            winner_hotkey=image_tournament.winner_hotkey,
+        )
+
+    tournament_weights: dict[str, float] = get_tournament_weights_from_data(text_tournament_data, image_tournament_data)
+
+    apply_tournament_weights_separated(
+        tournament_weights, hotkey_to_node_id, all_node_weights,
+        tournament_participation_map, scaled_text_tournament_weight, scaled_image_tournament_weight
+    )
+
+    # Apply participation weights
+    for hotkey in participants:
+        node_id = hotkey_to_node_id.get(hotkey)
+        if node_id is not None:
+            all_node_weights[node_id] += cts.TOURNAMENT_PARTICIPATION_WEIGHT
+
+    # Apply burn weight
+    burn_node_id: int | None = hotkey_to_node_id.get(cts.EMISSION_BURN_HOTKEY)
+    if burn_node_id is not None:
+        all_node_weights[burn_node_id] = scaled_burn_weight
+
+    logger.info(f"Number of non zero node weights: {sum(1 for weight in all_node_weights if weight != 0)}")
+
+    return NodeWeightsResult(
+        node_ids=all_node_ids,
+        node_weights=all_node_weights
     )
 
 


### PR DESCRIPTION

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR implements a new system for separate burn dynamics in the tournament reward system, splitting calculations between text and image tasks. It introduces new data models to track participation in different tournament types and calculates separate burn rates based on performance differences in text vs. image tournaments. The implementation allows for more granular allocation of rewards based on both tournament participation and weekly task activity, with weights distributed proportionally based on the type of tasks each node focuses on. The changes include new data models for tracking participation types, utility functions for calculating separated burn rates, and extensive test coverage for the new functionality.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `core/models/tournament_models.py` |
| 2 | `validator/core/weight_setting.py` |
| 3 | `validator/db/sql/tournaments.py` |
| 4 | `tests/test_separated_burn_dynamics.py` |
</details>



<!-- RECURSEML_SUMMARY:END -->

<!-- RECURSEML_ANALYSIS:START -->
## Review by RecurseML

 _🔍 Review performed on [1716c43..4fa16e9](https://github.com/rayonlabs/G.O.D/compare/1716c43455b494dd3ad99b85849ee5e003336693...4fa16e9fe59c2aa3478e742ce51ea988d0c602e2)_

✨ No bugs found, your code is sparkling clean

<details>
<summary>✅ Files analyzed, no issues (4)</summary>

  • `tests/test_separated_burn_dynamics.py`
  • `validator/core/weight_setting.py`
  • `validator/db/sql/tournaments.py`
  • `core/models/tournament_models.py`
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)
<!-- RECURSEML_ANALYSIS:END -->