### PR TITLE
env scoring: dispersion-weighted per-env contributions

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -61,12 +61,19 @@ class EnvironmentConfig:
     tournament_eval_command: list[str] | None = None
     gpu_multiplier: int = 4
     eval_payload_extra: dict | None = None
+    score_ref_max: float = 1.0
+    """Reference maximum used to normalize this env's per-miner score onto a common
+    scale before combining environments. PvP envs contribute a win-rate (already in
+    [0, 1]) so the default of 1.0 is correct; INDIVIDUAL envs whose raw score is not
+    in [0, 1] should set this to their score's natural maximum."""
 
     def __post_init__(self):
         if self.eval_type == EvalType.INDIVIDUAL and not self.tournament_eval_command:
             raise ValueError(
                 "EnvironmentConfig with eval_type=INDIVIDUAL must define tournament_eval_command"
             )
+        if self.score_ref_max <= 0:
+            raise ValueError("EnvironmentConfig.score_ref_max must be positive")
 
 
 ENVIRONMENT_CONFIGS: dict[EnvironmentName, EnvironmentConfig] = {

--- a/scripts/sim_env_scoring.py
+++ b/scripts/sim_env_scoring.py
@@ -1,0 +1,112 @@
+"""Backtest: old 3/1/0 pairwise scoring vs new dispersion-weighted scoring.
+
+Replays real round-1 data from environment tournament tourn_33c30659e3c920d5_20260601
+(liars_dice head-to-head + intercode individual scores) and prints how each group's
+winner and ordering change under the new scheme.
+
+Run: .venv/bin/python scripts/sim_env_scoring.py
+"""
+
+import statistics
+
+from core.constants import EnvironmentName
+from core.models.pvp_models import PvPEnvironmentResult
+from core.models.pvp_models import PvPEvalMetadata
+from core.models.pvp_models import PvPGroupResults
+from core.models.pvp_models import PvPPairResult
+from core.models.scoring_models import EnvironmentWeight
+from validator.evaluation.tournament_scoring import accumulate_points
+from validator.evaluation.tournament_scoring import dispersion_weighted_standings
+from validator.evaluation.tournament_scoring import individual_scores_to_pairwise
+from validator.evaluation.tournament_scoring import pvp_results_to_pairwise
+from validator.evaluation.tournament_scoring import pvp_results_to_winrates
+
+
+LD = EnvironmentName.LIARS_DICE
+IC = EnvironmentName.INTERCODE
+WEIGHTS = [EnvironmentWeight(environment=LD, weight=1.0), EnvironmentWeight(environment=IC, weight=1.0)]
+
+# (hotkeys, liars_dice pairs (a, b, a_wins, b_wins), intercode scores)
+GROUPS = {
+    "group_001": (
+        ["CMZQwPd", "CRwFq2Q", "EF2nASX", "FpdSckw", "GNP9XWd", "HWPK9f6"],
+        [
+            ("CMZQwPd", "CRwFq2Q", 0, 200), ("CMZQwPd", "EF2nASX", 0, 200), ("CMZQwPd", "FpdSckw", 0, 200),
+            ("CMZQwPd", "GNP9XWd", 2, 198), ("CMZQwPd", "HWPK9f6", 111, 89), ("CRwFq2Q", "EF2nASX", 1, 199),
+            ("CRwFq2Q", "FpdSckw", 1, 199), ("CRwFq2Q", "GNP9XWd", 35, 165), ("CRwFq2Q", "HWPK9f6", 138, 62),
+            ("EF2nASX", "FpdSckw", 90, 110), ("EF2nASX", "GNP9XWd", 134, 66), ("EF2nASX", "HWPK9f6", 200, 0),
+            ("FpdSckw", "GNP9XWd", 129, 71), ("FpdSckw", "HWPK9f6", 198, 2), ("GNP9XWd", "HWPK9f6", 200, 0),
+        ],
+        {"CMZQwPd": 0.791, "CRwFq2Q": 0.749, "EF2nASX": 0.729, "GNP9XWd": 0.721, "HWPK9f6": 0.719, "FpdSckw": 0.709},
+    ),
+    "group_002": (
+        ["CoNpVXZ", "CUgn1rt", "D2Qee4V", "EgpWgYv", "FRdgPRd", "HKEAZxF"],
+        [
+            ("CoNpVXZ", "D2Qee4V", 1, 199), ("CoNpVXZ", "EgpWgYv", 1, 199), ("CoNpVXZ", "FRdgPRd", 1, 199),
+            ("CoNpVXZ", "HKEAZxF", 2, 198), ("CUgn1rt", "CoNpVXZ", 200, 0), ("CUgn1rt", "D2Qee4V", 1, 199),
+            ("CUgn1rt", "EgpWgYv", 1, 199), ("CUgn1rt", "FRdgPRd", 1, 199), ("CUgn1rt", "HKEAZxF", 1, 199),
+            ("D2Qee4V", "EgpWgYv", 99, 101), ("D2Qee4V", "FRdgPRd", 105, 95), ("D2Qee4V", "HKEAZxF", 200, 0),
+            ("EgpWgYv", "FRdgPRd", 107, 93), ("EgpWgYv", "HKEAZxF", 121, 79), ("FRdgPRd", "HKEAZxF", 131, 69),
+        ],
+        {"D2Qee4V": 0.76, "HKEAZxF": 0.74, "FRdgPRd": 0.73, "CUgn1rt": 0.72, "EgpWgYv": 0.72, "CoNpVXZ": 0.71},
+    ),
+    "group_006": (
+        ["Ca32LwM", "CyKEP2X", "CZtSFWz", "FWLwQ2G", "GbMFGZS"],
+        [
+            ("Ca32LwM", "CyKEP2X", 198, 2), ("Ca32LwM", "FWLwQ2G", 2, 198), ("Ca32LwM", "GbMFGZS", 200, 0),
+            ("CyKEP2X", "FWLwQ2G", 0, 200), ("CyKEP2X", "GbMFGZS", 200, 0), ("CZtSFWz", "Ca32LwM", 1, 199),
+            ("CZtSFWz", "CyKEP2X", 75, 125), ("CZtSFWz", "FWLwQ2G", 1, 199), ("CZtSFWz", "GbMFGZS", 200, 0),
+            ("FWLwQ2G", "GbMFGZS", 200, 0),
+        ],
+        # GbMFGZS topped intercode (0.80) but went 0-4 at dice
+        {"GbMFGZS": 0.80, "FWLwQ2G": 0.76, "CyKEP2X": 0.74, "CZtSFWz": 0.73, "Ca32LwM": 0.73},
+    ),
+}
+
+
+def _group(hotkeys, pairs):
+    pair_results = [
+        PvPPairResult(
+            hotkey_a=a, hotkey_b=b,
+            results={LD: PvPEnvironmentResult(model_a_wins=aw, model_b_wins=bw, draws=0, total_games=aw + bw)},
+        )
+        for a, b, aw, bw in pairs
+    ]
+    return PvPGroupResults(base_model="base", hotkeys=hotkeys, pair_results=pair_results,
+                           metadata=PvPEvalMetadata(seed=42, temperature=0.0))
+
+
+def old_standings(g, intercode, hotkeys):
+    outcomes = pvp_results_to_pairwise(g) + individual_scores_to_pairwise(intercode, IC)
+    return accumulate_points(outcomes, hotkeys, WEIGHTS)
+
+
+def new_standings(g, intercode, hotkeys):
+    wr = pvp_results_to_winrates(g)[LD]
+    return dispersion_weighted_standings({LD: wr, IC: intercode}, hotkeys, weights=WEIGHTS), wr
+
+
+def main():
+    for name, (hotkeys, pairs, intercode) in GROUPS.items():
+        g = _group(hotkeys, pairs)
+        old = old_standings(g, intercode, hotkeys)
+        new, wr = new_standings(g, intercode, hotkeys)
+        std_ld = statistics.pstdev(wr.values())
+        std_ic = statistics.pstdev(intercode.values())
+        ratio = std_ld / std_ic if std_ic else float("inf")
+
+        print(f"\n=== {name} ===")
+        print(f"  dispersion: std(dice win-rate)={std_ld:.3f}  std(intercode)={std_ic:.3f}  "
+              f"-> dice influence {ratio:.1f}x intercode")
+        print(f"  OLD winner: {old[0].hotkey:9s} (dice rank "
+              f"{sorted(wr, key=lambda h: -wr[h]).index(old[0].hotkey) + 1})")
+        print(f"  NEW winner: {new[0].hotkey:9s} (dice rank "
+              f"{sorted(wr, key=lambda h: -wr[h]).index(new[0].hotkey) + 1})")
+        flip = "  >>> WINNER CHANGED" if old[0].hotkey != new[0].hotkey else "  (same winner)"
+        print(flip)
+        print("  ranking  OLD:", " > ".join(s.hotkey for s in old))
+        print("  ranking  NEW:", " > ".join(s.hotkey for s in new))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_dispersion_weighted_scoring.py
+++ b/tests/test_dispersion_weighted_scoring.py
@@ -1,0 +1,179 @@
+"""Tests for dispersion-weighted environment scoring.
+
+Covers the new group-stage aggregation that replaced the flat 3/1/0 pairwise
+accumulator: per-env win-rate / normalized score, combined with each env's
+influence scaled by configured weight x dispersion (stdev) of its scores.
+"""
+
+import pytest
+
+from core.constants import EnvironmentName
+from core.models.pvp_models import PvPEnvironmentResult
+from core.models.pvp_models import PvPEvalMetadata
+from core.models.pvp_models import PvPGroupResults
+from core.models.pvp_models import PvPPairResult
+from core.models.scoring_models import EnvironmentWeight
+from validator.evaluation.tournament_scoring import dispersion_weighted_standings
+from validator.evaluation.tournament_scoring import pvp_results_to_winrates
+
+
+LD = EnvironmentName.LIARS_DICE
+IC = EnvironmentName.INTERCODE
+
+
+def _group(hotkeys: list[str], pairs: list[tuple[str, str, int, int]], env=LD) -> PvPGroupResults:
+    """Build PvPGroupResults from (hotkey_a, hotkey_b, a_wins, b_wins) tuples (no draws)."""
+    pair_results = [
+        PvPPairResult(
+            hotkey_a=a,
+            hotkey_b=b,
+            results={env: PvPEnvironmentResult(model_a_wins=aw, model_b_wins=bw, draws=0, total_games=aw + bw)},
+        )
+        for a, b, aw, bw in pairs
+    ]
+    return PvPGroupResults(
+        base_model="base",
+        hotkeys=hotkeys,
+        pair_results=pair_results,
+        metadata=PvPEvalMetadata(seed=42, temperature=0.0),
+    )
+
+
+def _winner(standings) -> str:
+    return standings[0].hotkey
+
+
+def _rank(standings) -> list[str]:
+    return [s.hotkey for s in standings]
+
+
+# --- pvp_results_to_winrates ---
+
+
+def test_winrate_preserves_margin():
+    g = _group(["a", "b", "c"], [("a", "b", 200, 0), ("a", "c", 100, 100), ("b", "c", 0, 200)])
+    wr = pvp_results_to_winrates(g)[LD]
+    # a: 200/200 vs b + 100/200 vs c = 300/400 = 0.75
+    assert wr["a"] == pytest.approx(0.75)
+    # b: 0 vs a + 0 vs c = 0/400
+    assert wr["b"] == pytest.approx(0.0)
+    # c: 100 vs a + 200 vs b = 300/400 = 0.75
+    assert wr["c"] == pytest.approx(0.75)
+
+
+def test_winrate_counts_draws_as_half():
+    g = _group(["a", "b"], [("a", "b", 0, 0)], env=LD)
+    g.pair_results[0].results[LD] = PvPEnvironmentResult(model_a_wins=50, model_b_wins=50, draws=100, total_games=200)
+    wr = pvp_results_to_winrates(g)[LD]
+    # (50 + 0.5*100)/200 = 0.5 each
+    assert wr["a"] == pytest.approx(0.5)
+    assert wr["b"] == pytest.approx(0.5)
+
+
+# --- dispersion_weighted_standings ---
+
+
+def test_decisive_env_dominates_flat_env():
+    """A clustered env must not override a decisive one under equal configured weights."""
+    hotkeys = ["winner", "loser"]
+    env_scores = {
+        LD: {"winner": 1.0, "loser": 0.0},      # decisive: stdev 0.5
+        IC: {"winner": 0.70, "loser": 0.72},     # nearly flat, slight reverse edge: stdev 0.01
+    }
+    weights = [EnvironmentWeight(environment=LD, weight=1.0), EnvironmentWeight(environment=IC, weight=1.0)]
+    standings = dispersion_weighted_standings(env_scores, hotkeys, weights=weights)
+    # liars_dice (stdev 0.5) ~50x the influence of intercode (stdev 0.01)
+    assert _winner(standings) == "winner"
+
+
+def test_flat_env_contributes_nothing():
+    hotkeys = ["a", "b", "c"]
+    env_scores = {
+        LD: {"a": 0.9, "b": 0.5, "c": 0.1},  # decisive
+        IC: {"a": 0.5, "b": 0.5, "c": 0.5},  # perfectly flat -> stdev 0 -> zero influence
+    }
+    standings = dispersion_weighted_standings(env_scores, hotkeys)
+    assert _rank(standings) == ["a", "b", "c"]
+    # ranking is fully determined by the only env with signal
+    assert standings[0].points == pytest.approx(0.9)
+
+
+def test_missing_miner_scored_zero():
+    hotkeys = ["a", "b", "ghost"]
+    env_scores = {LD: {"a": 0.8, "b": 0.4}}  # ghost absent (e.g. eval never produced games)
+    standings = dispersion_weighted_standings(env_scores, hotkeys)
+    assert _rank(standings) == ["a", "b", "ghost"]
+    assert standings[-1].hotkey == "ghost"
+    assert standings[-1].points == pytest.approx(0.0)
+
+
+def test_all_flat_falls_back_to_mean_without_crashing():
+    hotkeys = ["a", "b"]
+    env_scores = {LD: {"a": 0.5, "b": 0.5}, IC: {"a": 0.3, "b": 0.3}}
+    standings = dispersion_weighted_standings(env_scores, hotkeys)
+    # No env separates anyone -> equal points, no division by zero
+    assert standings[0].points == pytest.approx(standings[1].points)
+    assert standings[0].points == pytest.approx(0.4)  # mean of normalized (0.5, 0.3)
+
+
+def test_single_miner_no_crash():
+    standings = dispersion_weighted_standings({LD: {"solo": 0.9}}, ["solo"])
+    assert _winner(standings) == "solo"
+
+
+def test_score_ref_max_normalizes_scale():
+    """An env scored 0-100 must not swamp a [0,1] env purely due to scale."""
+    hotkeys = ["a", "b"]
+    env_scores = {
+        LD: {"a": 1.0, "b": 0.0},        # ref 1.0 -> normalized spread 1.0
+        IC: {"a": 60.0, "b": 40.0},      # ref 100 -> normalized 0.6/0.4, spread 0.2
+    }
+    ref = {LD: 1.0, IC: 100.0}
+    standings = dispersion_weighted_standings(env_scores, hotkeys, score_ref_max=ref)
+    # combined points stay in [0,1] after normalization
+    assert all(0.0 <= s.points <= 1.0 for s in standings)
+    assert _winner(standings) == "a"
+
+
+# --- Backtest against real round-1 group 001 (tourn_33c30659e3c920d5_20260601) ---
+
+# liars_dice pair results (hotkey_a, hotkey_b, a_wins, b_wins), 200 games each
+_G1_PAIRS = [
+    ("CMZQwPd", "CRwFq2Q", 0, 200),
+    ("CMZQwPd", "EF2nASX", 0, 200),
+    ("CMZQwPd", "FpdSckw", 0, 200),
+    ("CMZQwPd", "GNP9XWd", 2, 198),
+    ("CMZQwPd", "HWPK9f6", 111, 89),
+    ("CRwFq2Q", "EF2nASX", 1, 199),
+    ("CRwFq2Q", "FpdSckw", 1, 199),
+    ("CRwFq2Q", "GNP9XWd", 35, 165),
+    ("CRwFq2Q", "HWPK9f6", 138, 62),
+    ("EF2nASX", "FpdSckw", 90, 110),
+    ("EF2nASX", "GNP9XWd", 134, 66),
+    ("EF2nASX", "HWPK9f6", 200, 0),
+    ("FpdSckw", "GNP9XWd", 129, 71),
+    ("FpdSckw", "HWPK9f6", 198, 2),
+    ("GNP9XWd", "HWPK9f6", 200, 0),
+]
+_G1_HOTKEYS = ["CMZQwPd", "CRwFq2Q", "EF2nASX", "FpdSckw", "GNP9XWd", "HWPK9f6"]
+_G1_INTERCODE = {
+    "CMZQwPd": 0.791, "CRwFq2Q": 0.749, "EF2nASX": 0.729,
+    "GNP9XWd": 0.721, "HWPK9f6": 0.719, "FpdSckw": 0.709,
+}
+
+
+def test_real_group001_flips_to_dice_champion():
+    """Under the new scheme the 5-0 liars_dice champion wins group 001,
+    instead of the intercode leader who went 1-4 head-to-head."""
+    winrates = pvp_results_to_winrates(_group(_G1_HOTKEYS, _G1_PAIRS))[LD]
+    env_scores = {LD: winrates, IC: _G1_INTERCODE}
+    weights = [EnvironmentWeight(environment=LD, weight=1.0), EnvironmentWeight(environment=IC, weight=1.0)]
+    standings = dispersion_weighted_standings(env_scores, _G1_HOTKEYS, weights=weights)
+
+    # FpdSckw was 5-0 at liars_dice; CMZQwPd was 1-4 but topped intercode (and won under the old 3/1/0 scheme).
+    assert _winner(standings) == "FpdSckw"
+    # The old winner collapses: CMZQwPd was swept 0-200 four times (win-rate 0.113, the worst),
+    # and its marginal intercode lead can't survive liars_dice getting ~11x the influence.
+    assert _rank(standings)[-1] == "CMZQwPd"
+    # Margin-aware win-rate correctly ranks CMZQwPd below HWPK9f6 (0-5 but more games won).
+    assert _rank(standings).index("HWPK9f6") < _rank(standings).index("CMZQwPd")

--- a/validator/evaluation/scoring.py
+++ b/validator/evaluation/scoring.py
@@ -25,7 +25,6 @@ from core.models.scoring_models import GroupStagePoints
 from core.models.scoring_models import IndividualEvalResult
 from core.models.scoring_models import IndividualScoresByEnv
 from core.models.scoring_models import MinerRepos
-from core.models.scoring_models import PairwiseOutcome
 from core.models.utility_models import ChatTemplateDatasetType
 from core.models.utility_models import DpoDatasetType
 from core.models.utility_models import EnvironmentDatasetType
@@ -53,9 +52,8 @@ from validator.evaluation.docker_evaluation import run_evaluation_basilica_image
 from validator.evaluation.docker_evaluation import run_evaluation_basilica_text
 from validator.evaluation.docker_evaluation import run_evaluation_individual
 from validator.evaluation.docker_evaluation import run_evaluation_pvp_pair
-from validator.evaluation.tournament_scoring import accumulate_points
-from validator.evaluation.tournament_scoring import individual_scores_to_pairwise
-from validator.evaluation.tournament_scoring import pvp_results_to_pairwise
+from validator.evaluation.tournament_scoring import dispersion_weighted_standings
+from validator.evaluation.tournament_scoring import pvp_results_to_winrates
 from validator.utils.logging import LogContext
 from validator.utils.logging import get_logger
 from validator.utils.minio import async_minio_client
@@ -697,21 +695,27 @@ async def _run_env_tournament_eval(
         f"pvp_envs={[e.value for e in pvp_envs]}, individual_envs={[e.value for e in individual_envs]}"
     )
 
-    all_outcomes: list[PairwiseOutcome] = []
+    env_scores: dict[core_cst.EnvironmentName, dict[str, float]] = {}
 
     if pvp_envs:
-        all_outcomes.extend(await _eval_pvp_envs(
+        env_scores.update(await _eval_pvp_envs(
             task_id=str(task.task_id), pvp_envs=pvp_envs, miners=miners,
             base_model=base_model, seed=seed, config=config,
         ))
 
     if individual_envs:
-        all_outcomes.extend(await _eval_individual_envs(
+        env_scores.update(await _eval_individual_envs(
             task_id=task.task_id, individual_envs=individual_envs, miners=miners,
             base_model=base_model, model_params=model_params, seed=seed, config=config,
         ))
 
-    standings = accumulate_points(all_outcomes, miners.hotkeys, weights=task.environment_weights or None)
+    score_ref_max = {
+        env: core_cst.ENVIRONMENT_CONFIGS[env].score_ref_max for env in task.environment_names
+    }
+    standings = dispersion_weighted_standings(
+        env_scores, miners.hotkeys, score_ref_max=score_ref_max,
+        weights=task.environment_weights or None,
+    )
     return _standings_to_results(standings, miners, task)
 
 
@@ -770,8 +774,8 @@ async def _eval_pvp_envs(
     base_model: str,
     seed: int,
     config: Config,
-) -> list[PairwiseOutcome]:
-    """Run pairwise PvP eval for PVP-type environments, return pairwise outcomes."""
+) -> dict[core_cst.EnvironmentName, dict[str, float]]:
+    """Run pairwise PvP eval for PVP-type environments, return per-env win-rates."""
     env_config = _get_shared_env_config(pvp_envs)
 
     group_results = await _get_or_run_pvp_pairs(
@@ -781,7 +785,7 @@ async def _eval_pvp_envs(
         gpu_count=cts.PVP_BASILICA_GPU_COUNT, config=config,
     )
 
-    return pvp_results_to_pairwise(group_results)
+    return pvp_results_to_winrates(group_results)
 
 
 async def _get_or_run_pvp_pairs(
@@ -901,8 +905,8 @@ async def _eval_individual_envs(
     model_params: int,
     seed: int,
     config: Config,
-) -> list[PairwiseOutcome]:
-    """Run per-miner containers for INDIVIDUAL-type envs, return synthetic pairwise outcomes."""
+) -> dict[core_cst.EnvironmentName, dict[str, float]]:
+    """Run per-miner containers for INDIVIDUAL-type envs, return per-env raw scores."""
     task_id_str = str(task_id)
     env_name_strs = [e.value for e in individual_envs]
 
@@ -951,11 +955,7 @@ async def _eval_individual_envs(
                 f"Individual eval {env.value}: assigned score=0 for exhausted hotkeys: {[hk[:8] for hk in missing_hks]}"
             )
 
-    outcomes: list[PairwiseOutcome] = []
-    for env in individual_envs:
-        result = scores.results[env]
-        outcomes.extend(individual_scores_to_pairwise(result.scores_by_hotkey, env))
-    return outcomes
+    return {env: dict(scores.results[env].scores_by_hotkey) for env in individual_envs}
 
 
 def _build_scores_from_db(

--- a/validator/evaluation/tournament_scoring.py
+++ b/validator/evaluation/tournament_scoring.py
@@ -1,5 +1,7 @@
 
 import itertools
+import statistics
+from collections import defaultdict
 
 import validator.core.constants as cts
 from core.constants import EnvironmentName
@@ -49,6 +51,59 @@ def accumulate_points(
     return standings
 
 
+def dispersion_weighted_standings(
+    env_scores: dict[EnvironmentName, dict[str, float]],
+    hotkeys: list[str],
+    score_ref_max: dict[EnvironmentName, float] | None = None,
+    weights: list[EnvironmentWeight] | None = None,
+) -> list[GroupStagePoints]:
+    """Combine per-environment, per-miner scores into group standings.
+
+    Each environment contributes a continuous, normalized score per miner
+    (`raw / score_ref_max[env]`), and its influence on the final ranking is
+    `configured_weight * stdev(normalized scores)`. So an environment where
+    miners are barely distinguishable contributes little, while one that
+    separates them decisively dominates — preventing a low-signal env from
+    acting as kingmaker. The combined score is the influence-weighted average
+    of each miner's normalized per-env scores, so it stays on a [0, 1] scale.
+
+    Miners absent from an environment are treated as scoring 0.0 there (they
+    produced no result), matching the upstream exhausted-attempt behaviour.
+    """
+    weight_map = {w.environment: w.weight for w in weights} if weights else {}
+    ref_map = score_ref_max or {}
+
+    normalized: dict[EnvironmentName, dict[str, float]] = {}
+    influence: dict[EnvironmentName, float] = {}
+    for env, scores in env_scores.items():
+        ref = ref_map.get(env, 1.0)
+        if ref <= 0:
+            logger.warning(f"score_ref_max for {env} is {ref}; falling back to 1.0")
+            ref = 1.0
+        norm = {hk: scores.get(hk, 0.0) / ref for hk in hotkeys}
+        normalized[env] = norm
+        dispersion = statistics.pstdev(norm.values()) if len(hotkeys) > 1 else 0.0
+        influence[env] = weight_map.get(env, 1.0) * dispersion
+
+    total_influence = sum(influence.values())
+
+    points: dict[str, float] = {}
+    if total_influence > 0:
+        for hk in hotkeys:
+            points[hk] = sum(influence[env] * normalized[env][hk] for env in normalized) / total_influence
+    else:
+        # Every environment is flat (no separation) — fall back to an unweighted mean
+        # of normalized scores so ordering stays defined (miners are likely tied).
+        n_env = len(normalized)
+        for hk in hotkeys:
+            points[hk] = (sum(normalized[env][hk] for env in normalized) / n_env) if n_env else 0.0
+        logger.info("dispersion_weighted_standings: all environments flat, using unweighted mean")
+
+    standings = [GroupStagePoints(hotkey=hk, points=points[hk]) for hk in hotkeys]
+    standings.sort(key=lambda s: s.points, reverse=True)
+    return standings
+
+
 # --- PvP → pairwise ---
 
 
@@ -73,6 +128,33 @@ def pvp_results_to_pairwise(group_results: PvPGroupResults) -> list[PairwiseOutc
             ))
 
     return outcomes
+
+
+def pvp_results_to_winrates(group_results: PvPGroupResults) -> dict[EnvironmentName, dict[str, float]]:
+    """Per-environment win-rate for each hotkey across all of its round-robin games.
+
+    Win-rate (games won, counting draws as a half-win, over games played) preserves
+    margin of victory — a 200-0 sweep yields 1.0 while a 101-99 squeaker yields ~0.5 —
+    unlike the binary win/loss the pairwise converter produces.
+    """
+    wins: dict[EnvironmentName, dict[str, float]] = defaultdict(lambda: defaultdict(float))
+    games: dict[EnvironmentName, dict[str, float]] = defaultdict(lambda: defaultdict(float))
+
+    for pair in group_results.pair_results:
+        for env_name, result in pair.results.items():
+            played = result.model_a_wins + result.model_b_wins + result.draws
+            wins[env_name][pair.hotkey_a] += result.model_a_wins + 0.5 * result.draws
+            wins[env_name][pair.hotkey_b] += result.model_b_wins + 0.5 * result.draws
+            games[env_name][pair.hotkey_a] += played
+            games[env_name][pair.hotkey_b] += played
+
+    winrates: dict[EnvironmentName, dict[str, float]] = {}
+    for env_name, env_games in games.items():
+        winrates[env_name] = {
+            hk: (wins[env_name][hk] / env_games[hk] if env_games[hk] else 0.0)
+            for hk in group_results.hotkeys
+        }
+    return winrates
 
 
 # --- Individual scores → pairwise ---


### PR DESCRIPTION
Replace the flat 3/1/0 pairwise accumulator for group-stage env tasks with a dispersion-weighted average of per-env, per-miner scores.

- PvP envs contribute a win-rate (margin-aware: 200-0 -> 1.0, 101-99 -> ~0.5)
- Individual envs contribute their raw score, normalized by EnvironmentConfig.score_ref_max
- Each env's influence = configured_weight * stdev(normalized scores), so a low-signal env (scores bunched together) can no longer override a decisive one.

Fixes the case where a marginal intercode leader who went 1-4 at liars_dice won its group. Adds unit tests and a backtest sim over real round-1 data.