### PR TITLE
Require valid commit SHA in miner tournament submissions

### DIFF
--- a/docs/tourn_miner.md
+++ b/docs/tourn_miner.md
@@ -89,7 +89,7 @@ You have two options for your tournament training repository:
 Use the official G.O.D repository as your starting point:
 
 - **GitHub Repository**: `https://github.com/rayonlabs/G.O.D`
-- **Commit Hash**: Use `"main"` for the latest version, or a specific commit hash for consistency
+- **Commit Hash**: Must be a full 40-character commit SHA (e.g. `"a1b2c3d4..."`) — branch names are not accepted
 
 The base repository includes functional training scripts that you can modify and improve.
 
@@ -115,7 +115,7 @@ Update the `get_training_repo()` function:
 async def get_training_repo(task_type: TournamentType) -> TrainingRepoResponse:
     return TrainingRepoResponse(
         github_repo="https://github.com/YOUR_USERNAME/YOUR_REPO",  # Your repo URL
-        commit_hash="YOUR_COMMIT_HASH"  # Specific commit or "main"
+        commit_hash="YOUR_COMMIT_HASH"  # Must be a full 40-char commit SHA
     )
 ```
 
@@ -124,16 +124,18 @@ async def get_training_repo(task_type: TournamentType) -> TrainingRepoResponse:
 ```python
 # Using the base miner
 github_repo="https://github.com/rayonlabs/G.O.D"
-commit_hash="main"
+commit_hash="a1b2c3d4e5f6789012345678901234567890abcd"  # git rev-parse HEAD
 
 # Using your own fork
 github_repo="https://github.com/yourname/my-training-repo"
-commit_hash="a1b2c3d4e5f6..."
+commit_hash="a1b2c3d4e5f6789012345678901234567890abcd"
 
 # Using a previous winner's approach
 github_repo="https://github.com/gradients-opensource/position-1-tournament-xyz"
-commit_hash="main"
+commit_hash="a1b2c3d4e5f6789012345678901234567890abcd"
 ```
+
+> **Note**: Branch names (e.g. `"main"`) are not accepted. Use `git rev-parse HEAD` to get the commit SHA.
 
 ### Private Repositories (Optional)
 

--- a/validator/tournament/tournament_manager.py
+++ b/validator/tournament/tournament_manager.py
@@ -1,6 +1,7 @@
 import asyncio
 import math
 import random
+import re
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
@@ -728,6 +729,14 @@ async def populate_tournament_participants(tournament_id: str, config: Config, p
                 repo_url = responding_node.training_repo_response.github_repo
                 commit_hash = responding_node.training_repo_response.commit_hash
                 github_token = responding_node.training_repo_response.github_token
+
+                if not re.fullmatch(r"[0-9a-f]{40}", commit_hash.lower()):
+                    logger.warning(
+                        f"Miner {responding_node.node.hotkey} submitted invalid commit hash '{commit_hash}' "
+                        f"for repo {repo_url}. Must be a 40-char hex SHA. Excluding from tournament."
+                    )
+                    continue
+
                 logger.info(f"Checking obfuscation for {responding_node.node.hotkey}'s repo: {repo_url}")
 
                 is_not_obfuscated = await validate_repo_obfuscation(repo_url, commit_hash, github_token)


### PR DESCRIPTION
## Summary
- Miners could submit branch names (e.g. `main`) as their `commit_hash`, meaning their code wasn't pinned between training attempts
- Added validation that `commit_hash` must be a 40-char hex SHA — rejects submissions that aren't