### PR TITLE
fix synth chat task from instruct

### DIFF
--- a/validator/tasks/synthetic_scheduler.py
+++ b/validator/tasks/synthetic_scheduler.py
@@ -601,7 +601,7 @@ async def create_synthetic_chat_task(
     model_id = await anext(models)
 
     logger.info("CHAT_TASK: Starting dataset selection...")
-    selected_datasets = await get_multiple_datasets(datasets, task_type=TaskType.CHATTASK, keypair=config.keypair)
+    selected_datasets = await get_multiple_datasets(datasets, task_type=TaskType.INSTRUCTTEXTTASK, keypair=config.keypair)
     logger.info(f"CHAT_TASK: Selected datasets: {[d.dataset_id for d in selected_datasets]}")
 
     primary_dataset = selected_datasets[0]


### PR DESCRIPTION

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes an issue in the synthetic chat task creation by changing the task type used for dataset selection from `TaskType.CHATTASK` to `TaskType.INSTRUCTTEXTTASK`. This one-line change corrects how datasets are retrieved for synthetic chat tasks, ensuring they're fetched using the appropriate task type.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `validator/tasks/synthetic_scheduler.py` |
</details>



<!-- RECURSEML_SUMMARY:END -->

<!-- RECURSEML_ANALYSIS:START -->
## Review by RecurseML

 _🔍 Review performed on [351ebce..02bc40a](https://github.com/rayonlabs/G.O.D/compare/351ebce404a8e2a2aad025e294fbd4b33b587376...02bc40a298c9f9091aa81046a3527c3db01dfcd2)_

✨ No bugs found, your code is sparkling clean

<details>
<summary>✅ Files analyzed, no issues (1)</summary>

  • `validator/tasks/synthetic_scheduler.py`
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)
<!-- RECURSEML_ANALYSIS:END -->