### PR TITLE
fix: per-miner baseline stats for continuous training

### DIFF
--- a/core/models/payload_models.py
+++ b/core/models/payload_models.py
@@ -133,6 +133,7 @@ class ModelPrepJob(TrainerJob):
     job_type: Literal["model_prep"] = "model_prep"
     task_id: str
     model_id: str
+    hotkey: str | None = None  # Set for per-miner preps
     result: "ModelPrepResponse | None" = None
 
     model_config = ConfigDict(protected_namespaces=())
@@ -179,6 +180,7 @@ class ModelPrepRequest(BaseModel):
     gpu_ids: list[int] = [0]
     reward_functions: list[RewardFunction] | None = None
     env_configs: dict[EnvironmentName, EnvConfig] | None = None
+    hotkey: str | None = None  # Per-miner prep key for recovery after restart
 
     model_config = ConfigDict(protected_namespaces=())
 

--- a/trainer/endpoints.py
+++ b/trainer/endpoints.py
@@ -137,7 +137,7 @@ async def model_prep(req: ModelPrepRequest) -> ModelPrepResponse:
                 status_code=409,
                 detail="GPU conflict detected. Requested GPUs are already in use.",
             )
-        await _start_model_prep_unlocked(req.task_id, req.model_id, req.gpu_ids)
+        await _start_model_prep_unlocked(req.task_id, req.model_id, req.gpu_ids, req.hotkey)
     try:
         result = await asyncio.to_thread(
             run_model_prep_container,
@@ -150,15 +150,15 @@ async def model_prep(req: ModelPrepRequest) -> ModelPrepResponse:
             reward_functions=req.reward_functions,
             env_configs=req.env_configs,
         )
-        await complete_model_prep(req.task_id, success=True, result=result)
+        await complete_model_prep(req.task_id, success=True, result=result, hotkey=req.hotkey)
         return result
     except Exception:
-        await complete_model_prep(req.task_id, success=False)
+        await complete_model_prep(req.task_id, success=False, hotkey=req.hotkey)
         raise
 
 
-async def get_model_prep_status(task_id: str) -> ModelPrepJob:
-    job = get_model_prep_job(task_id)
+async def get_model_prep_status(task_id: str, hotkey: str | None = None) -> ModelPrepJob:
+    job = get_model_prep_job(task_id, hotkey)
     if job is None:
         raise HTTPException(status_code=404, detail=f"Model prep job '{task_id}' not found.")
     return job

--- a/trainer/tasks.py
+++ b/trainer/tasks.py
@@ -128,12 +128,15 @@ async def update_container_name(task_id: str, hotkey: str, container_name: str):
 # Model prep job helpers
 # ---------------------------------------------------------------------------
 
-async def _start_model_prep_unlocked(task_id: str, model_id: str, gpu_ids: list[int]) -> ModelPrepJob:
+async def _start_model_prep_unlocked(task_id: str, model_id: str, gpu_ids: list[int], hotkey: str | None = None) -> ModelPrepJob:
     load_task_history()
 
     now = datetime.utcnow()
     for existing in task_history:
         if isinstance(existing, ModelPrepJob) and existing.task_id == task_id and existing.status == TaskStatus.TRAINING:
+            # For per-miner preps, only mark the same hotkey's job as failed
+            if hotkey and existing.hotkey and existing.hotkey != hotkey:
+                continue
             logger.warning(
                 "model_prep retry: marking previous TRAINING entry for task_id=%s gpu_ids=%s as FAILURE",
                 task_id,
@@ -146,6 +149,7 @@ async def _start_model_prep_unlocked(task_id: str, model_id: str, gpu_ids: list[
         task_id=task_id,
         model_id=model_id,
         gpu_ids=gpu_ids,
+        hotkey=hotkey,
         status=TaskStatus.TRAINING,
         started_at=now,
     )
@@ -154,11 +158,11 @@ async def _start_model_prep_unlocked(task_id: str, model_id: str, gpu_ids: list[
     return job
 
 
-async def complete_model_prep(task_id: str, success: bool = True, result=None):
+async def complete_model_prep(task_id: str, success: bool = True, result=None, hotkey: str | None = None):
     async with _task_lock:
         load_task_history()
 
-        job = get_model_prep_job(task_id)
+        job = get_model_prep_job(task_id, hotkey)
         if job is None:
             return
         job.status = TaskStatus.SUCCESS if success else TaskStatus.FAILURE
@@ -168,12 +172,14 @@ async def complete_model_prep(task_id: str, success: bool = True, result=None):
         await save_task_history()
 
 
-def get_model_prep_job(task_id: str) -> ModelPrepJob | None:
+def get_model_prep_job(task_id: str, hotkey: str | None = None) -> ModelPrepJob | None:
     # Prefer the currently-running entry so complete_model_prep targets the
     # active job, not an older entry with the same task_id from a prior retry.
     fallback: ModelPrepJob | None = None
     for job in task_history:
         if isinstance(job, ModelPrepJob) and job.task_id == task_id:
+            if hotkey and job.hotkey and job.hotkey != hotkey:
+                continue
             if job.status == TaskStatus.TRAINING:
                 return job
             if fallback is None:

--- a/trainer/utils/trainer_downloader.py
+++ b/trainer/utils/trainer_downloader.py
@@ -163,7 +163,11 @@ def _detect_and_merge_lora(model_dir: str) -> None:
         base_model_id, torch_dtype=torch.float16, device_map=device,
     )
     base_tokenizer = AutoTokenizer.from_pretrained(base_model_id)
-    lora_tokenizer = AutoTokenizer.from_pretrained(model_dir)
+    try:
+        lora_tokenizer = AutoTokenizer.from_pretrained(model_dir)
+    except Exception:
+        print(f"[downloader] No tokenizer in adapter dir, using base tokenizer", flush=True)
+        lora_tokenizer = base_tokenizer
 
     if len(lora_tokenizer) > base_model.get_input_embeddings().weight.shape[0]:
         base_model.resize_token_embeddings(len(lora_tokenizer))

--- a/validator/db/sql/tasks.py
+++ b/validator/db/sql/tasks.py
@@ -477,6 +477,48 @@ async def get_effective_prep_model(task_id: str, model_id: str, psql_db: PSQLDB)
         return model_id
 
 
+async def get_miners_needing_baseline_stats(task_id: str, psql_db: PSQLDB) -> list[tuple[str, str]]:
+    """Get (hotkey, starting_model_repo) pairs for miners that have a starting model but no baseline_stats yet."""
+    async with await psql_db.connection() as connection:
+        connection: Connection
+        rows = await connection.fetch(f"""
+            SELECT {cst.HOTKEY}, {cst.STARTING_MODEL_REPO}
+            FROM {cst.TASK_NODES_TABLE}
+            WHERE {cst.TASK_ID} = $1
+            AND {cst.STARTING_MODEL_REPO} IS NOT NULL
+            AND {cst.BASELINE_STATS} IS NULL
+        """, task_id)
+        return [(row[cst.HOTKEY], row[cst.STARTING_MODEL_REPO]) for row in rows]
+
+
+async def set_miner_baseline_stats(task_id: str, hotkey: str, baseline_stats: dict, psql_db: PSQLDB) -> None:
+    """Store per-miner baseline_stats on task_nodes."""
+    import json
+    async with await psql_db.connection() as connection:
+        connection: Connection
+        await connection.execute(f"""
+            UPDATE {cst.TASK_NODES_TABLE}
+            SET {cst.BASELINE_STATS} = $1::jsonb
+            WHERE {cst.TASK_ID} = $2
+            AND {cst.HOTKEY} = $3
+        """, json.dumps(baseline_stats), task_id, hotkey)
+
+
+async def get_miner_baseline_stats(task_id: str, hotkey: str, psql_db: PSQLDB) -> dict | None:
+    """Get per-miner baseline_stats from task_nodes."""
+    async with await psql_db.connection() as connection:
+        connection: Connection
+        row = await connection.fetchrow(f"""
+            SELECT {cst.BASELINE_STATS}
+            FROM {cst.TASK_NODES_TABLE}
+            WHERE {cst.TASK_ID} = $1
+            AND {cst.HOTKEY} = $2
+        """, task_id, hotkey)
+        if row and row[cst.BASELINE_STATS]:
+            return row[cst.BASELINE_STATS]
+        return None
+
+
 async def get_starting_model_repo(task_id: str, hotkey: str, psql_db: PSQLDB) -> str | None:
     """Get the per-miner starting model for this task, if set."""
     async with await psql_db.connection() as connection:

--- a/validator/db/sql/tasks.py
+++ b/validator/db/sql/tasks.py
@@ -491,6 +491,19 @@ async def get_miners_needing_baseline_stats(task_id: str, psql_db: PSQLDB) -> li
         return [(row[cst.HOTKEY], row[cst.STARTING_MODEL_REPO]) for row in rows]
 
 
+async def has_miners_with_starting_model(task_id: str, psql_db: PSQLDB) -> bool:
+    """Check if any miners for this task have a starting_model_repo set."""
+    async with await psql_db.connection() as connection:
+        connection: Connection
+        row = await connection.fetchrow(f"""
+            SELECT 1 FROM {cst.TASK_NODES_TABLE}
+            WHERE {cst.TASK_ID} = $1
+            AND {cst.STARTING_MODEL_REPO} IS NOT NULL
+            LIMIT 1
+        """, task_id)
+        return row is not None
+
+
 async def set_miner_baseline_stats(task_id: str, hotkey: str, baseline_stats: dict, psql_db: PSQLDB) -> None:
     """Store per-miner baseline_stats on task_nodes."""
     import json

--- a/validator/db/sql/tasks.py
+++ b/validator/db/sql/tasks.py
@@ -504,9 +504,13 @@ async def has_miners_with_starting_model(task_id: str, psql_db: PSQLDB) -> bool:
         return row is not None
 
 
-async def set_miner_baseline_stats(task_id: str, hotkey: str, baseline_stats: dict, psql_db: PSQLDB) -> None:
+async def set_miner_baseline_stats(task_id: str, hotkey: str, baseline_stats, psql_db: PSQLDB) -> None:
     """Store per-miner baseline_stats on task_nodes."""
     import json
+    if hasattr(baseline_stats, "model_dump"):
+        stats_dict = baseline_stats.model_dump()
+    else:
+        stats_dict = baseline_stats
     async with await psql_db.connection() as connection:
         connection: Connection
         await connection.execute(f"""
@@ -514,7 +518,7 @@ async def set_miner_baseline_stats(task_id: str, hotkey: str, baseline_stats: di
             SET {cst.BASELINE_STATS} = $1::jsonb
             WHERE {cst.TASK_ID} = $2
             AND {cst.HOTKEY} = $3
-        """, json.dumps(baseline_stats), task_id, hotkey)
+        """, json.dumps(stats_dict), task_id, hotkey)
 
 
 async def get_miner_baseline_stats(task_id: str, hotkey: str, psql_db: PSQLDB) -> dict | None:

--- a/validator/db/sql/tasks.py
+++ b/validator/db/sql/tasks.py
@@ -461,6 +461,22 @@ async def set_starting_model_repo(task_id: str, hotkey: str, starting_model_repo
         await connection.execute(query, starting_model_repo, task_id, hotkey, NETUID)
 
 
+async def get_effective_prep_model(task_id: str, model_id: str, psql_db: PSQLDB) -> str:
+    """Get the effective model for baseline prep: starting_model_repo if any miner has one, else model_id."""
+    async with await psql_db.connection() as connection:
+        connection: Connection
+        row = await connection.fetchrow(f"""
+            SELECT DISTINCT {cst.STARTING_MODEL_REPO}
+            FROM {cst.TASK_NODES_TABLE}
+            WHERE {cst.TASK_ID} = $1
+            AND {cst.STARTING_MODEL_REPO} IS NOT NULL
+            LIMIT 1
+        """, task_id)
+        if row and row[cst.STARTING_MODEL_REPO]:
+            return row[cst.STARTING_MODEL_REPO]
+        return model_id
+
+
 async def get_starting_model_repo(task_id: str, hotkey: str, psql_db: PSQLDB) -> str | None:
     """Get the per-miner starting model for this task, if set."""
     async with await psql_db.connection() as connection:

--- a/validator/db/sql/tournaments.py
+++ b/validator/db/sql/tournaments.py
@@ -1525,10 +1525,14 @@ async def delete_pvp_pair_results(task_id: str, psql_db: PSQLDB) -> None:
 
 
 async def get_sibling_env_baseline_stats(
-    task_id: str, model_id: str, psql_db: PSQLDB,
+    task_id: str, effective_model: str, psql_db: PSQLDB,
 ) -> dict | None:
-    """Find a sibling env task in the same round with matching model_id,
+    """Find a sibling env task in the same round with matching effective prep model,
     matching environment_names, no augmentation, and completed baseline_stats.
+
+    effective_model is starting_model_repo if set, else model_id.
+    Siblings match when their effective prep model (COALESCE of starting_model_repo
+    over model_id) equals the caller's.
 
     Only call for env tasks where the calling task has augmentation_config=None.
     Returns raw baseline_stats JSON dict if found, else None.
@@ -1546,23 +1550,34 @@ async def get_sibling_env_baseline_stats(
                 ON et_self.{cst.TASK_ID} = tt_self.{cst.TASK_ID}
             JOIN {cst.ENV_TASKS_TABLE} et_sibling
                 ON et_sibling.{cst.TASK_ID} = tt_sibling.{cst.TASK_ID}
+            LEFT JOIN LATERAL (
+                SELECT {cst.STARTING_MODEL_REPO}
+                FROM {cst.TASK_NODES_TABLE}
+                WHERE {cst.TASK_ID} = tt_sibling.{cst.TASK_ID}::text
+                AND {cst.STARTING_MODEL_REPO} IS NOT NULL
+                LIMIT 1
+            ) sib_sm ON true
             WHERE tt_self.{cst.TASK_ID} = $1
-                AND t.{cst.MODEL_ID} = $2
+                AND COALESCE(sib_sm.{cst.STARTING_MODEL_REPO}, t.{cst.MODEL_ID}) = $2
                 AND t.{cst.AUGMENTATION_CONFIG} IS NULL
                 AND t.{cst.BASELINE_STATS} IS NOT NULL
                 AND et_sibling.{cst.ENVIRONMENT_NAMES} = et_self.{cst.ENVIRONMENT_NAMES}
             LIMIT 1
-        """, task_id, model_id)
+        """, task_id, effective_model)
         if row and row[cst.BASELINE_STATS]:
             return row[cst.BASELINE_STATS]
         return None
 
 
 async def get_matching_sibling_task_ids(
-    task_id: str, model_id: str, psql_db: PSQLDB,
+    task_id: str, effective_model: str, psql_db: PSQLDB,
 ) -> list[str]:
-    """Get task_ids of sibling tasks in the same round with matching model_id
-    and no augmentation config (i.e. siblings that would produce identical model prep)."""
+    """Get task_ids of sibling tasks in the same round with matching effective
+    prep model and no augmentation config (i.e. siblings that would produce
+    identical model prep).
+
+    effective_model is starting_model_repo if set, else model_id.
+    """
     async with await psql_db.connection() as connection:
         rows = await connection.fetch(f"""
             SELECT tt_sibling.{cst.TASK_ID}::text AS task_id
@@ -1572,8 +1587,15 @@ async def get_matching_sibling_task_ids(
                 AND tt_sibling.{cst.TASK_ID} != tt_self.{cst.TASK_ID}
             JOIN {cst.TASKS_TABLE} t
                 ON t.{cst.TASK_ID} = tt_sibling.{cst.TASK_ID}
+            LEFT JOIN LATERAL (
+                SELECT {cst.STARTING_MODEL_REPO}
+                FROM {cst.TASK_NODES_TABLE}
+                WHERE {cst.TASK_ID} = tt_sibling.{cst.TASK_ID}::text
+                AND {cst.STARTING_MODEL_REPO} IS NOT NULL
+                LIMIT 1
+            ) sib_sm ON true
             WHERE tt_self.{cst.TASK_ID} = $1
-                AND t.{cst.MODEL_ID} = $2
+                AND COALESCE(sib_sm.{cst.STARTING_MODEL_REPO}, t.{cst.MODEL_ID}) = $2
                 AND t.{cst.AUGMENTATION_CONFIG} IS NULL
-        """, task_id, model_id)
+        """, task_id, effective_model)
         return [row["task_id"] for row in rows]

--- a/validator/db/sql/tournaments.py
+++ b/validator/db/sql/tournaments.py
@@ -1525,16 +1525,12 @@ async def delete_pvp_pair_results(task_id: str, psql_db: PSQLDB) -> None:
 
 
 async def get_sibling_env_baseline_stats(
-    task_id: str, effective_model: str, psql_db: PSQLDB,
+    task_id: str, model_id: str, psql_db: PSQLDB,
 ) -> dict | None:
-    """Find a sibling env task in the same round with matching effective prep model,
+    """Find a sibling env task in the same round with matching model_id,
     matching environment_names, no augmentation, and completed baseline_stats.
 
-    effective_model is starting_model_repo if set, else model_id.
-    Siblings match when their effective prep model (COALESCE of starting_model_repo
-    over model_id) equals the caller's.
-
-    Only call for env tasks where the calling task has augmentation_config=None.
+    Only called for round-1 style tasks (no per-miner starting models).
     Returns raw baseline_stats JSON dict if found, else None.
     """
     async with await psql_db.connection() as connection:
@@ -1550,34 +1546,23 @@ async def get_sibling_env_baseline_stats(
                 ON et_self.{cst.TASK_ID} = tt_self.{cst.TASK_ID}
             JOIN {cst.ENV_TASKS_TABLE} et_sibling
                 ON et_sibling.{cst.TASK_ID} = tt_sibling.{cst.TASK_ID}
-            LEFT JOIN LATERAL (
-                SELECT {cst.STARTING_MODEL_REPO}
-                FROM {cst.TASK_NODES_TABLE}
-                WHERE {cst.TASK_ID} = tt_sibling.{cst.TASK_ID}
-                AND {cst.STARTING_MODEL_REPO} IS NOT NULL
-                LIMIT 1
-            ) sib_sm ON true
             WHERE tt_self.{cst.TASK_ID} = $1
-                AND COALESCE(sib_sm.{cst.STARTING_MODEL_REPO}, t.{cst.MODEL_ID}) = $2
+                AND t.{cst.MODEL_ID} = $2
                 AND t.{cst.AUGMENTATION_CONFIG} IS NULL
                 AND t.{cst.BASELINE_STATS} IS NOT NULL
                 AND et_sibling.{cst.ENVIRONMENT_NAMES} = et_self.{cst.ENVIRONMENT_NAMES}
             LIMIT 1
-        """, task_id, effective_model)
+        """, task_id, model_id)
         if row and row[cst.BASELINE_STATS]:
             return row[cst.BASELINE_STATS]
         return None
 
 
 async def get_matching_sibling_task_ids(
-    task_id: str, effective_model: str, psql_db: PSQLDB,
+    task_id: str, model_id: str, psql_db: PSQLDB,
 ) -> list[str]:
-    """Get task_ids of sibling tasks in the same round with matching effective
-    prep model and no augmentation config (i.e. siblings that would produce
-    identical model prep).
-
-    effective_model is starting_model_repo if set, else model_id.
-    """
+    """Get task_ids of sibling tasks in the same round with matching model_id
+    and no augmentation config (i.e. siblings that would produce identical model prep)."""
     async with await psql_db.connection() as connection:
         rows = await connection.fetch(f"""
             SELECT tt_sibling.{cst.TASK_ID}::text AS task_id
@@ -1587,15 +1572,8 @@ async def get_matching_sibling_task_ids(
                 AND tt_sibling.{cst.TASK_ID} != tt_self.{cst.TASK_ID}
             JOIN {cst.TASKS_TABLE} t
                 ON t.{cst.TASK_ID} = tt_sibling.{cst.TASK_ID}
-            LEFT JOIN LATERAL (
-                SELECT {cst.STARTING_MODEL_REPO}
-                FROM {cst.TASK_NODES_TABLE}
-                WHERE {cst.TASK_ID} = tt_sibling.{cst.TASK_ID}
-                AND {cst.STARTING_MODEL_REPO} IS NOT NULL
-                LIMIT 1
-            ) sib_sm ON true
             WHERE tt_self.{cst.TASK_ID} = $1
-                AND COALESCE(sib_sm.{cst.STARTING_MODEL_REPO}, t.{cst.MODEL_ID}) = $2
+                AND t.{cst.MODEL_ID} = $2
                 AND t.{cst.AUGMENTATION_CONFIG} IS NULL
-        """, task_id, effective_model)
+        """, task_id, model_id)
         return [row["task_id"] for row in rows]

--- a/validator/db/sql/tournaments.py
+++ b/validator/db/sql/tournaments.py
@@ -1553,7 +1553,7 @@ async def get_sibling_env_baseline_stats(
             LEFT JOIN LATERAL (
                 SELECT {cst.STARTING_MODEL_REPO}
                 FROM {cst.TASK_NODES_TABLE}
-                WHERE {cst.TASK_ID} = tt_sibling.{cst.TASK_ID}::text
+                WHERE {cst.TASK_ID} = tt_sibling.{cst.TASK_ID}
                 AND {cst.STARTING_MODEL_REPO} IS NOT NULL
                 LIMIT 1
             ) sib_sm ON true
@@ -1590,7 +1590,7 @@ async def get_matching_sibling_task_ids(
             LEFT JOIN LATERAL (
                 SELECT {cst.STARTING_MODEL_REPO}
                 FROM {cst.TASK_NODES_TABLE}
-                WHERE {cst.TASK_ID} = tt_sibling.{cst.TASK_ID}::text
+                WHERE {cst.TASK_ID} = tt_sibling.{cst.TASK_ID}
                 AND {cst.STARTING_MODEL_REPO} IS NOT NULL
                 LIMIT 1
             ) sib_sm ON true

--- a/validator/tournament/orchestrator.py
+++ b/validator/tournament/orchestrator.py
@@ -1067,15 +1067,11 @@ async def _recover_model_prep_from_trainer(task, config: Config) -> bool:
 async def _recover_miner_preps_from_trainers(task, miners_needing: list[tuple[str, str]], config: Config) -> bool:
     """Check trainers for completed per-miner model prep results after a restart.
 
-    Polls each trainer for model prep jobs matching this task_id, then matches
-    by model_id to the miner's starting_model_repo. Stores recovered results
-    and returns True if any were found (caller should re-check miners_needing).
-    Also returns True if any prep is still in progress on a trainer.
+    Polls each trainer for each miner's prep job (keyed by task_id + hotkey).
+    Stores recovered results and returns True if any were found or still in progress.
     """
     task_id_str = str(task.task_id)
     trainers = await tournament_sql.get_trainers(config.psql_db)
-    # Build lookup: starting_model_repo → hotkey
-    repo_to_hotkey = {repo: hk for hk, repo in miners_needing}
     recovered_any = False
     in_progress = False
 
@@ -1083,24 +1079,23 @@ async def _recover_miner_preps_from_trainers(task, miners_needing: list[tuple[st
         trainer_ip = trainer.trainer_ip
         trainer_ip_with_port = f"{trainer_ip}:8001" if ":" not in trainer_ip else trainer_ip
 
-        try:
-            url = f"http://{trainer_ip_with_port}{MODEL_PREP_STATUS_ENDPOINT.format(task_id=task_id_str)}"
-            async with httpx.AsyncClient(timeout=_MODEL_PREP_STATUS_TIMEOUT) as client:
-                response = await client.get(url)
-                if response.status_code == 404:
-                    continue
-                response.raise_for_status()
-                job = ModelPrepJob.model_validate(response.json())
-        except Exception:
-            continue
+        for hotkey, _starting_model in miners_needing:
+            try:
+                url = f"http://{trainer_ip_with_port}{MODEL_PREP_STATUS_ENDPOINT.format(task_id=task_id_str)}"
+                async with httpx.AsyncClient(timeout=_MODEL_PREP_STATUS_TIMEOUT) as client:
+                    response = await client.get(url, params={"hotkey": hotkey})
+                    if response.status_code == 404:
+                        continue
+                    response.raise_for_status()
+                    job = ModelPrepJob.model_validate(response.json())
+            except Exception:
+                continue
 
-        if job.status == TaskStatus.TRAINING:
-            in_progress = True
-            continue
+            if job.status == TaskStatus.TRAINING:
+                in_progress = True
+                continue
 
-        if job.status == TaskStatus.SUCCESS and job.result is not None and job.result.baseline_stats:
-            hotkey = repo_to_hotkey.get(job.model_id)
-            if hotkey:
+            if job.status == TaskStatus.SUCCESS and job.result is not None and job.result.baseline_stats:
                 await task_sql.set_miner_baseline_stats(
                     task_id_str, hotkey, job.result.baseline_stats, config.psql_db,
                 )
@@ -1187,6 +1182,7 @@ async def process_awaiting_model_prep_tasks(config: Config):
                 gpu_ids=gpu_ids,
                 reward_functions=reward_fns,
                 is_env_task=True,
+                hotkey=hotkey,
             )
             if prep_result is not None and prep_result.baseline_stats:
                 await task_sql.set_miner_baseline_stats(

--- a/validator/tournament/orchestrator.py
+++ b/validator/tournament/orchestrator.py
@@ -1064,6 +1064,55 @@ async def _recover_model_prep_from_trainer(task, config: Config) -> bool:
     return False
 
 
+async def _recover_miner_preps_from_trainers(task, miners_needing: list[tuple[str, str]], config: Config) -> bool:
+    """Check trainers for completed per-miner model prep results after a restart.
+
+    Polls each trainer for model prep jobs matching this task_id, then matches
+    by model_id to the miner's starting_model_repo. Stores recovered results
+    and returns True if any were found (caller should re-check miners_needing).
+    Also returns True if any prep is still in progress on a trainer.
+    """
+    task_id_str = str(task.task_id)
+    trainers = await tournament_sql.get_trainers(config.psql_db)
+    # Build lookup: starting_model_repo → hotkey
+    repo_to_hotkey = {repo: hk for hk, repo in miners_needing}
+    recovered_any = False
+    in_progress = False
+
+    for trainer in trainers:
+        trainer_ip = trainer.trainer_ip
+        trainer_ip_with_port = f"{trainer_ip}:8001" if ":" not in trainer_ip else trainer_ip
+
+        try:
+            url = f"http://{trainer_ip_with_port}{MODEL_PREP_STATUS_ENDPOINT.format(task_id=task_id_str)}"
+            async with httpx.AsyncClient(timeout=_MODEL_PREP_STATUS_TIMEOUT) as client:
+                response = await client.get(url)
+                if response.status_code == 404:
+                    continue
+                response.raise_for_status()
+                job = ModelPrepJob.model_validate(response.json())
+        except Exception:
+            continue
+
+        if job.status == TaskStatus.TRAINING:
+            in_progress = True
+            continue
+
+        if job.status == TaskStatus.SUCCESS and job.result is not None and job.result.baseline_stats:
+            hotkey = repo_to_hotkey.get(job.model_id)
+            if hotkey:
+                await task_sql.set_miner_baseline_stats(
+                    task_id_str, hotkey, job.result.baseline_stats, config.psql_db,
+                )
+                logger.info(
+                    f"Recovered per-miner baseline_stats for task {task.task_id} "
+                    f"hotkey={hotkey[:8]}... from trainer {trainer_ip}"
+                )
+                recovered_any = True
+
+    return recovered_any or in_progress
+
+
 async def _try_reuse_sibling_model_prep(task, config: Config) -> bool:
     """For env tasks with no augmentation and no per-miner starting models,
     try to copy baseline_stats from a sibling in the same round, or skip if
@@ -1242,6 +1291,10 @@ async def process_awaiting_model_prep_tasks(config: Config):
                             task_id_str, config.psql_db,
                         )
                         if miners_needing:
+                            # Try to recover completed results from trainers (e.g. after restart)
+                            if await _recover_miner_preps_from_trainers(task, miners_needing, config):
+                                continue  # Re-check on next cycle
+
                             gpu_req = get_tournament_gpu_requirement(
                                 task.task_type, task.model_params_count or 0, task.model_id,
                             )

--- a/validator/tournament/orchestrator.py
+++ b/validator/tournament/orchestrator.py
@@ -1115,6 +1115,54 @@ async def process_awaiting_model_prep_tasks(config: Config):
     from validator.utils.model_prep import dispatch_augmentation_and_stats
     from validator.tournament.utils import get_tournament_gpu_requirement
 
+    # Track per-miner preps independently: "task_id:hotkey"
+    _miner_prep_in_progress: set[str] = set()
+
+    async def _run_miner_prep(task, hotkey, starting_model, trainer_ip, gpu_ids):
+        """Run model prep for a single miner's starting model. Releases GPUs when done."""
+        task_id_str = str(task.task_id)
+        prep_key = f"{task_id_str}:{hotkey}"
+        try:
+            logger.info(
+                f"Running per-miner model prep for task {task.task_id} "
+                f"hotkey={hotkey[:8]}... model={starting_model}"
+            )
+            reward_fns = getattr(task, "reward_functions", None)
+            prep_result = await dispatch_augmentation_and_stats(
+                task_id=task_id_str,
+                model_id=starting_model,
+                training_data_url=task.training_data,
+                augmentation_config=task.augmentation_config,
+                task_type=task.task_type,
+                trainer_ip=trainer_ip,
+                gpu_ids=gpu_ids,
+                reward_functions=reward_fns,
+                is_env_task=True,
+            )
+            if prep_result is not None and prep_result.baseline_stats:
+                await task_sql.set_miner_baseline_stats(
+                    task_id_str, hotkey, prep_result.baseline_stats, config.psql_db,
+                )
+                logger.info(f"Stored baseline_stats for task {task.task_id} hotkey={hotkey[:8]}...")
+            else:
+                logger.warning(
+                    f"Model prep returned no baseline_stats for task {task.task_id} "
+                    f"hotkey={hotkey[:8]}..., will retry next cycle"
+                )
+        except Exception as e:
+            logger.error(
+                f"Per-miner model prep failed for task {task.task_id} hotkey={hotkey[:8]}...: {e}",
+                exc_info=True,
+            )
+        finally:
+            _miner_prep_in_progress.discard(prep_key)
+            try:
+                await tournament_sql.update_gpu_availability(
+                    trainer_ip, gpu_ids, 0, config.psql_db
+                )
+            except Exception:
+                pass
+
     async def _run_single_prep(task_id_str, model_id, task, trainer_ip, gpu_ids):
         """Run one model prep for a given model_id and return the result."""
         reward_fns = getattr(task, "reward_functions", None)
@@ -1131,70 +1179,30 @@ async def process_awaiting_model_prep_tasks(config: Config):
             is_env_task=is_env_task,
         )
 
-    async def _run_model_prep(task, trainer_ip, gpu_ids):
+    async def _run_task_prep(task, trainer_ip, gpu_ids):
+        """Standard task-level model prep (text tasks, env round-1)."""
         task_id_str = str(task.task_id)
         try:
-            is_env_task = task.task_type == TaskType.ENVIRONMENTTASK
-            miners_needing_stats = []
-            if is_env_task:
-                miners_needing_stats = await task_sql.get_miners_needing_baseline_stats(
-                    task_id_str, config.psql_db,
-                )
+            prep_result = await _run_single_prep(
+                task_id_str, task.model_id, task, trainer_ip, gpu_ids,
+            )
+            if prep_result is not None:
+                if prep_result.augmented_model_id:
+                    task.augmented_model_id = prep_result.augmented_model_id
+                if prep_result.baseline_stats:
+                    task.baseline_stats = prep_result.baseline_stats
 
-            if miners_needing_stats:
-                # Per-miner baseline: run prep for each miner's starting model
-                for hotkey, starting_model in miners_needing_stats:
-                    logger.info(
-                        f"Running per-miner model prep for task {task.task_id} "
-                        f"hotkey={hotkey[:8]}… model={starting_model}"
-                    )
-                    prep_result = await _run_single_prep(
-                        task_id_str, starting_model, task, trainer_ip, gpu_ids,
-                    )
-                    if prep_result is not None and prep_result.baseline_stats:
-                        await task_sql.set_miner_baseline_stats(
-                            task_id_str, hotkey, prep_result.baseline_stats, config.psql_db,
-                        )
-                        logger.info(f"Stored baseline_stats for hotkey={hotkey[:8]}…")
-                    else:
-                        logger.warning(
-                            f"Model prep returned no baseline_stats for hotkey={hotkey[:8]}…, "
-                            f"will retry next cycle"
-                        )
-                        return  # Don't advance task — retry next cycle
-
-                # All miners done — store last result as task-level fallback
-                last_stats = prep_result.baseline_stats if prep_result else None
-                task.baseline_stats = last_stats
                 task.status = TaskStatus.LOOKING_FOR_NODES
                 await task_sql.update_task(task, config.psql_db)
                 logger.info(
-                    f"Per-miner model prep complete for task {task.task_id} "
-                    f"({len(miners_needing_stats)} miners), "
+                    f"Model prep complete for task {task.task_id}, "
                     f"moved to {TaskStatus.LOOKING_FOR_NODES.value}"
                 )
             else:
-                # Standard task-level prep (text tasks, or env tasks without starting models)
-                prep_result = await _run_single_prep(
-                    task_id_str, task.model_id, task, trainer_ip, gpu_ids,
+                logger.warning(
+                    f"Model prep dispatch returned None for task {task.task_id}, "
+                    f"will retry next cycle"
                 )
-                if prep_result is not None:
-                    if prep_result.augmented_model_id:
-                        task.augmented_model_id = prep_result.augmented_model_id
-                    if prep_result.baseline_stats:
-                        task.baseline_stats = prep_result.baseline_stats
-
-                    task.status = TaskStatus.LOOKING_FOR_NODES
-                    await task_sql.update_task(task, config.psql_db)
-                    logger.info(
-                        f"Model prep complete for task {task.task_id}, "
-                        f"moved to {TaskStatus.LOOKING_FOR_NODES.value}"
-                    )
-                else:
-                    logger.warning(
-                        f"Model prep dispatch returned None for task {task.task_id}, "
-                        f"will retry next cycle"
-                    )
         except Exception as e:
             logger.error(
                 f"Model prep failed for task {task.task_id}: {e}",
@@ -1207,7 +1215,7 @@ async def process_awaiting_model_prep_tasks(config: Config):
                     trainer_ip, gpu_ids, 0, config.psql_db
                 )
             except Exception:
-                pass  # Periodic sync will clean up
+                pass
 
     while True:
         try:
@@ -1224,12 +1232,50 @@ async def process_awaiting_model_prep_tasks(config: Config):
 
             for task in tasks:
                 task_id_str = str(task.task_id)
-                if task_id_str in _model_prep_in_progress:
-                    continue
 
                 with LogContext(task_id=task_id_str):
-                    # Check if a trainer already has a completed result
-                    # (e.g. from before a vali restart)
+                    is_env_task = task.task_type == TaskType.ENVIRONMENTTASK
+
+                    # --- Per-miner prep path (continuous training) ---
+                    if is_env_task:
+                        miners_needing = await task_sql.get_miners_needing_baseline_stats(
+                            task_id_str, config.psql_db,
+                        )
+                        if miners_needing:
+                            gpu_req = get_tournament_gpu_requirement(
+                                task.task_type, task.model_params_count or 0, task.model_id,
+                            )
+                            for hotkey, starting_model in miners_needing:
+                                prep_key = f"{task_id_str}:{hotkey}"
+                                if prep_key in _miner_prep_in_progress:
+                                    continue
+                                suitable = await _check_suitable_gpus(config, gpu_req)
+                                if suitable is None:
+                                    continue
+                                trainer_ip, gpu_ids = suitable
+                                await tournament_sql.update_gpu_availability(
+                                    trainer_ip, gpu_ids, cst.MODEL_PREP_GPU_RESERVE_HOURS, config.psql_db
+                                )
+                                _miner_prep_in_progress.add(prep_key)
+                                asyncio.create_task(
+                                    _run_miner_prep(task, hotkey, starting_model, trainer_ip, gpu_ids)
+                                )
+                            continue
+
+                        # No miners need stats — check if per-miner task is fully done
+                        if await task_sql.has_miners_with_starting_model(task_id_str, config.psql_db):
+                            task.status = TaskStatus.LOOKING_FOR_NODES
+                            await task_sql.update_task(task, config.psql_db)
+                            logger.info(
+                                f"All per-miner baseline_stats complete for task {task.task_id}, "
+                                f"moved to {TaskStatus.LOOKING_FOR_NODES.value}"
+                            )
+                            continue
+
+                    # --- Standard task-level prep path ---
+                    if task_id_str in _model_prep_in_progress:
+                        continue
+
                     recovered = await _recover_model_prep_from_trainer(task, config)
                     if recovered:
                         continue
@@ -1253,7 +1299,7 @@ async def process_awaiting_model_prep_tasks(config: Config):
 
                     _model_prep_in_progress.add(task_id_str)
                     try:
-                        asyncio.create_task(_run_model_prep(task, trainer_ip, gpu_ids))
+                        asyncio.create_task(_run_task_prep(task, trainer_ip, gpu_ids))
                     except Exception:
                         _model_prep_in_progress.discard(task_id_str)
                         await tournament_sql.update_gpu_availability(

--- a/validator/tournament/orchestrator.py
+++ b/validator/tournament/orchestrator.py
@@ -641,6 +641,10 @@ async def _create_training_request(
     starting_model = await task_sql.get_starting_model_repo(str(task.task_id), hotkey, config.psql_db)
     training_model = starting_model or task.augmented_model_id or task.model_id
 
+    # Per-miner baseline_stats (env continuous training), fall back to task-level
+    miner_stats = await task_sql.get_miner_baseline_stats(str(task.task_id), hotkey, config.psql_db)
+    baseline_stats = miner_stats or task.baseline_stats
+
     if task.task_type == TaskType.IMAGETASK:
         training_data = TrainRequestImage(
             model=training_model,
@@ -649,7 +653,7 @@ async def _create_training_request(
             expected_repo_name=expected_repo_name,
             dataset_zip=task.training_data,
             model_type=task.model_type,
-            baseline_stats=task.baseline_stats,
+            baseline_stats=baseline_stats,
         )
     else:
         dataset_type = _get_dataset_type(task)
@@ -662,7 +666,7 @@ async def _create_training_request(
             dataset=task.training_data,
             dataset_type=dataset_type,
             file_format=FileFormat.S3,  # always an S3 since we task prep
-            baseline_stats=task.baseline_stats,
+            baseline_stats=baseline_stats,
         )
 
     return TrainerProxyRequest(
@@ -1061,11 +1065,12 @@ async def _recover_model_prep_from_trainer(task, config: Config) -> bool:
 
 
 async def _try_reuse_sibling_model_prep(task, config: Config) -> bool:
-    """For env tasks with no augmentation, try to copy baseline_stats from a
-    sibling in the same round, or skip if a sibling is already running prep.
+    """For env tasks with no augmentation and no per-miner starting models,
+    try to copy baseline_stats from a sibling in the same round, or skip if
+    a sibling is already running prep.
 
-    Matches on effective prep model (starting_model_repo if set, else model_id)
-    so that tasks continuing from different checkpoints don't share baselines.
+    Skipped entirely when miners have per-miner starting models (continuous
+    training), since each miner needs their own baseline.
 
     Returns True if the task was handled (copied or should wait), False to proceed normally.
     """
@@ -1073,11 +1078,16 @@ async def _try_reuse_sibling_model_prep(task, config: Config) -> bool:
         return False
 
     task_id_str = str(task.task_id)
-    effective_model = await task_sql.get_effective_prep_model(
-        task_id_str, task.model_id, config.psql_db,
+
+    # Per-miner starting models → each miner needs their own baseline, no reuse
+    miners_with_starting = await task_sql.get_miners_needing_baseline_stats(
+        task_id_str, config.psql_db,
     )
+    if miners_with_starting:
+        return False
+
     sibling_stats = await tournament_sql.get_sibling_env_baseline_stats(
-        task_id_str, effective_model, config.psql_db,
+        task_id_str, task.model_id, config.psql_db,
     )
     if sibling_stats is not None:
         task.baseline_stats = sibling_stats
@@ -1086,7 +1096,7 @@ async def _try_reuse_sibling_model_prep(task, config: Config) -> bool:
         logger.info(f"Copied baseline_stats from sibling for env task {task.task_id}, skipping model prep")
         return True
 
-    sibling_ids = await tournament_sql.get_matching_sibling_task_ids(task_id_str, effective_model, config.psql_db)
+    sibling_ids = await tournament_sql.get_matching_sibling_task_ids(task_id_str, task.model_id, config.psql_db)
     if any(sid in _model_prep_in_progress for sid in sibling_ids):
         return True
 
@@ -1105,44 +1115,86 @@ async def process_awaiting_model_prep_tasks(config: Config):
     from validator.utils.model_prep import dispatch_augmentation_and_stats
     from validator.tournament.utils import get_tournament_gpu_requirement
 
+    async def _run_single_prep(task_id_str, model_id, task, trainer_ip, gpu_ids):
+        """Run one model prep for a given model_id and return the result."""
+        reward_fns = getattr(task, "reward_functions", None)
+        is_env_task = task.task_type == TaskType.ENVIRONMENTTASK
+        return await dispatch_augmentation_and_stats(
+            task_id=task_id_str,
+            model_id=model_id,
+            training_data_url=task.training_data,
+            augmentation_config=task.augmentation_config,
+            task_type=task.task_type,
+            trainer_ip=trainer_ip,
+            gpu_ids=gpu_ids,
+            reward_functions=reward_fns,
+            is_env_task=is_env_task,
+        )
+
     async def _run_model_prep(task, trainer_ip, gpu_ids):
         task_id_str = str(task.task_id)
         try:
-            reward_fns = getattr(task, "reward_functions", None)
             is_env_task = task.task_type == TaskType.ENVIRONMENTTASK
+            miners_needing_stats = []
+            if is_env_task:
+                miners_needing_stats = await task_sql.get_miners_needing_baseline_stats(
+                    task_id_str, config.psql_db,
+                )
 
-            effective_model = await task_sql.get_effective_prep_model(
-                task_id_str, task.model_id, config.psql_db,
-            )
-            prep_result = await dispatch_augmentation_and_stats(
-                task_id=task_id_str,
-                model_id=effective_model,
-                training_data_url=task.training_data,
-                augmentation_config=task.augmentation_config,
-                task_type=task.task_type,
-                trainer_ip=trainer_ip,
-                gpu_ids=gpu_ids,
-                reward_functions=reward_fns,
-                is_env_task=is_env_task,
-            )
+            if miners_needing_stats:
+                # Per-miner baseline: run prep for each miner's starting model
+                for hotkey, starting_model in miners_needing_stats:
+                    logger.info(
+                        f"Running per-miner model prep for task {task.task_id} "
+                        f"hotkey={hotkey[:8]}… model={starting_model}"
+                    )
+                    prep_result = await _run_single_prep(
+                        task_id_str, starting_model, task, trainer_ip, gpu_ids,
+                    )
+                    if prep_result is not None and prep_result.baseline_stats:
+                        await task_sql.set_miner_baseline_stats(
+                            task_id_str, hotkey, prep_result.baseline_stats, config.psql_db,
+                        )
+                        logger.info(f"Stored baseline_stats for hotkey={hotkey[:8]}…")
+                    else:
+                        logger.warning(
+                            f"Model prep returned no baseline_stats for hotkey={hotkey[:8]}…, "
+                            f"will retry next cycle"
+                        )
+                        return  # Don't advance task — retry next cycle
 
-            if prep_result is not None:
-                if prep_result.augmented_model_id:
-                    task.augmented_model_id = prep_result.augmented_model_id
-                if prep_result.baseline_stats:
-                    task.baseline_stats = prep_result.baseline_stats
-
+                # All miners done — store last result as task-level fallback
+                last_stats = prep_result.baseline_stats if prep_result else None
+                task.baseline_stats = last_stats
                 task.status = TaskStatus.LOOKING_FOR_NODES
                 await task_sql.update_task(task, config.psql_db)
                 logger.info(
-                    f"Model prep complete for task {task.task_id}, "
+                    f"Per-miner model prep complete for task {task.task_id} "
+                    f"({len(miners_needing_stats)} miners), "
                     f"moved to {TaskStatus.LOOKING_FOR_NODES.value}"
                 )
             else:
-                logger.warning(
-                    f"Model prep dispatch returned None for task {task.task_id}, "
-                    f"will retry next cycle"
+                # Standard task-level prep (text tasks, or env tasks without starting models)
+                prep_result = await _run_single_prep(
+                    task_id_str, task.model_id, task, trainer_ip, gpu_ids,
                 )
+                if prep_result is not None:
+                    if prep_result.augmented_model_id:
+                        task.augmented_model_id = prep_result.augmented_model_id
+                    if prep_result.baseline_stats:
+                        task.baseline_stats = prep_result.baseline_stats
+
+                    task.status = TaskStatus.LOOKING_FOR_NODES
+                    await task_sql.update_task(task, config.psql_db)
+                    logger.info(
+                        f"Model prep complete for task {task.task_id}, "
+                        f"moved to {TaskStatus.LOOKING_FOR_NODES.value}"
+                    )
+                else:
+                    logger.warning(
+                        f"Model prep dispatch returned None for task {task.task_id}, "
+                        f"will retry next cycle"
+                    )
         except Exception as e:
             logger.error(
                 f"Model prep failed for task {task.task_id}: {e}",

--- a/validator/tournament/orchestrator.py
+++ b/validator/tournament/orchestrator.py
@@ -1064,14 +1064,20 @@ async def _try_reuse_sibling_model_prep(task, config: Config) -> bool:
     """For env tasks with no augmentation, try to copy baseline_stats from a
     sibling in the same round, or skip if a sibling is already running prep.
 
+    Matches on effective prep model (starting_model_repo if set, else model_id)
+    so that tasks continuing from different checkpoints don't share baselines.
+
     Returns True if the task was handled (copied or should wait), False to proceed normally.
     """
     if task.task_type != TaskType.ENVIRONMENTTASK or task.augmentation_config is not None:
         return False
 
     task_id_str = str(task.task_id)
-    sibling_stats = await tournament_sql.get_sibling_env_baseline_stats(
+    effective_model = await task_sql.get_effective_prep_model(
         task_id_str, task.model_id, config.psql_db,
+    )
+    sibling_stats = await tournament_sql.get_sibling_env_baseline_stats(
+        task_id_str, effective_model, config.psql_db,
     )
     if sibling_stats is not None:
         task.baseline_stats = sibling_stats
@@ -1080,7 +1086,7 @@ async def _try_reuse_sibling_model_prep(task, config: Config) -> bool:
         logger.info(f"Copied baseline_stats from sibling for env task {task.task_id}, skipping model prep")
         return True
 
-    sibling_ids = await tournament_sql.get_matching_sibling_task_ids(task_id_str, task.model_id, config.psql_db)
+    sibling_ids = await tournament_sql.get_matching_sibling_task_ids(task_id_str, effective_model, config.psql_db)
     if any(sid in _model_prep_in_progress for sid in sibling_ids):
         return True
 
@@ -1105,9 +1111,12 @@ async def process_awaiting_model_prep_tasks(config: Config):
             reward_fns = getattr(task, "reward_functions", None)
             is_env_task = task.task_type == TaskType.ENVIRONMENTTASK
 
+            effective_model = await task_sql.get_effective_prep_model(
+                task_id_str, task.model_id, config.psql_db,
+            )
             prep_result = await dispatch_augmentation_and_stats(
                 task_id=task_id_str,
-                model_id=task.model_id,
+                model_id=effective_model,
                 training_data_url=task.training_data,
                 augmentation_config=task.augmentation_config,
                 task_type=task.task_type,

--- a/validator/utils/model_prep.py
+++ b/validator/utils/model_prep.py
@@ -44,6 +44,7 @@ async def dispatch_augmentation_and_stats(
     gpu_ids: list[int],
     reward_functions=None,
     is_env_task: bool = False,
+    hotkey: str | None = None,
 ) -> ModelPrepResponse | None:
     """Dispatch augmentation and stats collection to a trainer with GPU.
 
@@ -66,6 +67,7 @@ async def dispatch_augmentation_and_stats(
         gpu_ids=gpu_ids,
         reward_functions=reward_functions,
         env_configs=_build_env_configs() if is_env_task else None,
+        hotkey=hotkey,
     )
 
     url = f"http://{trainer_ip_with_port}{MODEL_PREP_ENDPOINT}"


### PR DESCRIPTION
## Summary
- Model prep was computing one shared baseline per task against the base model. For continuous training (R2+), each miner continues from their own checkpoint and needs their own baseline_stats computed against their starting model.
- Per-miner preps now dispatch independently with their own GPU allocation. Task advances only when all miners have baseline_stats.
- Round 1 / text / image tournaments unchanged — shared task-level baseline via sibling reuse.

## Changes
- **Schema**: `ALTER TABLE task_nodes ADD COLUMN baseline_stats JSONB`
- **`tasks.py`**: `get_miners_needing_baseline_stats`, `set_miner_baseline_stats`, `get_miner_baseline_stats`, `has_miners_with_starting_model`, `get_effective_prep_model`
- **`orchestrator.py`**: `_run_miner_prep` (per-miner, independent GPU), `_run_task_prep` (task-level), `_recover_miner_preps_from_trainers` (restart recovery), main loop split into per-miner vs task-level paths, `_create_training_request` pulls per-miner stats with task-level fallback
- **`tournaments.py`**: sibling queries reverted to simple model_id matching (sibling reuse skipped for per-miner tasks)
- **`payload_models.py`**: `hotkey` field on `ModelPrepRequest` / `ModelPrepJob` for per-miner keying
- **`trainer/tasks.py`** + **`endpoints.py`**: hotkey threaded through model prep start/complete/status
- **`model_prep.py`**: `hotkey` param passed through to trainer
- **`trainer_downloader.py`**: fall back to base tokenizer when LoRA adapter dir has no tokenizer files