### PR TITLE
Fix boss miner assigned to every group instead of one

### DIFF
--- a/validator/tournament/tournament_manager.py
+++ b/validator/tournament/tournament_manager.py
@@ -281,11 +281,15 @@ async def assign_nodes_to_tournament_tasks(
     if isinstance(round_structure, GroupRound):
         all_round_tasks = await get_tournament_tasks(round_structure.round_id, psql_db)
 
+        boss_assigned = False
         for i, group in enumerate(round_structure.groups):
             if is_environment_tournament:
                 group_participants = list(group.member_ids)
-                if EMISSION_BURN_HOTKEY not in group_participants:
+                if EMISSION_BURN_HOTKEY in group_participants:
+                    boss_assigned = True
+                elif not boss_assigned:
                     group_participants.append(EMISSION_BURN_HOTKEY)
+                    boss_assigned = True
                 participants_to_assign = group_participants
 
                 if is_final_round:


### PR DESCRIPTION
## Summary
- Boss (`EMISSION_BURN_HOTKEY`) was being appended to every group's participant list inside the loop in `assign_nodes_to_tournament_tasks`
- Added `boss_assigned` flag so it only joins the first group per round (groups are already shuffled, so this is random)