### PR TITLE
Separated

### DIFF
--- a/validator/core/weight_setting.py
+++ b/validator/core/weight_setting.py
@@ -709,6 +709,12 @@ def apply_regular_weights_separated(
                     text_regular_contribution: float = (burn_data.text_regular_weight * weekly_part.text_task_proportion) * scale_factor
                     image_regular_contribution: float = (burn_data.image_regular_weight * weekly_part.image_task_proportion) * scale_factor
                     total_regular_weight: float = text_regular_contribution + image_regular_contribution
+
+                    logger.info(f"Node ID {node_id} (hotkey: {node_result.hotkey[:8]}...): "
+                               f"LEGACY MINER - text_prop={weekly_part.text_task_proportion:.2f}, "
+                               f"image_prop={weekly_part.image_task_proportion:.2f}, "
+                               f"text_regular={text_regular_contribution:.6f}, "
+                               f"image_regular={image_regular_contribution:.6f}")
                 else:
                     # No weekly participation - use base regular weight
                     total_regular_weight = cts.BASE_REGULAR_WEIGHT * scale_factor
@@ -755,6 +761,8 @@ def apply_tournament_weights_separated(
 
                 if tournament_part:
                     logger.info(f"Node ID {node_id} (hotkey: {hotkey[:8]}...): "
+                               f"TOURNAMENT MINER - text_prop={tournament_part.text_proportion:.2f}, "
+                               f"image_prop={tournament_part.image_proportion:.2f}, "
                                f"tournament_weight={weight:.6f}, "
                                f"text_contribution={text_contribution:.6f}, "
                                f"image_contribution={image_contribution:.6f}, "
@@ -785,6 +793,15 @@ async def get_node_weights_from_period_scores_separated(
 
     # Get separated burn data
     burn_data: TournamentBurnDataSeparated = await get_tournament_burn_details_separated(psql_db)
+
+    logger.info(f"=== SEPARATED BURN DATA ===")
+    logger.info(f"Text performance diff: {burn_data.text_performance_diff:.2%}")
+    logger.info(f"Image performance diff: {burn_data.image_performance_diff:.2%}")
+    logger.info(f"Text tournament weight: {burn_data.text_tournament_weight:.6f}")
+    logger.info(f"Image tournament weight: {burn_data.image_tournament_weight:.6f}")
+    logger.info(f"Text regular weight: {burn_data.text_regular_weight:.6f}")
+    logger.info(f"Image regular weight: {burn_data.image_regular_weight:.6f}")
+    logger.info(f"Total burn weight: {burn_data.burn_weight:.6f}")
 
     # Get participation data
     tournament_participation: list[HotkeyTournamentParticipation] = await get_tournament_participation_data(psql_db)


### PR DESCRIPTION

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR enhances logging in the weight calculation process for the validator system. It adds detailed logging for legacy miners and tournament miners, including their text and image proportions. Additionally, it adds comprehensive logging of separated burn data metrics. The PR also switches from using the combined weight calculation function to the separated version by replacing `get_node_weights_from_period_scores` with `get_node_weights_from_period_scores_separated`.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `validator/core/weight_setting.py` |
</details>



<!-- RECURSEML_SUMMARY:END -->

<!-- RECURSEML_ANALYSIS:START -->
## Review by RecurseML

 _🔍 Review performed on [dbf9771..f9da791](https://github.com/rayonlabs/G.O.D/compare/dbf9771178270e77e852e1780d88c46833098d5d...f9da791ee36e59718ba23e2095f4d4713140559d)_

✨ No bugs found, your code is sparkling clean

<details>
<summary>✅ Files analyzed, no issues (1)</summary>

  • `validator/core/weight_setting.py`
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)
<!-- RECURSEML_ANALYSIS:END -->