### PR TITLE
Separated

### DIFF
--- a/validator/core/weight_setting.py
+++ b/validator/core/weight_setting.py
@@ -1195,9 +1195,11 @@ async def _get_and_set_weights(config: Config, validator_node_id: int) -> bool:
     tournament_audit_data.regular_weight_multiplier = burn_data.regular_weight
     tournament_audit_data.burn_weight = burn_data.burn_weight
 
-    all_node_ids, all_node_weights = await get_node_weights_from_period_scores_separated(
+    result = await get_node_weights_from_period_scores_separated(
         config.substrate, config.netuid, node_results, config.psql_db
     )
+    all_node_ids = result.node_ids
+    all_node_weights = result.node_weights
     logger.info("Weights calculated, about to set...")
 
     success = await set_weights(config, all_node_ids, all_node_weights, validator_node_id)

--- a/validator/core/weight_setting.py
+++ b/validator/core/weight_setting.py
@@ -1195,7 +1195,7 @@ async def _get_and_set_weights(config: Config, validator_node_id: int) -> bool:
     tournament_audit_data.regular_weight_multiplier = burn_data.regular_weight
     tournament_audit_data.burn_weight = burn_data.burn_weight
 
-    all_node_ids, all_node_weights = await get_node_weights_from_period_scores(
+    all_node_ids, all_node_weights = await get_node_weights_from_period_scores_separated(
         config.substrate, config.netuid, node_results, config.psql_db
     )
     logger.info("Weights calculated, about to set...")

--- a/validator/core/weight_setting.py
+++ b/validator/core/weight_setting.py
@@ -709,6 +709,12 @@ def apply_regular_weights_separated(
                     text_regular_contribution: float = (burn_data.text_regular_weight * weekly_part.text_task_proportion) * scale_factor
                     image_regular_contribution: float = (burn_data.image_regular_weight * weekly_part.image_task_proportion) * scale_factor
                     total_regular_weight: float = text_regular_contribution + image_regular_contribution
+
+                    logger.info(f"Node ID {node_id} (hotkey: {node_result.hotkey[:8]}...): "
+                               f"LEGACY MINER - text_prop={weekly_part.text_task_proportion:.2f}, "
+                               f"image_prop={weekly_part.image_task_proportion:.2f}, "
+                               f"text_regular={text_regular_contribution:.6f}, "
+                               f"image_regular={image_regular_contribution:.6f}")
                 else:
                     # No weekly participation - use base regular weight
                     total_regular_weight = cts.BASE_REGULAR_WEIGHT * scale_factor
@@ -755,6 +761,8 @@ def apply_tournament_weights_separated(
 
                 if tournament_part:
                     logger.info(f"Node ID {node_id} (hotkey: {hotkey[:8]}...): "
+                               f"TOURNAMENT MINER - text_prop={tournament_part.text_proportion:.2f}, "
+                               f"image_prop={tournament_part.image_proportion:.2f}, "
                                f"tournament_weight={weight:.6f}, "
                                f"text_contribution={text_contribution:.6f}, "
                                f"image_contribution={image_contribution:.6f}, "
@@ -785,6 +793,15 @@ async def get_node_weights_from_period_scores_separated(
 
     # Get separated burn data
     burn_data: TournamentBurnDataSeparated = await get_tournament_burn_details_separated(psql_db)
+
+    logger.info(f"=== SEPARATED BURN DATA ===")
+    logger.info(f"Text performance diff: {burn_data.text_performance_diff:.2%}")
+    logger.info(f"Image performance diff: {burn_data.image_performance_diff:.2%}")
+    logger.info(f"Text tournament weight: {burn_data.text_tournament_weight:.6f}")
+    logger.info(f"Image tournament weight: {burn_data.image_tournament_weight:.6f}")
+    logger.info(f"Text regular weight: {burn_data.text_regular_weight:.6f}")
+    logger.info(f"Image regular weight: {burn_data.image_regular_weight:.6f}")
+    logger.info(f"Total burn weight: {burn_data.burn_weight:.6f}")
 
     # Get participation data
     tournament_participation: list[HotkeyTournamentParticipation] = await get_tournament_participation_data(psql_db)

--- a/validator/evaluation/tournament_scoring.py
+++ b/validator/evaluation/tournament_scoring.py
@@ -222,3 +222,34 @@ def get_tournament_weights_from_data(
     result = tournament_scores_to_weights(combined_score_list, prev_winner_hotkey, prev_winner_won_final)
     logger.info(f"Final tournament weights: {result}")
     return result
+
+
+def get_tournament_weights_from_data_separated(
+    text_tournament_data: Optional[TournamentResultsWithWinners],
+    image_tournament_data: Optional[TournamentResultsWithWinners],
+) -> tuple[dict[str, float], dict[str, float]]:
+    """Get tournament weights keeping text and image tournaments separate."""
+
+    # Calculate text tournament weights
+    text_result = calculate_tournament_type_scores_from_data(TournamentType.TEXT, text_tournament_data)
+    text_weights = {}
+    if text_result.scores:
+        text_weights = tournament_scores_to_weights(
+            text_result.scores,
+            text_result.prev_winner_hotkey,
+            text_result.prev_winner_won_final
+        )
+    logger.info(f"Text tournament weights: {text_weights}")
+
+    # Calculate image tournament weights
+    image_result = calculate_tournament_type_scores_from_data(TournamentType.IMAGE, image_tournament_data)
+    image_weights = {}
+    if image_result.scores:
+        image_weights = tournament_scores_to_weights(
+            image_result.scores,
+            image_result.prev_winner_hotkey,
+            image_result.prev_winner_won_final
+        )
+    logger.info(f"Image tournament weights: {image_weights}")
+
+    return text_weights, image_weights


### PR DESCRIPTION

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR separates the tournament weight calculation logic for text and image tournaments. Rather than combining the two tournament types and applying proportions afterward, the PR implements a fully separated approach where text and image tournaments are processed independently. The main change is the introduction of a new function `get_tournament_weights_from_data_separated` which handles text and image tournaments separately, returning distinct weight dictionaries for each. The existing `apply_tournament_weights_separated` function has been refactored to accept these separate weight dictionaries instead of a combined one. Additionally, the PR adds more detailed logging to make the weight calculation process more transparent and easier to debug.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `validator/evaluation/tournament_scoring.py` |
| 2 | `validator/core/weight_setting.py` |
</details>



<!-- RECURSEML_SUMMARY:END -->