### PR TITLE
Reject tournament tasks with high dataset near-duplicate rate

### DIFF
--- a/validator/tournament/constants.py
+++ b/validator/tournament/constants.py
@@ -15,6 +15,10 @@ PERIODIC_GPU_AVAILABILITY_UPDATE_INTERVAL = 60
 MODEL_PREP_CYCLE_INTERVAL = 30
 MODEL_PREP_GPU_RESERVE_HOURS = 1.0
 
+# Reject a task whose dataset near-duplicate rate (from baseline_stats) is at or above this
+# fraction. Only applies to text tasks (instruct/dpo/grpo); env tasks have no dataset stats.
+MAX_NEAR_DUPLICATE_RATE = 0.20
+
 TOURNAMENT_PENDING_CYCLE_INTERVAL = 15 * 60
 TOURNAMENT_ACTIVE_CYCLE_INTERVAL = 15 * 60
 TOURNAMENT_PENDING_ROUND_CYCLE_INTERVAL = 15 * 60

--- a/validator/tournament/orchestrator.py
+++ b/validator/tournament/orchestrator.py
@@ -995,6 +995,35 @@ _model_prep_in_progress: set[str] = set()
 _MODEL_PREP_STATUS_TIMEOUT = 5.0  # seconds — fast check, don't stall the cycle
 
 
+def _exceeds_near_duplicate_threshold(task, baseline_stats) -> bool:
+    """True if the prepped dataset's near-duplicate rate is at/above the cutoff.
+
+    Only text tasks (instruct/dpo/grpo) carry dataset stats; env tasks and any
+    stats without a dataset are never rejected. Organic tasks are exempt: we log
+    but let them proceed.
+    """
+    dataset = getattr(baseline_stats, "dataset", None)
+    if dataset is None:
+        return False
+    rate = dataset.near_duplicate_rate
+    if rate < cst.MAX_NEAR_DUPLICATE_RATE:
+        return False
+
+    if task.is_organic:
+        logger.warning(
+            f"Task {task.task_id} has near_duplicate_rate={rate:.3f} "
+            f">= {cst.MAX_NEAR_DUPLICATE_RATE} but is organic — allowing through"
+        )
+        return False
+
+    logger.warning(
+        f"Task {task.task_id} rejected: near_duplicate_rate={rate:.3f} "
+        f">= {cst.MAX_NEAR_DUPLICATE_RATE}, marking {TaskStatus.PREP_TASK_FAILURE.value} "
+        f"for replacement"
+    )
+    return True
+
+
 async def _recover_model_prep_from_trainer(task, config: Config) -> bool:
     """Check all trainers for an existing model prep job for this task.
 
@@ -1028,6 +1057,15 @@ async def _recover_model_prep_from_trainer(task, config: Config) -> bool:
                 task.augmented_model_id = job.result.augmented_model_id
             if job.result.baseline_stats:
                 task.baseline_stats = job.result.baseline_stats
+
+            if job.result.baseline_stats and _exceeds_near_duplicate_threshold(
+                task, job.result.baseline_stats
+            ):
+                task.status = TaskStatus.PREP_TASK_FAILURE
+                await task_sql.update_task(task, config.psql_db)
+                return True
+
+            if job.result.baseline_stats:
                 new_hours = apply_baseline_ctx_scale(task.hours_to_complete, task.baseline_stats)
                 task.hours_to_complete = new_hours
                 task.termination_at = datetime.utcnow() + timedelta(hours=new_hours)
@@ -1222,6 +1260,15 @@ async def process_awaiting_model_prep_tasks(config: Config):
                     task.augmented_model_id = prep_result.augmented_model_id
                 if prep_result.baseline_stats:
                     task.baseline_stats = prep_result.baseline_stats
+
+                if prep_result.baseline_stats and _exceeds_near_duplicate_threshold(
+                    task, prep_result.baseline_stats
+                ):
+                    task.status = TaskStatus.PREP_TASK_FAILURE
+                    await task_sql.update_task(task, config.psql_db)
+                    return
+
+                if prep_result.baseline_stats:
                     new_hours = apply_baseline_ctx_scale(task.hours_to_complete, task.baseline_stats)
                     task.hours_to_complete = new_hours
                     task.termination_at = datetime.utcnow() + timedelta(hours=new_hours)


### PR DESCRIPTION
Gate model prep on baseline_stats.dataset.near_duplicate_rate: at/above 20% the task is set to PREP_TASK_FAILURE, which triggers an automatic tournament replacement. Applies to both the normal prep path and the restart-recovery path. Env tasks (no dataset stats) and organic tasks are exempt; organic logs a warning and proceeds.