### PR TITLE
fix bencmark task copies unique constraint

### DIFF
--- a/validator/db/migrations/20250919142043_fix_benchmark_task_copies_constraint.sql
+++ b/validator/db/migrations/20250919142043_fix_benchmark_task_copies_constraint.sql
@@ -1,0 +1,18 @@
+-- migrate:up
+-- Drop the existing unique constraint
+ALTER TABLE benchmark_task_copies 
+DROP CONSTRAINT benchmark_task_copies_root_task_id_participant_hotkey_key;
+
+-- Add new unique constraint that includes tournament_id
+ALTER TABLE benchmark_task_copies 
+ADD CONSTRAINT benchmark_task_copies_root_task_id_participant_hotkey_tournament_id_key 
+UNIQUE (root_task_id, participant_hotkey, tournament_id);
+
+-- migrate:down
+-- Revert the changes
+ALTER TABLE benchmark_task_copies 
+DROP CONSTRAINT benchmark_task_copies_root_task_id_participant_hotkey_tournament_id_key;
+
+ALTER TABLE benchmark_task_copies 
+ADD CONSTRAINT benchmark_task_copies_root_task_id_participant_hotkey_key 
+UNIQUE (root_task_id, participant_hotkey);


### PR DESCRIPTION

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a constraint issue in the benchmark_task_copies table by updating the unique constraint to include tournament_id alongside root_task_id and participant_hotkey. The migration script drops the existing constraint and adds a new one with the additional column. The code is also updated in the add_benchmark_task_copy function to match the new constraint definition. Additionally, some code formatting improvements were made in the tournaments.py file, converting single quotes to double quotes and improving indentation.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `validator/db/migrations/20250919142043_fix_benchmark_task_copies_constraint.sql` |
| 2 | `validator/db/sql/tournaments.py` |
</details>



<!-- RECURSEML_SUMMARY:END -->

<!-- RECURSEML_ANALYSIS:START -->
## Review by RecurseML

 _🔍 Review performed on [7a75d2b..b7cd10c](https://github.com/rayonlabs/G.O.D/compare/7a75d2b6d4fe07dd3e48982ae40078fc54bea9ee...b7cd10c02474611cd92a0286bf7af31d80530e1e)_

✨ No bugs found, your code is sparkling clean

<details>
<summary>✅ Files analyzed, no issues (1)</summary>

  • `validator/db/sql/tournaments.py`
</details>

<details>
<summary>⏭️ Files skipped (trigger manually) (1)</summary>

| &nbsp; Locations &nbsp; | &nbsp; Trigger Analysis &nbsp; |
|-----------|:------------------:|
`validator/db/migrations/20250919142043_fix_benchmark_task_copies_constraint.sql` | [![Analyze](https://img.shields.io/badge/Analyze-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/d0d3eace6cc86a8ef1530b2199e2c6d986304575f8268acaa8d53b47dca53c57/?repo_owner=rayonlabs&repo_name=G.O.D&pr_number=853)
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)
<!-- RECURSEML_ANALYSIS:END -->