### PR TITLE
formatting fix

### DIFF
--- a/docs/scoring_system.md
+++ b/docs/scoring_system.md
@@ -98,6 +98,7 @@ image_burn_proportion = min(0.75, 0.04 * 5.0) = 0.20
 ```
 
 **Weight Redistribution (using BASE_TOURNAMENT_WEIGHT = 0.525, TOURNAMENT_TEXT_WEIGHT = 0.55, TOURNAMENT_IMAGE_WEIGHT = 0.45, BASE_REGULAR_WEIGHT = 0.15, LEGACY_PERFORM_DIFF_EMISSION_GAIN_PERCENT = 0.25):**
+
 ```
 # Calculate tournament burn amounts
 text_tournament_burn = 0.525 * 0.55 * 0.70 = 0.202
@@ -114,9 +115,10 @@ image_regular_weight = 0.15 + (0.047 * 0.25) = 0.162
 # Burn weight gets remainder
 total_tournament_burn = 0.202 + 0.047 = 0.249
 burn_weight = (1 - 0.15 - 0.525) + (0.249 * (1 - 0.25)) = 0.512
-
+```
 
 **Legacy Boosts (using LEGACY_PERFORM_DIFF_EMISSION_GAIN_PERCENT = 0.25):**
+
 ```
 text_legacy_boost = -0.14 * 0.25 = -0.035 (3.5% boost applied to individual legacy miners' scores)
 image_legacy_boost = -0.04 * 0.25 = -0.01 (1% boost applied to individual legacy miners' scores)


### PR DESCRIPTION

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR makes minor formatting fixes to the documentation of the scoring system. Specifically, it adds missing empty lines and code block closure markers in the mathematical examples of weight redistribution and legacy boosts calculations. These changes improve readability without altering any of the actual documentation content.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/scoring_system.md` |
</details>



<!-- RECURSEML_SUMMARY:END -->

<!-- RECURSEML_ANALYSIS:START -->
## Review by RecurseML

 _🔍 Review performed on [eee8564..8e61117](https://github.com/rayonlabs/G.O.D/compare/eee85646c7e2a1e58d03b6710e2376eb12063680...8e61117f8f43214135f94cb96708ac96435645c8)_

✨ No bugs found, your code is sparkling clean

<details>
<summary>⏭️ Files skipped (trigger manually) (1)</summary>

| &nbsp; Locations &nbsp; | &nbsp; Trigger Analysis &nbsp; |
|-----------|:------------------:|
`docs/scoring_system.md` | [![Analyze](https://img.shields.io/badge/Analyze-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/a9d9d333169923457affcbc00cf928799ffcc2b04a2a84499755d216aff0b723/?repo_owner=rayonlabs&repo_name=G.O.D&pr_number=846)
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)
<!-- RECURSEML_ANALYSIS:END -->