### PR TITLE
filter out obsolete reward fns from historical grpo tasks

### DIFF
--- a/core/models/utility_models.py
+++ b/core/models/utility_models.py
@@ -94,6 +94,7 @@ class RewardFunction(BaseModel):
     reward_weight: float = Field(..., ge=0)
     func_hash: str | None = None
     is_generic: bool | None = None
+    is_manual: bool | None = None
 
 
 class GrpoDatasetType(BaseModel):

--- a/validator/db/sql/grpo.py
+++ b/validator/db/sql/grpo.py
@@ -113,7 +113,7 @@ async def get_generic_reward_functions_from_db(psql_db: PSQLDB, num_rewards: int
         List of generic RewardFunction objects
     """
     query = f"""
-        SELECT {cst.REWARD_ID}, {cst.FUNC_HASH}, {cst.REWARD_FUNC}, {cst.IS_GENERIC}
+        SELECT {cst.REWARD_ID}, {cst.FUNC_HASH}, {cst.REWARD_FUNC}, {cst.IS_GENERIC}, {cst.IS_MANUAL}
         FROM {cst.REWARD_FUNCTIONS_TABLE}
         WHERE {cst.IS_GENERIC} = true
         AND {cst.IS_MANUAL} = true
@@ -129,6 +129,7 @@ async def get_generic_reward_functions_from_db(psql_db: PSQLDB, num_rewards: int
                 reward_func=row[cst.REWARD_FUNC],
                 func_hash=row[cst.FUNC_HASH],
                 is_generic=row[cst.IS_GENERIC],
+                is_manual=row[cst.IS_MANUAL],
                 reward_weight=1.0,
             )
             for row in rows

--- a/validator/db/sql/tasks.py
+++ b/validator/db/sql/tasks.py
@@ -327,9 +327,9 @@ async def get_tasks_with_status(
                 """
             elif task_type == TaskType.CHATTASK.value:
                 specific_query = f"""
-                    SELECT 
-                        t.*, 
-                        gt.synthetic_data, 
+                    SELECT
+                        t.*,
+                        gt.synthetic_data,
                         gt.file_format,
                         gt.chat_template,
                         gt.chat_column,
@@ -338,7 +338,7 @@ async def get_tasks_with_status(
                         gt.chat_user_reference,
                         gt.chat_assistant_reference
                     FROM {cst.TASKS_TABLE} t
-                    LEFT JOIN {cst.CHAT_TASKS_TABLE} gt 
+                    LEFT JOIN {cst.CHAT_TASKS_TABLE} gt
                         ON t.{cst.TASK_ID} = gt.{cst.TASK_ID}
                     WHERE t.{cst.TASK_ID} = $1
                 """
@@ -806,9 +806,9 @@ async def get_task(task_id: UUID, psql_db: PSQLDB, connection: Connection | None
             """
         elif task_type == TaskType.CHATTASK.value:
             specific_query = f"""
-                SELECT 
-                    t.*, 
-                    gt.synthetic_data, 
+                SELECT
+                    t.*,
+                    gt.synthetic_data,
                     gt.file_format,
                     gt.chat_template,
                     gt.chat_column,
@@ -817,7 +817,7 @@ async def get_task(task_id: UUID, psql_db: PSQLDB, connection: Connection | None
                     gt.chat_user_reference,
                     gt.chat_assistant_reference
                 FROM {cst.TASKS_TABLE} t
-                LEFT JOIN {cst.CHAT_TASKS_TABLE} gt 
+                LEFT JOIN {cst.CHAT_TASKS_TABLE} gt
                     ON t.{cst.TASK_ID} = gt.{cst.TASK_ID}
                 WHERE t.{cst.TASK_ID} = $1
             """
@@ -914,9 +914,9 @@ async def get_task_by_id(task_id: UUID, psql_db: PSQLDB) -> AnyTypeTask:
         elif task_type == TaskType.CHATTASK.value:
             specific_query = f"""
                 {victorious_repo_cte}
-                SELECT 
-                    tasks.*, 
-                    tt.synthetic_data, 
+                SELECT
+                    tasks.*,
+                    tt.synthetic_data,
                     tt.file_format,
                     tt.chat_template,
                     tt.chat_column,
@@ -926,7 +926,7 @@ async def get_task_by_id(task_id: UUID, psql_db: PSQLDB) -> AnyTypeTask:
                     tt.chat_assistant_reference,
                     COALESCE(tasks.training_repo_backup, victorious_repo.repo) as trained_model_repository
                 FROM {cst.TASKS_TABLE} tasks
-                LEFT JOIN {cst.CHAT_TASKS_TABLE} tt 
+                LEFT JOIN {cst.CHAT_TASKS_TABLE} tt
                     ON tasks.{cst.TASK_ID} = tt.{cst.TASK_ID}
                 LEFT JOIN victorious_repo ON tasks.task_id = victorious_repo.task_id
                 WHERE tasks.{cst.TASK_ID} = $1
@@ -1492,7 +1492,7 @@ async def add_reward_functions(task_id: UUID, reward_functions: list[RewardFunct
 async def get_reward_functions(task_id: UUID, psql_db: PSQLDB, connection: Connection | None = None) -> list[RewardFunction]:
     async def _get_reward_functions(conn: Connection) -> list[RewardFunction]:
         query = f"""
-            SELECT rf.{cst.REWARD_ID}, rf.{cst.REWARD_FUNC}, rf.{cst.FUNC_HASH}, rf.{cst.IS_GENERIC}, gtf.{cst.REWARD_WEIGHT}
+            SELECT rf.{cst.REWARD_ID}, rf.{cst.REWARD_FUNC}, rf.{cst.FUNC_HASH}, rf.{cst.IS_GENERIC}, rf.{cst.IS_MANUAL}, gtf.{cst.REWARD_WEIGHT}
             FROM {cst.REWARD_FUNCTIONS_TABLE} rf
             JOIN {cst.GRPO_TASK_FUNCTIONS_TABLE} gtf ON rf.{cst.REWARD_ID} = gtf.{cst.REWARD_ID}
             WHERE gtf.{cst.TASK_ID} = $1
@@ -1504,6 +1504,7 @@ async def get_reward_functions(task_id: UUID, psql_db: PSQLDB, connection: Conne
                 reward_func=row[cst.REWARD_FUNC],
                 func_hash=row[cst.FUNC_HASH],
                 is_generic=row[cst.IS_GENERIC],
+                is_manual=row[cst.IS_MANUAL],
                 reward_weight=row[cst.REWARD_WEIGHT],
             )
             for row in rows

--- a/validator/tournament/boss_round_sync.py
+++ b/validator/tournament/boss_round_sync.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import asyncio
-import random
 from datetime import datetime
 from uuid import uuid4
 
@@ -9,8 +8,11 @@ import validator.core.constants as cst
 from core.models.tournament_models import TournamentRoundData
 from core.models.tournament_models import TournamentTask
 from core.models.utility_models import TaskStatus
+from core.models.utility_models import TaskType
 from validator.core.config import Config
+from validator.core.models import AnyTypeTask
 from validator.db.database import PSQLDB
+from validator.db.sql import grpo as grpo_sql
 from validator.db.sql.tasks import add_task
 from validator.db.sql.tasks import get_task
 from validator.db.sql.tournaments import add_tournament_tasks
@@ -20,6 +22,58 @@ from validator.utils.minio import async_minio_client
 
 
 logger = get_logger(__name__)
+
+
+async def _postprocess_task_for_tournament(tournament_task: AnyTypeTask, psql_db: PSQLDB) -> AnyTypeTask:
+    """
+    For GRPO tasks: filter out non-manual reward functions.
+    If no manual reward functions remain, add one fallback from the database.
+    """
+    tournament_task.is_organic = False
+    tournament_task.task_id = uuid4()
+    tournament_task.status = TaskStatus.LOOKING_FOR_NODES
+    tournament_task.account_id = cst.NULL_ACCOUNT_ID
+    tournament_task.times_delayed = 0
+    tournament_task.assigned_miners = None
+    tournament_task.miner_scores = None
+    tournament_task.training_repo_backup = None
+    tournament_task.result_model_name = None
+    tournament_task.created_at = datetime.utcnow()
+    tournament_task.next_delay_at = None
+    tournament_task.updated_at = None
+    tournament_task.started_at = None
+    tournament_task.termination_at = None
+    tournament_task.completed_at = None
+    tournament_task.n_eval_attempts = 0
+
+    # Resign S3 URLs to ensure they're not expired
+    if tournament_task.training_data:
+        logger.info("Regenerating presigned URL for training_data")
+        tournament_task.training_data = await async_minio_client.get_new_presigned_url(tournament_task.training_data)
+
+    if tournament_task.test_data:
+        logger.info("Regenerating presigned URL for test_data")
+        tournament_task.test_data = await async_minio_client.get_new_presigned_url(tournament_task.test_data)
+
+    if hasattr(tournament_task, 'synthetic_data') and tournament_task.synthetic_data:
+        logger.info("Regenerating presigned URL for synthetic_data")
+        tournament_task.synthetic_data = await async_minio_client.get_new_presigned_url(tournament_task.synthetic_data)
+
+    if tournament_task.task_type == TaskType.GRPOTASK:
+        manual_reward_functions = [rf for rf in tournament_task.reward_functions if rf.is_manual]
+        if not manual_reward_functions:
+            logger.warning(f"GRPO task {tournament_task.task_id} has no manual reward functions after filtering, adding fallback")
+            # Add a fallback reward function from database
+            fallback_functions = await grpo_sql.get_generic_reward_functions_from_db(psql_db, 1)
+            tournament_task.reward_functions = fallback_functions
+            logger.info(f"Added fallback reward function for GRPO task {tournament_task.task_id}")
+        else:
+            original_count = len(tournament_task.reward_functions)
+            tournament_task.reward_functions = manual_reward_functions
+            if len(manual_reward_functions) < original_count:
+                logger.info(f"Filtered GRPO task {tournament_task.task_id} reward functions: {original_count} -> {len(manual_reward_functions)} (manual only)")
+
+    return tournament_task
 
 
 async def sync_boss_round_tasks_to_general(
@@ -62,7 +116,7 @@ async def copy_historical_task_into_boss_round_tournament(
     round_id: str,
     pair_id: str,
     psql_db: PSQLDB,
-):
+) -> AnyTypeTask | None:
     original_task = await get_task(historical_task_id, psql_db)
     if not original_task:
         logger.error(f"Could not find historical task {historical_task_id}")
@@ -71,38 +125,10 @@ async def copy_historical_task_into_boss_round_tournament(
     logger.info(f"Copying historical task {historical_task_id} for boss round tournament")
 
     tournament_task = original_task.model_copy()
-    tournament_task.is_organic = False
-    tournament_task.task_id = uuid4()
-    tournament_task.status = TaskStatus.LOOKING_FOR_NODES
-    tournament_task.account_id = cst.NULL_ACCOUNT_ID
-    tournament_task.times_delayed = 0
-    tournament_task.assigned_miners = None
-    tournament_task.miner_scores = None
-    tournament_task.training_repo_backup = None
-    tournament_task.result_model_name = None
-    tournament_task.created_at = datetime.utcnow()
-    tournament_task.next_delay_at = None
-    tournament_task.updated_at = None
-    tournament_task.started_at = None
-    tournament_task.termination_at = None
-    tournament_task.completed_at = None
-    tournament_task.n_eval_attempts = 0
-
-    # Resign S3 URLs to ensure they're not expired
-    if tournament_task.training_data:
-        logger.info("Regenerating presigned URL for training_data")
-        tournament_task.training_data = await async_minio_client.get_new_presigned_url(tournament_task.training_data)
-    
-    if tournament_task.test_data:
-        logger.info("Regenerating presigned URL for test_data")
-        tournament_task.test_data = await async_minio_client.get_new_presigned_url(tournament_task.test_data)
-    
-    if hasattr(tournament_task, 'synthetic_data') and tournament_task.synthetic_data:
-        logger.info("Regenerating presigned URL for synthetic_data")
-        tournament_task.synthetic_data = await async_minio_client.get_new_presigned_url(tournament_task.synthetic_data)
+    tournament_task = await _postprocess_task_for_tournament(tournament_task, psql_db)
 
     await add_task(tournament_task, psql_db)
-    
+
     tournament_task_entry = TournamentTask(
         tournament_id=tournament_id,
         round_id=round_id,
@@ -111,7 +137,7 @@ async def copy_historical_task_into_boss_round_tournament(
         pair_id=pair_id,
     )
     await add_tournament_tasks([tournament_task_entry], psql_db)
-    
+
     await _record_task_sync_link(tournament_task.task_id, historical_task_id, psql_db)
 
     logger.info(f"Successfully copied historical task {historical_task_id} -> tournament task {tournament_task.task_id}")
@@ -157,7 +183,7 @@ async def copy_tournament_task_into_general_miner_pool(
 async def _record_task_sync_link(tournament_task_id: str, general_task_id: str, psql_db: PSQLDB):
     async with await psql_db.connection() as connection:
         query = """
-            INSERT INTO boss_round_synced_tasks 
+            INSERT INTO boss_round_synced_tasks
             (tournament_task_id, general_task_id)
             VALUES ($1, $2)
             ON CONFLICT (tournament_task_id, general_task_id) DO NOTHING


### PR DESCRIPTION

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds functionality to filter out obsolete reward functions from historical GRPO (Gradient-based Reward Policy Optimization) tasks. The core change is the addition of an `is_manual` flag to the `RewardFunction` model and the implementation of a filtering mechanism that ensures only manual reward functions are used when copying historical tasks for tournaments. If no manual reward functions remain after filtering, a fallback reward function is retrieved from the database to ensure task validity. The changes primarily affect database queries and the boss round synchronization process.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `core/models/utility_models.py` |
| 2 | `validator/db/sql/grpo.py` |
| 3 | `validator/db/sql/tasks.py` |
| 4 | `validator/tournament/boss_round_sync.py` |
</details>



<!-- RECURSEML_SUMMARY:END -->

<!-- RECURSEML_ANALYSIS:START -->
## Review by RecurseML

 _🔍 Review performed on [1f4e671..392d49d](https://github.com/rayonlabs/G.O.D/compare/1f4e671eee3250e0fa4a99c3b13a2cc5bb95ec4e...392d49d4e0f24015b087e4c05478c864ad39f250)_

✨ No bugs found, your code is sparkling clean

<details>
<summary>✅ Files analyzed, no issues (4)</summary>

  • `validator/tournament/boss_round_sync.py`
  • `validator/db/sql/tasks.py`
  • `validator/db/sql/grpo.py`
  • `core/models/utility_models.py`
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)
<!-- RECURSEML_ANALYSIS:END -->