### PR TITLE
tournament: don't double-assign the boss across env groups

### DIFF
--- a/validator/tournament/tournament_manager.py
+++ b/validator/tournament/tournament_manager.py
@@ -283,7 +283,13 @@ async def assign_nodes_to_tournament_tasks(
     if isinstance(round_structure, GroupRound):
         all_round_tasks = await get_tournament_tasks(round_structure.round_id, psql_db)
 
-        boss_assigned = False
+        # The boss (EMISSION_BURN_HOTKEY) may already be a real member of one of the
+        # groups (e.g. it advanced into a group this round). Detect that up front so we
+        # don't greedily append it to an earlier group as well — otherwise the boss gets
+        # assigned to two tasks in the same round.
+        boss_assigned = any(
+            EMISSION_BURN_HOTKEY in group.member_ids for group in round_structure.groups
+        )
         for i, group in enumerate(round_structure.groups):
             if is_environment_tournament:
                 group_participants = list(group.member_ids)


### PR DESCRIPTION
In env group rounds the boss (EMISSION_BURN_HOTKEY) is appended to the first group that doesn't already contain it. But the boss can already be a real member of a *later* group this round, and the boss_assigned flag was only set greedily on the first group — so it got appended to group 1 AND kept in its real group, assigning the boss to two tasks in the same round.

Seed boss_assigned by scanning all groups up front, so the boss is only appended when no group already contains it.