### PR TITLE
add raise if empty chat data

### DIFF
--- a/validator/tasks/synthetic_scheduler.py
+++ b/validator/tasks/synthetic_scheduler.py
@@ -297,6 +297,8 @@ async def merge_and_upload_chat_datasets(dataset_ids: list[str], input_field: st
     merged_data = []
     for ds_id in dataset_ids:
         merged_data.extend(await convert_instruct_dataset_to_chat_format(ds_id, input_field, output_field))
+    if not merged_data:
+        raise ValueError("Error creating chat dataset - no data")
     dataset_json, _ = await save_json_to_temp_file(merged_data, prefix="chat_dataset_")
     uploaded_url = await upload_file_to_minio(dataset_json, cst.BUCKET_NAME, f"{os.urandom(8).hex()}_chat_data.json")
     if os.path.exists(dataset_json):


### PR DESCRIPTION

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a simple validation check to the `merge_and_upload_chat_datasets` function in the synthetic scheduler. It adds a conditional statement that raises a `ValueError` exception if the merged chat dataset is empty, preventing the function from proceeding with uploading an empty dataset. This improves error handling by explicitly failing early with a descriptive error message when no data is available, rather than potentially creating and uploading an empty dataset file.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `validator/tasks/synthetic_scheduler.py` |
</details>



<!-- RECURSEML_SUMMARY:END -->

<!-- RECURSEML_ANALYSIS:START -->
## Review by RecurseML

 _🔍 Review performed on [b53bc44..2512c61](https://github.com/rayonlabs/G.O.D/compare/b53bc443f9ccbccf2e87d149c02ec40a01779b66...2512c615b533281268e138c52423558c8b5ee661)_

✨ No bugs found, your code is sparkling clean

<details>
<summary>✅ Files analyzed, no issues (1)</summary>

  • `validator/tasks/synthetic_scheduler.py`
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)
<!-- RECURSEML_ANALYSIS:END -->