### PR TITLE
Separated

### DIFF
--- a/docs/scoring_system.md
+++ b/docs/scoring_system.md
@@ -1,0 +1,139 @@
+# Scoring System and Weight Distribution
+
+## Constants Reference
+
+The scoring system uses these key constants (see [`validator/core/constants.py`](../validator/core/constants.py)):
+
+- `BURN_REDUCTION_RATE` - Burn multiplier (determines burn rate per % performance difference)
+- `LEGACY_PERFORM_DIFF_EMISSION_GAIN_PERCENT` - Legacy boost multiplier
+- `TOURNAMENT_TEXT_WEIGHT` - Base text tournament weight
+- `TOURNAMENT_IMAGE_WEIGHT` - Base image tournament weight
+- `EMISSION_BURN_HOTKEY` - Address that receives burned emissions
+- `MAX_BURN_PROPORTION` - Maximum proportion of weight that can be burned
+
+## Overview
+
+The Gradient subnet balances regular task performance with tournament results using separated burn dynamics. Text and image miners are treated differently based on how their respective tournaments perform compared to regular tasks.
+
+## How Miners Are Classified
+
+### Tournament Miners
+Miners get classified based on which tournaments they participate in (see [`get_tournament_participation_data`](../validator/db/sql/tournaments.py)):
+
+- **Text-only**: Only participated in text tournaments
+- **Image-only**: Only participated in image tournaments
+- **Both**: Participated in both tournament types (weighted by `TOURNAMENT_TEXT_WEIGHT` and `TOURNAMENT_IMAGE_WEIGHT`)
+
+### Legacy Miners
+Miners who do regular tasks but don't participate in tournaments. They're classified by their task completion history over the past 7 days - what proportion of their tasks were text vs image (see [`get_weekly_task_participation_data`](../validator/db/sql/tournaments.py)).
+
+## Tournament Performance Tracking
+
+The system compares tournament winners against the best legacy miner scores for the same tasks (see [`calculate_performance_difference`](../validator/core/weight_setting.py)). When tournaments underperform, this triggers burn dynamics.
+
+Performance differences are calculated as:
+```
+performance_difference = (tournament_score - best_legacy_score_for_same_task) / best_legacy_score_for_same_task
+```
+
+## Separated Burn System
+
+### The Core Mechanism
+When tournaments underperform, weight gets redistributed (see [`get_tournament_burn_details_separated`](../validator/core/weight_setting.py)):
+
+1. **Tournament miners lose weight** - proportional to their tournament type's underperformance
+2. **Legacy miners gain weight** - they get boosted because their approach outperformed tournaments
+3. **Excess weight goes to burn** - sent to `EMISSION_BURN_HOTKEY`
+
+### Text vs Image Separation
+The key insight is that text and image tournaments are evaluated separately:
+
+- If text tournaments perform poorly but image tournaments perform well, only text miners face penalties
+- Legacy miners get different boosts for their text vs image task work
+- Weight redistribution happens proportionally based on `TOURNAMENT_TEXT_WEIGHT` and `TOURNAMENT_IMAGE_WEIGHT`
+
+### The Burn Rate
+The system uses `BURN_REDUCTION_RATE` as a multiplier:
+```
+burn_proportion = min(MAX_BURN_PROPORTION, abs(performance_difference) * BURN_REDUCTION_RATE)
+```
+
+This creates strong incentives for tournament performance while capping maximum burn at `MAX_BURN_PROPORTION`.
+
+## Weight Application
+
+### Tournament Miners
+Tournament miners receive weights based on their performance and participation (see [`apply_tournament_weights_separated`](../validator/core/weight_setting.py)):
+
+- Their tournament ranking (better performers get more weight)
+- Which tournaments they participated in
+- How well those tournaments performed overall
+- The scaled weight allocation after burn adjustments
+
+### Legacy Miners
+Legacy miners receive their base performance weight plus boosts (see [`apply_regular_weights_separated`](../validator/core/weight_setting.py)):
+```
+boost = performance_difference * LEGACY_PERFORM_DIFF_EMISSION_GAIN_PERCENT
+```
+- Boosts are calculated from tournament underperformance
+- Applied proportionally to their text vs image task participation over the past 7 days
+
+### Burn Allocation
+All burned weight goes to `EMISSION_BURN_HOTKEY` rather than being lost, maintaining the total emission while redistributing it based on performance.
+
+## Example Scenario
+
+Consider a scenario where:
+- Text tournaments underperform by 14% compared to best legacy miner scores on the same tasks (`text_performance_diff = -0.14`)
+- Image tournaments underperform by 4% compared to best legacy miner scores on the same tasks (`image_performance_diff = -0.04`)
+
+**Burn Calculations (using BURN_REDUCTION_RATE = 5.0, MAX_BURN_PROPORTION = 0.75):**
+```
+text_burn_proportion = min(0.75, 0.14 * 5.0) = 0.70
+image_burn_proportion = min(0.75, 0.04 * 5.0) = 0.20
+```
+
+**Weight Redistribution (using TOURNAMENT_TEXT_WEIGHT = 0.6, TOURNAMENT_IMAGE_WEIGHT = 0.4):**
+```
+text_tournament_weight = 0.6 * (1 - 0.70) = 0.18
+image_tournament_weight = 0.4 * (1 - 0.20) = 0.32
+text_regular_weight = 0.6  # stays at base
+image_regular_weight = 0.4  # stays at base
+burn_weight = (0.6 * 0.70) + (0.4 * 0.20) = 0.50
+```
+
+**Legacy Boosts (using LEGACY_PERFORM_DIFF_EMISSION_GAIN_PERCENT = 0.25):**
+```
+text_legacy_boost = -0.14 * 0.25 = -0.035 (3.5% boost applied to individual legacy miners' scores)
+image_legacy_boost = -0.04 * 0.25 = -0.01 (1% boost applied to individual legacy miners' scores)
+```
+
+**Results:**
+- Text tournament miners face 70% weight reduction
+- Image tournament miners face 20% weight reduction
+- Legacy miners doing text tasks get 3.5% boost to their individual scores
+- Legacy miners doing image tasks get 1% boost to their individual scores
+- Miners doing both get proportional boosts based on their 7-day task mix
+- 50% of total weight goes to `EMISSION_BURN_HOTKEY`
+
+## Key Benefits
+
+**Performance Incentives**: Tournament underperformance directly reduces tournament miner rewards while boosting legacy miners who outperformed.
+
+**Type-Specific Fairness**: Text and image miners aren't penalized for the other type's poor performance.
+
+**Proportional Participation**: Miners participating in both tournaments get appropriately weighted contributions from each.
+
+**Legacy Protection**: Regular task miners get rewarded when their approach outperforms tournaments.
+
+**System Stability**: All weight redistribution is conservative and bounded (max burn at `MAX_BURN_PROPORTION`) to prevent extreme swings.
+
+This system creates a competitive balance where tournament participation is rewarded when it produces superior results, but legacy approaches are protected and boosted when tournaments fail to deliver improvements.
+
+## Implementation Details
+
+The main entry point is [`get_node_weights_from_period_scores_separated`](../validator/core/weight_setting.py) which orchestrates the entire process. Key functions include:
+
+- [`get_tournament_weights_from_data_separated`](../validator/evaluation/tournament_scoring.py) - Calculates separate text/image tournament weights
+- [`tournament_scores_to_weights`](../validator/evaluation/tournament_scoring.py) - Converts tournament scores to weight distributions
+- [`calculate_final_round_winner`](../validator/evaluation/tournament_scoring.py) - Determines tournament winners

--- a/validator/core/weight_setting.py
+++ b/validator/core/weight_setting.py
@@ -1195,9 +1195,11 @@ async def _get_and_set_weights(config: Config, validator_node_id: int) -> bool:
     tournament_audit_data.regular_weight_multiplier = burn_data.regular_weight
     tournament_audit_data.burn_weight = burn_data.burn_weight
 
-    all_node_ids, all_node_weights = await get_node_weights_from_period_scores_separated(
+    result = await get_node_weights_from_period_scores_separated(
         config.substrate, config.netuid, node_results, config.psql_db
     )
+    all_node_ids = result.node_ids
+    all_node_weights = result.node_weights
     logger.info("Weights calculated, about to set...")
 
     success = await set_weights(config, all_node_ids, all_node_weights, validator_node_id)

--- a/validator/core/weight_setting.py
+++ b/validator/core/weight_setting.py
@@ -1195,7 +1195,7 @@ async def _get_and_set_weights(config: Config, validator_node_id: int) -> bool:
     tournament_audit_data.regular_weight_multiplier = burn_data.regular_weight
     tournament_audit_data.burn_weight = burn_data.burn_weight
 
-    all_node_ids, all_node_weights = await get_node_weights_from_period_scores(
+    all_node_ids, all_node_weights = await get_node_weights_from_period_scores_separated(
         config.substrate, config.netuid, node_results, config.psql_db
     )
     logger.info("Weights calculated, about to set...")

--- a/validator/core/weight_setting.py
+++ b/validator/core/weight_setting.py
@@ -709,6 +709,12 @@ def apply_regular_weights_separated(
                     text_regular_contribution: float = (burn_data.text_regular_weight * weekly_part.text_task_proportion) * scale_factor
                     image_regular_contribution: float = (burn_data.image_regular_weight * weekly_part.image_task_proportion) * scale_factor
                     total_regular_weight: float = text_regular_contribution + image_regular_contribution
+
+                    logger.info(f"Node ID {node_id} (hotkey: {node_result.hotkey[:8]}...): "
+                               f"LEGACY MINER - text_prop={weekly_part.text_task_proportion:.2f}, "
+                               f"image_prop={weekly_part.image_task_proportion:.2f}, "
+                               f"text_regular={text_regular_contribution:.6f}, "
+                               f"image_regular={image_regular_contribution:.6f}")
                 else:
                     # No weekly participation - use base regular weight
                     total_regular_weight = cts.BASE_REGULAR_WEIGHT * scale_factor
@@ -755,6 +761,8 @@ def apply_tournament_weights_separated(
 
                 if tournament_part:
                     logger.info(f"Node ID {node_id} (hotkey: {hotkey[:8]}...): "
+                               f"TOURNAMENT MINER - text_prop={tournament_part.text_proportion:.2f}, "
+                               f"image_prop={tournament_part.image_proportion:.2f}, "
                                f"tournament_weight={weight:.6f}, "
                                f"text_contribution={text_contribution:.6f}, "
                                f"image_contribution={image_contribution:.6f}, "
@@ -785,6 +793,15 @@ async def get_node_weights_from_period_scores_separated(
 
     # Get separated burn data
     burn_data: TournamentBurnDataSeparated = await get_tournament_burn_details_separated(psql_db)
+
+    logger.info(f"=== SEPARATED BURN DATA ===")
+    logger.info(f"Text performance diff: {burn_data.text_performance_diff:.2%}")
+    logger.info(f"Image performance diff: {burn_data.image_performance_diff:.2%}")
+    logger.info(f"Text tournament weight: {burn_data.text_tournament_weight:.6f}")
+    logger.info(f"Image tournament weight: {burn_data.image_tournament_weight:.6f}")
+    logger.info(f"Text regular weight: {burn_data.text_regular_weight:.6f}")
+    logger.info(f"Image regular weight: {burn_data.image_regular_weight:.6f}")
+    logger.info(f"Total burn weight: {burn_data.burn_weight:.6f}")
 
     # Get participation data
     tournament_participation: list[HotkeyTournamentParticipation] = await get_tournament_participation_data(psql_db)

--- a/validator/evaluation/tournament_scoring.py
+++ b/validator/evaluation/tournament_scoring.py
@@ -222,3 +222,34 @@ def get_tournament_weights_from_data(
     result = tournament_scores_to_weights(combined_score_list, prev_winner_hotkey, prev_winner_won_final)
     logger.info(f"Final tournament weights: {result}")
     return result
+
+
+def get_tournament_weights_from_data_separated(
+    text_tournament_data: Optional[TournamentResultsWithWinners],
+    image_tournament_data: Optional[TournamentResultsWithWinners],
+) -> tuple[dict[str, float], dict[str, float]]:
+    """Get tournament weights keeping text and image tournaments separate."""
+
+    # Calculate text tournament weights
+    text_result = calculate_tournament_type_scores_from_data(TournamentType.TEXT, text_tournament_data)
+    text_weights = {}
+    if text_result.scores:
+        text_weights = tournament_scores_to_weights(
+            text_result.scores,
+            text_result.prev_winner_hotkey,
+            text_result.prev_winner_won_final
+        )
+    logger.info(f"Text tournament weights: {text_weights}")
+
+    # Calculate image tournament weights
+    image_result = calculate_tournament_type_scores_from_data(TournamentType.IMAGE, image_tournament_data)
+    image_weights = {}
+    if image_result.scores:
+        image_weights = tournament_scores_to_weights(
+            image_result.scores,
+            image_result.prev_winner_hotkey,
+            image_result.prev_winner_won_final
+        )
+    logger.info(f"Image tournament weights: {image_weights}")
+
+    return text_weights, image_weights


### PR DESCRIPTION

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR implements a separated scoring system for text and image tournament weights in the Gradient subnet validation process. The key change is the separation of text and image tournament calculations in the weight distribution mechanism, allowing each tournament type to be evaluated independently. The implementation adds a new function `get_tournament_weights_from_data_separated` to handle the separate tournament scoring, modifies `apply_tournament_weights_separated` to use independent text and image weights, and updates the weight calculation process in `get_node_weights_from_period_scores_separated`. The PR also adds detailed documentation that explains the separated burn system, how miners are classified, and the weight distribution mechanics with concrete examples.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `validator/evaluation/tournament_scoring.py` |
| 2 | `validator/core/weight_setting.py` |
| 3 | `docs/scoring_system.md` |
</details>



<!-- RECURSEML_SUMMARY:END -->

<!-- RECURSEML_ANALYSIS:START -->
## Review by RecurseML

 _🔍 Review performed on [e110dff..e7b71e4](https://github.com/rayonlabs/G.O.D/compare/e110dffd7d19deb359352aeb33447dce87deffba...e7b71e4386a62d0f559c184d4ab56f535541f293)_

✨ No bugs found, your code is sparkling clean

<details>
<summary>✅ Files analyzed, no issues (2)</summary>

  • `validator/core/weight_setting.py`
  • `validator/evaluation/tournament_scoring.py`
</details>

<details>
<summary>⏭️ Files skipped (trigger manually) (1)</summary>

| &nbsp; Locations &nbsp; | &nbsp; Trigger Analysis &nbsp; |
|-----------|:------------------:|
`docs/scoring_system.md` | [![Analyze](https://img.shields.io/badge/Analyze-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/f89fe66e7907aed901965e5b922ba97f54fea1838a48caa710161ca345a1b5e2/?repo_owner=rayonlabs&repo_name=G.O.D&pr_number=842)
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)
<!-- RECURSEML_ANALYSIS:END -->