### PR TITLE
fix: add missing migration for task_nodes.baseline_stats

### DIFF
--- a/validator/db/migrations/20260530120000_add_baseline_stats_to_task_nodes.sql
+++ b/validator/db/migrations/20260530120000_add_baseline_stats_to_task_nodes.sql
@@ -1,0 +1,7 @@
+-- migrate:up
+ALTER TABLE task_nodes
+    ADD COLUMN baseline_stats JSONB DEFAULT NULL;
+
+-- migrate:down
+ALTER TABLE task_nodes
+    DROP COLUMN IF EXISTS baseline_stats;


### PR DESCRIPTION
Column was applied manually to prod when the feature landed in #1143. This adds the missing migration file.