### PR TITLE
remove sync from failures

### DIFF
--- a/validator/tournament/tournament_manager.py
+++ b/validator/tournament/tournament_manager.py
@@ -939,36 +939,7 @@ async def is_tourn_task_completed(
     elif task_obj.status == TaskStatus.FAILURE.value:
         discord_message = f"Warning: Task {tournament_task.task_id} in Tournament Round {tournament_task.round_id} has failed, please investigate."
         await _notify_discord(discord_message, config)
-
-        synced_task_id = await get_synced_task_id(tournament_task.task_id, config.psql_db)
-        if synced_task_id:
-            synced_task_obj = await task_sql.get_task(synced_task_id, config.psql_db)
-            if synced_task_obj.status == TaskStatus.SUCCESS.value:
-                logger.info(
-                    f"Tournament task {tournament_task.task_id} failed, but synced task {synced_task_id} "
-                    "completed successfully. Ignoring..."
-                )
-                return True, "Tournament task failed, but synced task completed successfully."
-            if synced_task_obj.status == TaskStatus.FAILURE.value:
-                logger.info(
-                    f"Both tournament and synced tasks failed (tournament: {tournament_task.task_id}, "
-                    f"synced: {synced_task_id}). Replacing..."
-                )
-                new_task_id = await replace_tournament_task(
-                    tournament_task.task_id,
-                    tournament_task.tournament_id,
-                    tournament_task.round_id,
-                    tournament_task.group_id,
-                    tournament_task.pair_id,
-                    config,
-                )
-                return False, f"Both tournament and synced tasks failed. Replaced with a new task {new_task_id}."
-            else:
-                return False, "Synced task is not completed. Status: " + synced_task_obj.status
-        else:
-            logger.info(f"Tournament task {tournament_task.task_id} failed. Copying to main cycle...")
-            await copy_tournament_task_into_general_miner_pool(tournament_task.task_id, config.psql_db)
-            return False, "Tournament task failed. Synced to main cycle."
+        return False, "Task failed"
 
     elif task_obj.status == TaskStatus.PREP_TASK_FAILURE.value:
         logger.info(f"Task {task_obj.task_id} failed during preparation, creating replacement immediately.")


### PR DESCRIPTION

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR removes synchronization logic from the failure handling path in tournament task processing. Previously, when a tournament task failed, the system would check for a corresponding synced task and either ignore the failure if the synced task succeeded, replace both tasks if both failed, or copy the task to the general miner pool. This change simplifies the failure handling to immediately return `False` with a "Task failed" message, eliminating all sync-related recovery mechanisms.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `validator/tournament/tournament_manager.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->