### PR TITLE
Pass baseline_stats via file instead of env var to avoid ARG_MAX

### DIFF
--- a/trainer/image_manager.py
+++ b/trainer/image_manager.py
@@ -185,7 +185,11 @@ async def run_trainer_container_image(
 
     environment: dict[str, str] = {"TRANSFORMERS_CACHE": cst.HUGGINGFACE_CACHE_PATH}
     if baseline_stats:
-        environment["BASELINE_STATS"] = json.dumps(baseline_stats.model_dump())
+        vol = client.volumes.get(cst.CACHE_VOLUME_NAME)
+        stats_filename = f"baseline_stats_{task_id}.json"
+        with open(os.path.join(vol.attrs["Mountpoint"], stats_filename), "w") as f:
+            json.dump(baseline_stats.model_dump(), f)
+        environment["BASELINE_STATS_PATH"] = os.path.join(cst.CACHE_ROOT_PATH, stats_filename)
 
     container_name = f"image-trainer-{uuid.uuid4().hex}"
 
@@ -260,7 +264,11 @@ async def run_trainer_container_text(
 
     environment = build_wandb_env(task_id, hotkey)
     if baseline_stats:
-        environment["BASELINE_STATS"] = json.dumps(baseline_stats.model_dump())
+        vol = client.volumes.get(cst.CACHE_VOLUME_NAME)
+        stats_filename = f"baseline_stats_{task_id}_{hotkey[:8]}.json"
+        with open(os.path.join(vol.attrs["Mountpoint"], stats_filename), "w") as f:
+            json.dump(baseline_stats.model_dump(), f)
+        environment["BASELINE_STATS_PATH"] = os.path.join(cst.CACHE_ROOT_PATH, stats_filename)
     if env_server_urls:
         environment["ENVIRONMENT_SERVER_URLS"] = env_server_urls
     if miner_datasets:


### PR DESCRIPTION
Large models (9B+) produce baseline_stats JSON exceeding Linux's ARG_MAX limit when passed as a Docker environment variable, causing "argument list too long" container failures. Write to a JSON file in the cache volume and pass BASELINE_STATS_PATH instead.