### PR TITLE
Deduplicate model prep for env tournament sibling tasks

### DIFF
--- a/validator/db/sql/tournaments.py
+++ b/validator/db/sql/tournaments.py
@@ -1498,3 +1498,52 @@ async def delete_pvp_pair_results(task_id: str, psql_db: PSQLDB) -> None:
         await connection.execute(
             f"DELETE FROM {cst.PVP_PAIR_RESULTS_TABLE} WHERE {cst.TASK_ID} = $1", task_id
         )
+
+
+
+async def get_sibling_env_baseline_stats(
+    task_id: str, model_id: str, psql_db: PSQLDB,
+) -> dict | None:
+    """Find a sibling env task in the same round with matching model_id,
+    matching environment_names, no augmentation, and completed baseline_stats.
+
+    Only call for env tasks where the calling task has augmentation_config=None.
+    Returns raw baseline_stats JSON dict if found, else None.
+    """
+    async with await psql_db.connection() as connection:
+        row = await connection.fetchrow(f"""
+            SELECT t.{cst.BASELINE_STATS}
+            FROM {cst.TOURNAMENT_TASKS_TABLE} tt_self
+            JOIN {cst.TOURNAMENT_TASKS_TABLE} tt_sibling
+                ON tt_sibling.{cst.ROUND_ID} = tt_self.{cst.ROUND_ID}
+                AND tt_sibling.{cst.TASK_ID} != tt_self.{cst.TASK_ID}
+            JOIN {cst.TASKS_TABLE} t
+                ON t.{cst.TASK_ID} = tt_sibling.{cst.TASK_ID}
+            JOIN {cst.ENV_TASKS_TABLE} et_self
+                ON et_self.{cst.TASK_ID} = tt_self.{cst.TASK_ID}
+            JOIN {cst.ENV_TASKS_TABLE} et_sibling
+                ON et_sibling.{cst.TASK_ID} = tt_sibling.{cst.TASK_ID}
+            WHERE tt_self.{cst.TASK_ID} = $1
+                AND t.{cst.MODEL_ID} = $2
+                AND t.{cst.AUGMENTATION_CONFIG} IS NULL
+                AND t.{cst.BASELINE_STATS} IS NOT NULL
+                AND et_sibling.{cst.ENVIRONMENT_NAMES} = et_self.{cst.ENVIRONMENT_NAMES}
+            LIMIT 1
+        """, task_id, model_id)
+        if row and row[cst.BASELINE_STATS]:
+            return row[cst.BASELINE_STATS]
+        return None
+
+
+async def get_sibling_task_ids(task_id: str, psql_db: PSQLDB) -> list[str]:
+    """Get task_ids of sibling tasks in the same tournament round."""
+    async with await psql_db.connection() as connection:
+        rows = await connection.fetch(f"""
+            SELECT tt_sibling.{cst.TASK_ID}::text AS task_id
+            FROM {cst.TOURNAMENT_TASKS_TABLE} tt_self
+            JOIN {cst.TOURNAMENT_TASKS_TABLE} tt_sibling
+                ON tt_sibling.{cst.ROUND_ID} = tt_self.{cst.ROUND_ID}
+                AND tt_sibling.{cst.TASK_ID} != tt_self.{cst.TASK_ID}
+            WHERE tt_self.{cst.TASK_ID} = $1
+        """, task_id)
+        return [row["task_id"] for row in rows]

--- a/validator/tournament/orchestrator.py
+++ b/validator/tournament/orchestrator.py
@@ -1149,6 +1149,29 @@ async def process_awaiting_model_prep_tasks(config: Config):
                     if recovered:
                         continue
 
+                    # Env tasks with no augmentation: reuse sibling's baseline_stats
+                    is_env_task = task.task_type == TaskType.ENVIRONMENTTASK
+                    if is_env_task and task.augmentation_config is None:
+                        sibling_stats = await tournament_sql.get_sibling_env_baseline_stats(
+                            task_id_str, task.model_id, config.psql_db,
+                        )
+                        if sibling_stats is not None:
+                            task.baseline_stats = sibling_stats
+                            task.status = TaskStatus.LOOKING_FOR_NODES
+                            await task_sql.update_task(task, config.psql_db)
+                            logger.info(
+                                f"Copied baseline_stats from sibling for env task {task.task_id}, "
+                                f"skipping model prep"
+                            )
+                            continue
+
+                        # A sibling is already running model prep — wait for it
+                        sibling_ids = await tournament_sql.get_sibling_task_ids(
+                            task_id_str, config.psql_db,
+                        )
+                        if any(sid in _model_prep_in_progress for sid in sibling_ids):
+                            continue
+
                     gpu_req = get_tournament_gpu_requirement(task.task_type, task.model_params_count or 0, task.model_id)
                     suitable = await _check_suitable_gpus(config, gpu_req)
                     if suitable is None:

--- a/validator/tournament/orchestrator.py
+++ b/validator/tournament/orchestrator.py
@@ -1063,6 +1063,33 @@ async def _recover_model_prep_from_trainer(task, config: Config) -> bool:
     return False
 
 
+async def _try_reuse_sibling_model_prep(task, config: Config) -> bool:
+    """For env tasks with no augmentation, try to copy baseline_stats from a
+    sibling in the same round, or skip if a sibling is already running prep.
+
+    Returns True if the task was handled (copied or should wait), False to proceed normally.
+    """
+    if task.task_type != TaskType.ENVIRONMENTTASK or task.augmentation_config is not None:
+        return False
+
+    task_id_str = str(task.task_id)
+    sibling_stats = await tournament_sql.get_sibling_env_baseline_stats(
+        task_id_str, task.model_id, config.psql_db,
+    )
+    if sibling_stats is not None:
+        task.baseline_stats = sibling_stats
+        task.status = TaskStatus.LOOKING_FOR_NODES
+        await task_sql.update_task(task, config.psql_db)
+        logger.info(f"Copied baseline_stats from sibling for env task {task.task_id}, skipping model prep")
+        return True
+
+    sibling_ids = await tournament_sql.get_sibling_task_ids(task_id_str, config.psql_db)
+    if any(sid in _model_prep_in_progress for sid in sibling_ids):
+        return True
+
+    return False
+
+
 async def process_awaiting_model_prep_tasks(config: Config):
     """Poll for tasks awaiting model prep and dispatch to a trainer with GPU.
 
@@ -1149,28 +1176,8 @@ async def process_awaiting_model_prep_tasks(config: Config):
                     if recovered:
                         continue
 
-                    # Env tasks with no augmentation: reuse sibling's baseline_stats
-                    is_env_task = task.task_type == TaskType.ENVIRONMENTTASK
-                    if is_env_task and task.augmentation_config is None:
-                        sibling_stats = await tournament_sql.get_sibling_env_baseline_stats(
-                            task_id_str, task.model_id, config.psql_db,
-                        )
-                        if sibling_stats is not None:
-                            task.baseline_stats = sibling_stats
-                            task.status = TaskStatus.LOOKING_FOR_NODES
-                            await task_sql.update_task(task, config.psql_db)
-                            logger.info(
-                                f"Copied baseline_stats from sibling for env task {task.task_id}, "
-                                f"skipping model prep"
-                            )
-                            continue
-
-                        # A sibling is already running model prep — wait for it
-                        sibling_ids = await tournament_sql.get_sibling_task_ids(
-                            task_id_str, config.psql_db,
-                        )
-                        if any(sid in _model_prep_in_progress for sid in sibling_ids):
-                            continue
+                    if await _try_reuse_sibling_model_prep(task, config):
+                        continue
 
                     gpu_req = get_tournament_gpu_requirement(task.task_type, task.model_params_count or 0, task.model_id)
                     suitable = await _check_suitable_gpus(config, gpu_req)


### PR DESCRIPTION
## Summary
- Env tournament rounds create N tasks (one per group) with identical model_id, environment_names, and no augmentation
- Model prep produces the same baseline_stats for all — previously ran N times wastefully
- Now only one task dispatches to the trainer; siblings either copy the completed result or wait if one is already in flight