### PR TITLE
Remove branch support from clone_repo, commit hash only

### DIFF
--- a/core/models/payload_models.py
+++ b/core/models/payload_models.py
@@ -97,7 +97,6 @@ class TrainerProxyRequest(BaseModel):
     github_repo: str
     gpu_ids: list[int]
     hotkey: str
-    github_branch: str | None = None
     github_commit_hash: str | None = None
     github_token: str | None = None
     requested_datasets: list[str] | None = None
@@ -122,7 +121,6 @@ class TrainerTaskLog(TrainerJob):
     training_data: TrainRequestImage | TrainRequestText
     github_repo: str
     hotkey: str
-    github_branch: str | None = None
     github_commit_hash: str | None = None
     github_token: str | None = None
     requested_datasets: list[str] | None = None

--- a/test_dataset_whitelist.sh
+++ b/test_dataset_whitelist.sh
@@ -31,8 +31,7 @@ PAYLOAD=$(cat <<EOF
     "github_repo": "https://github.com/wonderingwanderingwonders/god-dataset-whitelist-test",
     "gpu_ids": [0],
     "hotkey": "5Gwwwk2hiYjsk7jhj9grvMagD7g6nqQDfFe4Y9NtM3C3KjXy",
-    "github_branch": null,
-    "github_commit_hash": "main",
+    "github_commit_hash": "abc123def456abc123def456abc123def456abc1",
     "github_token": null,
     "requested_datasets": ["tasksource/Boardgame-QA"]
 }

--- a/trainer/endpoints.py
+++ b/trainer/endpoints.py
@@ -58,7 +58,6 @@ async def _run_training_with_clone(req: TrainerProxyRequest) -> None:
             clone_repo,
             repo_url=req.github_repo,
             parent_dir=cst.TEMP_REPO_PATH,
-            branch=req.github_branch,
             commit_hash=req.github_commit_hash,
             github_token=req.github_token,
             task_id=req.training_data.task_id,

--- a/trainer/utils/misc.py
+++ b/trainer/utils/misc.py
@@ -19,8 +19,7 @@ from trainer.tasks import get_running_jobs
 def clone_repo(
     repo_url: str,
     parent_dir: str,
-    branch: str = None,
-    commit_hash: str = None,
+    commit_hash: str,
     github_token: str | None = None,
     task_id: str | None = None,
     hotkey: str | None = None,
@@ -39,10 +38,7 @@ def clone_repo(
         try:
             repo = Repo(repo_dir)
             current_commit = repo.head.commit.hexsha
-
-            if commit_hash and current_commit.startswith(commit_hash):
-                return repo_dir
-            elif branch and repo.active_branch.name == branch:
+            if current_commit.startswith(commit_hash):
                 return repo_dir
             shutil.rmtree(repo_dir)
         except Exception:
@@ -50,20 +46,15 @@ def clone_repo(
 
     try:
         clone_url = build_authenticated_git_url(repo_url, github_token)
-        repo = Repo.clone_from(clone_url, repo_dir, branch=branch) if branch else Repo.clone_from(clone_url, repo_dir)
-
-        if commit_hash:
-            repo.git.fetch("--all")
-            repo.git.fetch("origin")
-            try:
-                repo.git.checkout(commit_hash)
-            except GitCommandError as checkout_error:
-                # Check if it's an invalid commit hash format issue
-                if "pathspec" in str(checkout_error) and "did not match any file(s) known to git" in str(checkout_error):
-                    raise RuntimeError(f"Invalid commit hash '{commit_hash}' - commit not found in repository")
-                else:
-                    # Re-raise other git checkout errors
-                    raise
+        repo = Repo.clone_from(clone_url, repo_dir)
+        repo.git.fetch("--all")
+        repo.git.fetch("origin")
+        try:
+            repo.git.checkout(commit_hash)
+        except GitCommandError as checkout_error:
+            if "pathspec" in str(checkout_error) and "did not match any file(s) known to git" in str(checkout_error):
+                raise RuntimeError(f"Invalid commit hash '{commit_hash}' - commit not found in repository")
+            raise
 
         return repo_dir
 


### PR DESCRIPTION
## Summary
- Remove `github_branch` field from `TrainerProxyRequest` and `TrainerTaskLog` models
- Remove `branch` parameter from `clone_repo()` in trainer — always clone then checkout specific SHA
- Follows up on #1130 which enforces 40-char hex SHA at submission time