### PR TITLE
increase beta grpo

### DIFF
--- a/validator/core/constants.py
+++ b/validator/core/constants.py
@@ -372,7 +372,7 @@ MIN_SYNTH_JOBS_REQUIRED_PER_DAY = 3
 
 # Default, fixed Hyperparameters
 BETA_DPO = 0.1
-BETA_GRPO = 0.04
+BETA_GRPO = 0.1
 
 # GRPO evaluation
 GRPO_INITIAL_BATCH_SIZE = 16


### PR DESCRIPTION

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR increases the value of the `BETA_GRPO` hyperparameter from 0.04 to 0.1. This appears to be a simple configuration change that modifies a constant value used in the GRPO (likely General Reinforcement Policy Optimization) algorithm implementation. The change increases the beta parameter value to match the existing `BETA_DPO` value.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `validator/core/constants.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->