### PR TITLE
challenger needs win all 3 image

### DIFF
--- a/docs/tourn_miner.md
+++ b/docs/tourn_miner.md
@@ -247,7 +247,10 @@ Tournaments run continuously with 4-7 day duration and 24-hour gaps between tour
 ### Boss Round
 - Tournament winner must face defending champion
 - Uses progressive threshold system with exponential decay based on consecutive wins
-- Defending champion retains title unless clearly outperformed
+- **Tournament-Specific Winning Requirements**:
+  - **Text tournaments**: Challenger wins by majority rule (2/3 or 3/3 tasks)
+  - **Image tournaments**: Challenger must win ALL 3 tasks (perfect sweep) to dethrone the champion
+- Defending champion retains title unless challenger meets the tournament-specific winning requirement
 
 #### Championship Defense Thresholds
 The advantage required to dethrone a champion decreases with each successful defense using an exponential decay formula:

--- a/docs/tournament_overview.md
+++ b/docs/tournament_overview.md
@@ -123,12 +123,15 @@ PENDING → ACTIVE → COMPLETED
 When tournament reaches final round with single winner:
 
 1. **Historical Task Selection**: Boss round uses proven historical tasks from the database with at least 2 successful quality scores
-   - Text tournaments: 1 of each type (InstructText, DPO, GRPO) 
+   - Text tournaments: 1 of each type (InstructText, DPO, GRPO)
    - Image tournaments: 3 random image tasks
    - Tasks are copied with new IDs while preserving original training data
 2. **Score Comparison**: Tournament miners' results are compared against the best historical scores from general miners
 3. **Winner Determination**: Based on `calculate_final_round_winner()` with 5% margin requirement
-4. **Champion Defense**: Previous winner retains title unless clearly outperformed
+4. **Tournament-Specific Winning Requirements**:
+   - **Text tournaments**: Challenger wins by majority rule (2/3 or 3/3 tasks)
+   - **Image tournaments**: Challenger must win **ALL 3 tasks** (perfect sweep) to dethrone the defending champion
+5. **Champion Defense**: Previous winner retains title unless challenger meets the tournament-specific winning requirement
 
 ## Scoring & Weight Distribution
 


### PR DESCRIPTION
challenger now needs winning all 3 image tasks on image tourn final round to win

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR modifies the tournament system to implement different winning requirements for image tournaments versus text tournaments in the boss round. Specifically, it requires challengers in image tournaments to win ALL 3 tasks (perfect sweep) to dethrone the defending champion, while text tournaments continue to use majority rule (2/3 or 3/3 tasks). The implementation includes a new `determine_boss_round_winner()` function that applies the appropriate logic based on tournament type, replacing the previous hardcoded majority-win logic. The documentation files have been updated to clearly reflect these new tournament-specific winning requirements.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `validator/tournament/utils.py` |
| 2 | `docs/tournament_overview.md` |
| 3 | `docs/tourn_miner.md` |
</details>



<!-- RECURSEML_SUMMARY:END -->

<!-- RECURSEML_ANALYSIS:START -->
## Review by RecurseML

 _🔍 Review performed on [61d692f..b73c61b](https://github.com/rayonlabs/G.O.D/compare/61d692f7c0b9d622926f6f42e8b86cf38ca1d25b...b73c61b0abfa9ee5d10ca0678fa862c1bc152d49)_

✨ No bugs found, your code is sparkling clean

<details>
<summary>✅ Files analyzed, no issues (1)</summary>

  • `validator/tournament/utils.py`
</details>

<details>
<summary>⏭️ Files skipped (trigger manually) (2)</summary>

| &nbsp; Locations &nbsp; | &nbsp; Trigger Analysis &nbsp; |
|-----------|:------------------:|
`docs/tourn_miner.md` | [![Analyze](https://img.shields.io/badge/Analyze-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/1e60ac4d29d8c87b1785a3c9135f2c784f2964a5342cd8388ab9b37baa06f052/?repo_owner=rayonlabs&repo_name=G.O.D&pr_number=859)
`docs/tournament_overview.md` | [![Analyze](https://img.shields.io/badge/Analyze-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/7df4a9f73f533fc2d2feeda78249ba567c36a35200b4f180219c280c7c334a69/?repo_owner=rayonlabs&repo_name=G.O.D&pr_number=859)
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)
<!-- RECURSEML_ANALYSIS:END -->