### PR TITLE
fix: resolve chained LoRA adapters in downloader and upload

### DIFF
--- a/trainer/utils/hf_upload.py
+++ b/trainer/utils/hf_upload.py
@@ -10,11 +10,35 @@ import wandb
 from huggingface_hub import HfApi, login
 
 
+def _resolve_base_model(model_id: str) -> str:
+    """If model_id is a LoRA adapter repo, follow the chain to the real base model."""
+    from huggingface_hub import hf_hub_download
+    resolved = model_id
+    for _ in range(10):
+        try:
+            cfg_path = hf_hub_download(resolved, "adapter_config.json")
+            with open(cfg_path) as f:
+                parent = json.load(f).get("base_model_name_or_path")
+            if not parent:
+                break
+            print(f"[upload] Resolving LoRA chain: {resolved} -> {parent}", flush=True)
+            resolved = parent
+        except Exception:
+            break
+    return resolved
+
+
 def patch_model_metadata(output_dir: str, base_model_id: str):
     try:
         adapter_config_path = os.path.join(output_dir, "adapter_config.json")
 
         if os.path.exists(adapter_config_path):
+            # Resolve chained LoRA refs to the real base model
+            real_base = _resolve_base_model(base_model_id)
+            if real_base != base_model_id:
+                print(f"[upload] Resolved base model: {base_model_id} -> {real_base}", flush=True)
+                base_model_id = real_base
+
             with open(adapter_config_path, "r") as f:
                 config = json.load(f)
 

--- a/trainer/utils/trainer_downloader.py
+++ b/trainer/utils/trainer_downloader.py
@@ -153,6 +153,25 @@ def _detect_and_merge_lora(model_dir: str) -> None:
         print(f"WARNING: {LORA_ADAPTER_CONFIG} missing base_model_name_or_path, skipping merge", flush=True)
         return
 
+    # Resolve LoRA chains: if base_model_id is itself a LoRA adapter, follow
+    # the chain until we find the real base model.
+    resolved_base = base_model_id
+    for _ in range(10):  # max depth guard
+        try:
+            remote_adapter = hf_hub_download(resolved_base, LORA_ADAPTER_CONFIG)
+            with open(remote_adapter) as f:
+                parent_config = json.load(f)
+            parent_base = parent_config.get("base_model_name_or_path")
+            if not parent_base:
+                break
+            print(f"[downloader] Chained LoRA: {resolved_base} -> {parent_base}", flush=True)
+            resolved_base = parent_base
+        except Exception:
+            break  # Not a LoRA repo — this is the real base model
+    if resolved_base != base_model_id:
+        print(f"[downloader] Resolved LoRA chain: {base_model_id} -> {resolved_base}", flush=True)
+        base_model_id = resolved_base
+
     print(f"[downloader] LoRA adapter detected in {model_dir}", flush=True)
     print(f"[downloader] Base model: {base_model_id}", flush=True)
 


### PR DESCRIPTION
## Summary
- Downloader: when a LoRA adapter's `base_model_name_or_path` points to another LoRA adapter (chained from continuous training rounds), follow the chain to find the real base model before merging.
- Upload: before writing `adapter_config.json`, resolve the same chain so future downloads don't need to.

This prevents download failures when R3 LoRA → R2 LoRA → R1 LoRA → base model.