### PR TITLE
Skip model anonymization when model prep did not run

### DIFF
--- a/trainer/image_manager.py
+++ b/trainer/image_manager.py
@@ -368,6 +368,7 @@ def run_downloader_container(
     file_format: FileFormat | None = None,
     model_type: ImageModelType | None = None,
     log_labels: dict[str, str] | None = None,
+    anonymize: bool = True,
 ) -> tuple[int, Exception | None]:
     client = docker.from_env()
 
@@ -387,8 +388,15 @@ def run_downloader_container(
     if model_type:
         command += ["--model-type", model_type]
 
+    if anonymize:
+        command += ["--anonymize"]
+
     container_name = f"downloader-{task_id}-{str(uuid.uuid4())[:8]}"
     container = None
+
+    environment = {}
+    if anonymize:
+        environment["MODEL_HASH_SALT"] = os.environ.get("MODEL_HASH_SALT", "")
 
     try:
         logger.info(f"Starting downloader container: {container_name}", extra=log_labels)
@@ -398,7 +406,7 @@ def run_downloader_container(
             command=command,
             labels=log_labels,
             volumes={cst.CACHE_VOLUME_NAME: {"bind": "/cache", "mode": "rw"}},
-            environment={"MODEL_HASH_SALT": os.environ.get("MODEL_HASH_SALT", "")},
+            environment=environment,
             remove=False,
             detach=True,
         )
@@ -804,6 +812,8 @@ async def start_training_task(task: TrainerProxyRequest, local_repo_path: str):
         logger.info("Running Cache Download Container", extra=log_labels)
         await log_task(training_data.task_id, task.hotkey, "Downloading data")
 
+        model_prep_ran = training_data.baseline_stats is not None
+
         download_status, exc = await asyncio.to_thread(
             run_downloader_container,
             task_id=training_data.task_id,
@@ -814,6 +824,7 @@ async def start_training_task(task: TrainerProxyRequest, local_repo_path: str):
             file_format=getattr(training_data, "file_format", None),
             model_type=training_data.model_type if task_type == TaskType.IMAGETASK else None,
             log_labels=log_labels,
+            anonymize=model_prep_ran,
         )
 
         if download_status == 0:
@@ -857,14 +868,17 @@ async def start_training_task(task: TrainerProxyRequest, local_repo_path: str):
             env_server_url_str = ",".join(env_urls)
             await log_task(training_data.task_id, task.hotkey, f"Environment servers ready.")
 
-        anonymous_model = get_anonymous_model_dir(training_data.model)
+        if model_prep_ran:
+            model_for_container = get_anonymous_model_dir(training_data.model)
+        else:
+            model_for_container = training_data.model
 
         if task_type == TaskType.IMAGETASK:
             container = await asyncio.wait_for(
                 run_trainer_container_image(
                     task_id=training_data.task_id,
                     tag=tag,
-                    model=anonymous_model,
+                    model=model_for_container,
                     dataset_zip=training_data.dataset_zip,
                     model_type=training_data.model_type,
                     expected_repo_name=training_data.expected_repo_name,
@@ -883,7 +897,7 @@ async def start_training_task(task: TrainerProxyRequest, local_repo_path: str):
                     task_id=training_data.task_id,
                     hotkey=task.hotkey,
                     tag=tag,
-                    model=anonymous_model,
+                    model=model_for_container,
                     dataset=training_data.dataset,
                     dataset_type=training_data.dataset_type,
                     task_type=task_type,

--- a/trainer/utils/trainer_downloader.py
+++ b/trainer/utils/trainer_downloader.py
@@ -104,8 +104,14 @@ def download_from_huggingface(repo_id: str, filename: str, local_dir: str) -> st
         raise e
 
 
-async def download_base_model(repo_id: str, save_root: str, model_type: ImageModelType) -> str:
-    model_name = get_anonymous_model_dir(repo_id)
+def _model_dir_name(repo_id: str, anonymize: bool) -> str:
+    if anonymize:
+        return get_anonymous_model_dir(repo_id)
+    return repo_id.replace("/", "--")
+
+
+async def download_base_model(repo_id: str, save_root: str, model_type: ImageModelType, anonymize: bool = True) -> str:
+    model_name = _model_dir_name(repo_id, anonymize)
     save_path = os.path.join(save_root, model_name)
     if os.path.exists(save_path):
         print(f"Model already cached at {save_path}. Skipping download.")
@@ -117,17 +123,19 @@ async def download_base_model(repo_id: str, save_root: str, model_type: ImageMod
         else:
             snapshot_download(repo_id=repo_id, repo_type="model", local_dir=save_path, local_dir_use_symlinks=False)
             result = save_path
-        scrub_model_identity(save_path)
+        if anonymize:
+            scrub_model_identity(save_path)
         return result
 
 
-async def download_axolotl_base_model(repo_id: str, save_dir: str) -> str:
-    model_dir = os.path.join(save_dir, get_anonymous_model_dir(repo_id))
+async def download_axolotl_base_model(repo_id: str, save_dir: str, anonymize: bool = True) -> str:
+    model_dir = os.path.join(save_dir, _model_dir_name(repo_id, anonymize))
     if os.path.exists(model_dir):
         print(f"Model already cached at {model_dir}. Skipping download.")
         return model_dir
     snapshot_download(repo_id=repo_id, repo_type="model", local_dir=model_dir, local_dir_use_symlinks=False)
-    scrub_model_identity(model_dir)
+    if anonymize:
+        scrub_model_identity(model_dir)
     return model_dir
 
 
@@ -169,6 +177,7 @@ async def main():
     parser.add_argument("--dataset")
     parser.add_argument("--file-format")
     parser.add_argument("--model-type", choices=[ImageModelType.FLUX.value, ImageModelType.SDXL.value, ImageModelType.Z_IMAGE.value, ImageModelType.QWEN_IMAGE.value])
+    parser.add_argument("--anonymize", action="store_true", help="Anonymize model directory name and scrub identity")
     args = parser.parse_args()
 
     if args.command == "download-miner-dataset":
@@ -190,7 +199,7 @@ async def main():
 
     if args.task_type == TaskType.IMAGETASK.value:
         dataset_zip_path = await download_image_dataset(args.dataset, args.task_id, dataset_dir)
-        model_path = await download_base_model(args.model, model_dir, args.model_type)
+        model_path = await download_base_model(args.model, model_dir, args.model_type, anonymize=args.anonymize)
 
         if args.model_type == ImageModelType.Z_IMAGE.value:
             print("Downloading Z-Image adapter...", flush=True)
@@ -221,7 +230,7 @@ async def main():
             allow_patterns=["tokenizer_config.json", "spiece.model", "special_tokens_map.json", "config.json"],
         )
     elif args.task_type == TaskType.ENVIRONMENTTASK.value:
-        model_path = await download_axolotl_base_model(args.model, model_dir)
+        model_path = await download_axolotl_base_model(args.model, model_dir, anonymize=args.anonymize)
         input_data_path = train_paths.get_text_dataset_path(args.task_id)
         write_environment_task_proxy_dataset(
             out_path=input_data_path,
@@ -231,7 +240,7 @@ async def main():
         )
     else:
         dataset_path, _ = await download_text_dataset(args.task_id, args.dataset, args.file_format, dataset_dir)
-        model_path = await download_axolotl_base_model(args.model, model_dir)
+        model_path = await download_axolotl_base_model(args.model, model_dir, anonymize=args.anonymize)
 
     print(f"Model path: {model_path}", flush=True)
     print(f"Dataset path: {dataset_dir}", flush=True)


### PR DESCRIPTION
Tasks where model prep is disabled (env, image) were failing because the downloader saved models to an anonymous hash directory and scrubbed _name_or_path from config.json, but vLLM/transformers couldn't resolve the model from HF with the identity removed.

Gate anonymization on whether baseline_stats is present (set only when model prep actually ran). When model prep is skipped, use the original model ID and directory naming so the training container can resolve it.