### PR TITLE
Scope sibling model prep check to matching model and no augmentation

### DIFF
--- a/validator/db/sql/tournaments.py
+++ b/validator/db/sql/tournaments.py
@@ -1500,7 +1500,6 @@ async def delete_pvp_pair_results(task_id: str, psql_db: PSQLDB) -> None:
         )
 
 
-
 async def get_sibling_env_baseline_stats(
     task_id: str, model_id: str, psql_db: PSQLDB,
 ) -> dict | None:
@@ -1535,8 +1534,11 @@ async def get_sibling_env_baseline_stats(
         return None
 
 
-async def get_sibling_task_ids(task_id: str, psql_db: PSQLDB) -> list[str]:
-    """Get task_ids of sibling tasks in the same tournament round."""
+async def get_matching_sibling_task_ids(
+    task_id: str, model_id: str, psql_db: PSQLDB,
+) -> list[str]:
+    """Get task_ids of sibling tasks in the same round with matching model_id
+    and no augmentation config (i.e. siblings that would produce identical model prep)."""
     async with await psql_db.connection() as connection:
         rows = await connection.fetch(f"""
             SELECT tt_sibling.{cst.TASK_ID}::text AS task_id
@@ -1544,6 +1546,10 @@ async def get_sibling_task_ids(task_id: str, psql_db: PSQLDB) -> list[str]:
             JOIN {cst.TOURNAMENT_TASKS_TABLE} tt_sibling
                 ON tt_sibling.{cst.ROUND_ID} = tt_self.{cst.ROUND_ID}
                 AND tt_sibling.{cst.TASK_ID} != tt_self.{cst.TASK_ID}
+            JOIN {cst.TASKS_TABLE} t
+                ON t.{cst.TASK_ID} = tt_sibling.{cst.TASK_ID}
             WHERE tt_self.{cst.TASK_ID} = $1
-        """, task_id)
+                AND t.{cst.MODEL_ID} = $2
+                AND t.{cst.AUGMENTATION_CONFIG} IS NULL
+        """, task_id, model_id)
         return [row["task_id"] for row in rows]

--- a/validator/tournament/orchestrator.py
+++ b/validator/tournament/orchestrator.py
@@ -1083,7 +1083,7 @@ async def _try_reuse_sibling_model_prep(task, config: Config) -> bool:
         logger.info(f"Copied baseline_stats from sibling for env task {task.task_id}, skipping model prep")
         return True
 
-    sibling_ids = await tournament_sql.get_sibling_task_ids(task_id_str, config.psql_db)
+    sibling_ids = await tournament_sql.get_matching_sibling_task_ids(task_id_str, task.model_id, config.psql_db)
     if any(sid in _model_prep_in_progress for sid in sibling_ids):
         return True
 


### PR DESCRIPTION
## Summary
- Follow-up to #1132 — the sibling task_ids query wasn't filtering by model_id or augmentation_config
- Could incorrectly stall waiting on a sibling with a different model or augmentation enabled
- Now only considers siblings that would produce identical model prep output