### PR TITLE
Make weight projection placement-aware and env-correct

### DIFF
--- a/core/models/tournament_models.py
+++ b/core/models/tournament_models.py
@@ -523,6 +523,12 @@ class TournamentProjection(BaseModel):
     current_champion_decay: float
     initial_weight: float
     projections: list[WeightProjection]
+    # "champion" if the projected performance dethrones the boss, else "runner_up"
+    placement: str = "champion"
+    # Performance margin (env: win rate) the challenger must exceed to take the crown
+    dethrone_threshold: float = 0.0
+    # Emission boost applied on top of base weight (0 when runner_up or below boost threshold)
+    emission_boost: float = 0.0
 
 
 class WeightProjectionResponse(BaseModel):

--- a/validator/core/weight_setting.py
+++ b/validator/core/weight_setting.py
@@ -87,6 +87,20 @@ def calculate_emission_boost_from_perf(performance_diff: float | None) -> float:
     return emission_increase
 
 
+def calculate_env_perf_diff_from_win_pct(win_pct: float) -> float:
+    """
+    Map an environment-tournament win percentage (0.0-1.0) to a performance
+    difference, using the same PvP mapping the scoring pipeline applies.
+
+    Below the win-rate threshold the challenger gains no emission boost; above it
+    the perf diff scales linearly so 100% win rate hits the max boost.
+    """
+    win_pct = max(0.0, win_pct)
+    if win_pct < cts.PVP_WIN_PCT_THRESHOLD:
+        return 0.0
+    return cts.EMISSION_MULTIPLIER_THRESHOLD + (win_pct - cts.PVP_WIN_PCT_THRESHOLD) * cts.PVP_PERF_DIFF_SLOPE
+
+
 def calculate_tournament_weight_with_decay(
     tournament_type: TournamentType,
     base_weight: float,

--- a/validator/endpoints/performance.py
+++ b/validator/endpoints/performance.py
@@ -137,6 +137,7 @@ async def get_latest_tournament_weights(config: Config = Depends(get_config)) ->
 @router.get("/v1/performance/weight-projection")
 async def get_weight_projection(
     percentage_improvement: float,
+    environment_win_pct: float = 80.0,
     config: Config = Depends(get_config),
 ) -> WeightProjectionResponse:
     text_projection = await calculate_tournament_projection(
@@ -155,12 +156,14 @@ async def get_weight_projection(
         cts.MAX_IMAGE_TOURNAMENT_WEIGHT,
     )
 
+    # Environment tournaments are PvP: the input is a win rate (%), not a score improvement.
     environment_projection = await calculate_tournament_projection(
         config.psql_db,
         TournamentType.ENVIRONMENT,
         percentage_improvement,
         cts.TOURNAMENT_ENVIRONMENT_WEIGHT,
         cts.MAX_ENVIRONMENT_TOURNAMENT_WEIGHT,
+        win_pct=environment_win_pct / 100.0,
     )
 
     return WeightProjectionResponse(

--- a/validator/tournament/performance_calculator.py
+++ b/validator/tournament/performance_calculator.py
@@ -142,13 +142,12 @@ async def calculate_boss_round_performance_differences(tournament_id: str, psql_
             continue
 
         if task_obj.task_type == TaskType.ENVIRONMENTTASK:
+            # Local import breaks the weight_setting <-> performance_calculator import cycle.
+            from validator.core.weight_setting import calculate_env_perf_diff_from_win_pct
+
             num_envs = len(task_obj.environment_names) if task_obj.environment_names else 1
             win_pct = (2 * challenger_score + boss_score - 3 * num_envs) / (3 * num_envs)
-            win_pct = max(0.0, win_pct)
-            if win_pct < cts.PVP_WIN_PCT_THRESHOLD:
-                perf_diff = 0.0
-            else:
-                perf_diff = cts.EMISSION_MULTIPLIER_THRESHOLD + (win_pct - cts.PVP_WIN_PCT_THRESHOLD) * cts.PVP_PERF_DIFF_SLOPE
+            perf_diff = calculate_env_perf_diff_from_win_pct(win_pct)
             challenger_won = challenger_score > boss_score
         elif is_higher_better:
             if boss_score > 0:

--- a/validator/tournament/performance_utils.py
+++ b/validator/tournament/performance_utils.py
@@ -9,6 +9,7 @@ from core.models.tournament_models import TournamentType
 from core.models.tournament_models import WeightProjection
 from validator.core.constants import EMISSION_BURN_HOTKEY
 from validator.core.weight_setting import calculate_emission_boost_from_perf
+from validator.core.weight_setting import calculate_env_perf_diff_from_win_pct
 from validator.core.weight_setting import calculate_hybrid_decays
 from validator.core.weight_setting import calculate_tournament_weight_with_decay
 from validator.db.sql.tournaments import count_champion_consecutive_wins
@@ -17,6 +18,7 @@ from validator.db.sql.tournaments import get_latest_completed_tournament
 from validator.db.sql.tournaments import get_tournament_participants
 from validator.db.sql.tournaments import get_tournament_where_champion_first_won
 from validator.evaluation.tournament_scoring import exponential_decline_mapping
+from validator.tournament.utils import get_progressive_threshold
 from validator.tournament.utils import get_real_tournament_winner
 
 
@@ -110,11 +112,24 @@ async def calculate_tournament_projection(
     percentage_improvement: float,
     base_weight: float,
     max_weight: float,
+    win_pct: float | None = None,
 ) -> TournamentProjection:
+    """
+    Project a challenger's emission for a tournament type.
+
+    For TEXT/IMAGE the input is a percentage score improvement over the boss.
+    For ENVIRONMENT the input is a win rate (``win_pct``, 0.0-1.0) mapped through
+    the PvP emission curve.
+
+    A challenger only becomes champion if they exceed the dethrone threshold;
+    below it the boss defends and the challenger projects as the 2nd-place
+    runner-up (base-pool share, no champion boost, no time decay).
+    """
     latest_tournament = await get_latest_completed_tournament(psql_db, tournament_type)
     current_champion = get_real_tournament_winner(latest_tournament) if latest_tournament else None
 
     current_champion_decay = 0.0
+    consecutive_wins = 0
     if current_champion and latest_tournament:
         consecutive_wins = await count_champion_consecutive_wins(psql_db, tournament_type, current_champion)
         first_win_tournament = await get_tournament_where_champion_first_won(psql_db, tournament_type, current_champion)
@@ -126,59 +141,91 @@ async def calculate_tournament_projection(
             )
             current_champion_decay = new_decay
 
-    # Calculate the winner's share within the tournament using participant count
+    # Determine the challenger's performance diff and whether it dethrones the boss.
+    if tournament_type == TournamentType.ENVIRONMENT:
+        effective_win_pct = win_pct if win_pct is not None else percentage_improvement / 100.0
+        performance_diff = calculate_env_perf_diff_from_win_pct(effective_win_pct)
+        dethrone_threshold = cts.PVP_WIN_PCT_THRESHOLD
+        dethrones = effective_win_pct >= cts.PVP_WIN_PCT_THRESHOLD
+    else:
+        performance_diff = percentage_improvement / 100.0
+        dethrone_threshold = get_progressive_threshold(consecutive_wins, tournament_type)
+        dethrones = performance_diff > dethrone_threshold
+
+    # Tournament-internal share by rank and the participation scale factor.
     num_participants = 0
     if latest_tournament:
         participants = await get_tournament_participants(latest_tournament.tournament_id, psql_db)
         num_participants = len(participants)
     winner_share = exponential_decline_mapping(max(num_participants, 1), 1)
 
-    # Calculate participation scale factor (same as weight_setting.py)
     active_participants = await get_active_tournament_participants(psql_db)
     participation_total = len(active_participants) * cts.TOURNAMENT_PARTICIPATION_WEIGHT
     scale_factor = 1.0 - participation_total if participation_total > 0 else 1.0
 
-    performance_diff = percentage_improvement / 100.0
-    emission_boost = calculate_emission_boost_from_perf(performance_diff)
+    projection_days = [7, 30, 90, 180]
 
-    raw_initial_weight = calculate_tournament_weight_with_decay(
-        tournament_type=tournament_type,
-        base_weight=base_weight,
-        emission_boost=emission_boost,
-        old_decay=0.0,
-        new_decay=0.0,
-        apply_hybrid=False,
-        max_weight=max_weight,
-    )
+    if dethrones:
+        emission_boost = calculate_emission_boost_from_perf(performance_diff)
 
-    # Winner's actual emission weight = winner_share * tournament_weight * scale_factor
-    initial_weight = winner_share * raw_initial_weight * scale_factor
-
-    projection_days = [1, 7, 30, 90]
-
-    projections = []
-    for days in projection_days:
-        new_decay = days * cts.EMISSION_DAILY_TIME_DECAY_RATE
-
-        raw_future_weight = calculate_tournament_weight_with_decay(
+        raw_initial_weight = calculate_tournament_weight_with_decay(
             tournament_type=tournament_type,
             base_weight=base_weight,
             emission_boost=emission_boost,
             old_decay=0.0,
-            new_decay=new_decay,
+            new_decay=0.0,
             apply_hybrid=False,
             max_weight=max_weight,
         )
+        # Winner's actual emission weight = winner_share * tournament_weight * scale_factor
+        initial_weight = winner_share * raw_initial_weight * scale_factor
 
-        weight = winner_share * raw_future_weight * scale_factor
-        cumulative_alpha = days * cts.DAILY_ALPHA_TO_MINERS * (initial_weight + weight) / 2.0
+        projections = []
+        for days in projection_days:
+            new_decay = days * cts.EMISSION_DAILY_TIME_DECAY_RATE
 
-        projections.append(WeightProjection(days=days, weight=weight, total_alpha=cumulative_alpha))
+            raw_future_weight = calculate_tournament_weight_with_decay(
+                tournament_type=tournament_type,
+                base_weight=base_weight,
+                emission_boost=emission_boost,
+                old_decay=0.0,
+                new_decay=new_decay,
+                apply_hybrid=False,
+                max_weight=max_weight,
+            )
+
+            weight = winner_share * raw_future_weight * scale_factor
+            cumulative_alpha = days * cts.DAILY_ALPHA_TO_MINERS * (initial_weight + weight) / 2.0
+
+            projections.append(WeightProjection(days=days, weight=weight, total_alpha=cumulative_alpha))
+
+        placement = "champion"
+    else:
+        # Below the dethrone threshold the boss defends; the challenger places 2nd
+        # and earns the runner-up share of the base pool (no champion boost, no decay).
+        emission_boost = 0.0
+        runner_up_share = exponential_decline_mapping(max(num_participants, 1), 2)
+        runner_up_weight = runner_up_share * base_weight * scale_factor
+        initial_weight = runner_up_weight
+
+        projections = [
+            WeightProjection(
+                days=days,
+                weight=runner_up_weight,
+                total_alpha=days * cts.DAILY_ALPHA_TO_MINERS * runner_up_weight,
+            )
+            for days in projection_days
+        ]
+
+        placement = "runner_up"
 
     return TournamentProjection(
         tournament_type=tournament_type.value,
         current_champion_decay=current_champion_decay,
         initial_weight=initial_weight,
         projections=projections,
+        placement=placement,
+        dethrone_threshold=dethrone_threshold,
+        emission_boost=emission_boost,
     )
 


### PR DESCRIPTION
The weight-projection endpoint mapped percentage_improvement to emission identically for all tournament types. Environment tournaments are PvP and score emission off a win rate, not a relative score improvement, so env projections were wrong.

- Add calculate_env_perf_diff_from_win_pct() and reuse it in the boss-round scorer so projection and scoring can't drift.
- weight-projection takes environment_win_pct; env projects off the win-rate curve (capped via MAX_ENVIRONMENT_TOURNAMENT_WEIGHT).
- Below the dethrone threshold the challenger does not become champion: project the 2nd-place runner-up share of the base pool (no boost, no decay) instead of a winner share. Expose placement, dethrone_threshold and emission_boost.
- Projection milestones now cover 7/30/90/180 days (was 1/7/30/90).