### PR TITLE
tournament: fall back to base model when continuation model is missing

### DIFF
--- a/validator/tournament/tournament_manager.py
+++ b/validator/tournament/tournament_manager.py
@@ -7,7 +7,9 @@ from datetime import timedelta
 from datetime import timezone
 
 from fiber.chain.models import Node
+from huggingface_hub import repo_exists
 
+from core.constants import HUGGINGFACE_TOKEN
 from core.constants import RAYONLABS_HF_USERNAME
 from core.constants import TrainingStartPoint
 import validator.core.constants as cst
@@ -216,6 +218,20 @@ async def _create_tournament_tasks(
     return tasks
 
 
+async def _hf_repo_exists(repo_id: str) -> bool:
+    """Whether an HF model repo exists.
+
+    A continuation model can be missing if the miner's previous round failed to
+    upload (e.g. its training errored). On a lookup error we assume it exists, so
+    we only fall back to the base model on a definitive 'not found'.
+    """
+    try:
+        return await asyncio.to_thread(repo_exists, repo_id, repo_type="model", token=HUGGINGFACE_TOKEN)
+    except Exception as e:
+        logger.warning(f"HF repo existence check failed for {repo_id}: {e}; assuming it exists")
+        return True
+
+
 async def _get_previous_round_repo(tournament_id: str, hotkey: str, psql_db: PSQLDB) -> str | None:
     """Look up a miner's output repo from the previous round for model continuation."""
     rounds = await get_tournament_rounds(tournament_id, psql_db)
@@ -324,6 +340,15 @@ async def assign_nodes_to_tournament_tasks(
 
                         if task_obj and task_obj.training_start_point == TrainingStartPoint.CONTINUATION:
                             prev_repo = await _get_previous_round_repo(tournament_id, hotkey, psql_db)
+                            # The continuation model may not exist (e.g. the miner's previous
+                            # round failed to upload). Fall back to the base model so prep and
+                            # training still run instead of blocking on a 404 forever.
+                            if prev_repo and not await _hf_repo_exists(prev_repo):
+                                logger.warning(
+                                    f"Continuation model {prev_repo} for {hotkey[:8]} not found on HF; "
+                                    f"falling back to base model {task_obj.model_id}"
+                                )
+                                prev_repo = task_obj.model_id
                             if prev_repo:
                                 await task_sql.set_starting_model_repo(
                                     tournament_task.task_id, hotkey, prev_repo, psql_db,


### PR DESCRIPTION
Model-continuation rounds set a miner's starting model to its previous-round output repo without checking it exists. If that round failed to upload (e.g. the miner's training errored), the repo 404s and model prep fails on download every cycle with no give-up — the task is stuck in awaiting_model_prep forever.

Verify the continuation repo exists on HF; if not, fall back to the task's base model so prep and training still run. On a lookup error we assume it exists, so we only fall back on a definitive 'not found'.