### PR TITLE
updating logs and only non organic

### DIFF
--- a/validator/db/sql/historical_tasks.py
+++ b/validator/db/sql/historical_tasks.py
@@ -40,7 +40,7 @@ async def get_random_historical_task_by_type(
 
         query = f"""
             WITH eligible_tasks AS (
-                SELECT 
+                SELECT
                     t.{cst.TASK_ID},
                     COUNT(tn.{cst.TEST_LOSS}) as successful_scores
                 FROM {cst.TASKS_TABLE} t
@@ -48,6 +48,7 @@ async def get_random_historical_task_by_type(
                 WHERE t.{cst.TASK_TYPE} = $1
                 AND t.{cst.CREATED_AT} >= $2::timestamptz
                 AND t.{cst.CREATED_AT} < $3::timestamptz
+                AND t.{cst.IS_ORGANIC} = FALSE
                 AND tn.{cst.TEST_LOSS} IS NOT NULL
                 AND NOT (tn.{cst.TEST_LOSS} = 'NaN'::numeric)
                 {exclude_clause}
@@ -63,10 +64,10 @@ async def get_random_historical_task_by_type(
         result = await connection.fetchval(query, *params)
 
         if result:
-            logger.info(f"Found random historical {task_type} task: {result}")
+            logger.info(f"Found random historical synthetic {task_type} task: {result}")
         else:
             logger.warning(
-                f"No historical {task_type} tasks found between {start_date} and {end_date} "
+                f"No historical synthetic {task_type} tasks found between {start_date} and {end_date} "
                 f"with at least {min_successful_scores} valid test loss values"
             )
 


### PR DESCRIPTION

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR modifies the SQL query in the `get_random_historical_task_by_type` function to filter out organic tasks, ensuring only synthetic tasks are returned. It also updates the log messages to explicitly state that the tasks being retrieved are synthetic, providing clearer context in the logs. The change adds a condition `t.{cst.IS_ORGANIC} = FALSE` to the SQL query to filter out organic tasks.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `validator/db/sql/historical_tasks.py` |
</details>



<!-- RECURSEML_SUMMARY:END -->

<!-- RECURSEML_ANALYSIS:START -->
## Review by RecurseML

 _🔍 Review performed on [8455dc0..ab10283](https://github.com/rayonlabs/G.O.D/compare/8455dc06398a20b44a76ce51aaa6665815d179db...ab1028333a02f435f2c2ebbc7abb28ae4a92480c)_

✨ No bugs found, your code is sparkling clean

<details>
<summary>✅ Files analyzed, no issues (1)</summary>

  • `validator/db/sql/historical_tasks.py`
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)
<!-- RECURSEML_ANALYSIS:END -->