### PR TITLE
Forfeit game on context length overflow instead of crashing eval

### DIFF
--- a/validator/evaluation/pvp/bot.py
+++ b/validator/evaluation/pvp/bot.py
@@ -10,6 +10,7 @@ import re
 import signal
 
 import numpy as np
+import openai
 import pyspiel
 
 from core.models.pvp_models import ChatCompletionConfig, ChatFn, ChatMessage, ChatRole
@@ -25,6 +26,14 @@ class TurnTimeoutError(Exception):
     def __init__(self, player_id: int):
         self.player_id = player_id
         super().__init__(f"Player {player_id} exceeded {vcst.PVP_TURN_TIMEOUT_SECONDS}s turn timeout")
+
+
+class ContextOverflowError(Exception):
+    """Raised when a bot's input exceeds the model's context length."""
+
+    def __init__(self, player_id: int):
+        self.player_id = player_id
+        super().__init__(f"Player {player_id} exceeded model context length")
 
 
 class EmptyLegalActionsError(Exception):
@@ -125,7 +134,12 @@ class LLMBot(pyspiel.Bot):
         self._conversation.append(ChatMessage(role=ChatRole.USER, content=user_prompt))
 
         for attempt in range(vcst.PVP_BOT_MAX_PARSING_RETRIES + 1):
-            result = self._chat_fn(self._config, self._conversation)
+            try:
+                result = self._chat_fn(self._config, self._conversation)
+            except openai.BadRequestError as exc:
+                if "context length" in str(exc).lower():
+                    raise ContextOverflowError(self._player_id) from exc
+                raise
 
             response_text = result.content or ""
             self._conversation.append(ChatMessage(role=ChatRole.ASSISTANT, content=response_text))

--- a/validator/evaluation/pvp/game_runner.py
+++ b/validator/evaluation/pvp/game_runner.py
@@ -33,7 +33,7 @@ from validator.evaluation.pvp.agents import (
     LeducPokerAgent,
     LiarsDiceAgent,
 )
-from validator.evaluation.pvp.bot import EmptyLegalActionsError, LLMBot, TurnTimeoutError
+from validator.evaluation.pvp.bot import ContextOverflowError, EmptyLegalActionsError, LLMBot, TurnTimeoutError
 from validator.evaluation.pvp.chat import chat_completion, create_client
 from validator.evaluation.pvp.scoring import determine_outcome
 
@@ -269,6 +269,12 @@ def _evaluate_with_timeout(
     except TurnTimeoutError as exc:
         logger.warning(
             "Player %d timed out on turn — opponent wins by forfeit",
+            exc.player_id,
+        )
+        return _forfeit_returns(state, exc.player_id)
+    except ContextOverflowError as exc:
+        logger.warning(
+            "Player %d exceeded context length — opponent wins by forfeit",
             exc.player_id,
         )
         return _forfeit_returns(state, exc.player_id)


### PR DESCRIPTION
When a model's conversation exceeds its context window, the opponent now wins by forfeit — same as turn timeouts. Previously this was an unhandled BadRequestError that killed the entire evaluation.