### PR TITLE
env tournament: save winner's real base model, not the target constant

### DIFF
--- a/validator/tournament/tournament_manager.py
+++ b/validator/tournament/tournament_manager.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import math
 import random
 import re
@@ -7,6 +8,7 @@ from datetime import timedelta
 from datetime import timezone
 
 from fiber.chain.models import Node
+from huggingface_hub import hf_hub_download
 from huggingface_hub import repo_exists
 
 from core.constants import HUGGINGFACE_TOKEN
@@ -250,6 +252,27 @@ async def _get_previous_round_repo(tournament_id: str, hotkey: str, psql_db: PSQ
     return None
 
 
+async def _resolve_winner_base_model(winner_repo: str, fallback_model_id: str | None) -> str | None:
+    """The winner model's real foundation base model.
+
+    With the trainer's merge-on-download + base-repoint-on-upload, a winner adapter's
+    base_model_name_or_path already points at the real foundation (no adapter-on-adapter
+    chains), so a single read is enough. Full merged-model winners have no adapter_config,
+    so fall back to the task's declared base model.
+    """
+    try:
+        cfg_path = await asyncio.to_thread(
+            hf_hub_download, winner_repo, "adapter_config.json", token=HUGGINGFACE_TOKEN
+        )
+        with open(cfg_path) as f:
+            base = json.load(f).get("base_model_name_or_path")
+        if base:
+            return base
+    except Exception:
+        pass  # not an adapter (full merged model) — use the task's declared base
+    return fallback_model_id
+
+
 async def _save_winner_model_repo(
     tournament_id: str, winner_hotkey: str, round_tasks: list[TournamentTask], psql_db: PSQLDB,
 ) -> None:
@@ -274,13 +297,19 @@ async def _save_winner_model_repo(
         winner_repo = f"{RAYONLABS_HF_USERNAME}/{repo_name}"
 
         if task_obj.training_start_point == TrainingStartPoint.PREVIOUS_WINNER:
-            logger.info(f"Saving PREVIOUS_WINNER lineage: {winner_repo} (base={t_cst.ENV_TARGET_TOURN_MODEL})")
-            await update_tournament_winner_model(tournament_id, winner_repo, t_cst.ENV_TARGET_TOURN_MODEL, psql_db)
+            # Record the winner's *actual* foundation base, not the target constant.
+            # Hardcoding ENV_TARGET_TOURN_MODEL here made next tournament's
+            # continue-vs-from-scratch check (winner_model_base == ENV_TARGET_TOURN_MODEL)
+            # always pass, so the boss kept continuing a stale-base lineage and never
+            # reset to the target when the constant changed.
+            base = await _resolve_winner_base_model(winner_repo, task_obj.model_id) or t_cst.ENV_TARGET_TOURN_MODEL
+            logger.info(f"Saving PREVIOUS_WINNER lineage: {winner_repo} (resolved base={base})")
+            await update_tournament_winner_model(tournament_id, winner_repo, base, psql_db)
             return
 
         if not fallback_repo:
             fallback_repo = winner_repo
-            fallback_base_model = task_obj.model_id
+            fallback_base_model = await _resolve_winner_base_model(winner_repo, task_obj.model_id)
 
     if fallback_repo and fallback_base_model:
         await update_tournament_winner_model(tournament_id, fallback_repo, fallback_base_model, psql_db)


### PR DESCRIPTION
_save_winner_model_repo hardcoded winner_model_base = ENV_TARGET_TOURN_MODEL for the PREVIOUS_WINNER lineage. That made next tournament's continue-vs-from-scratch guard (winner_model_base == ENV_TARGET_TOURN_MODEL) always pass, so the boss kept continuing a stale-base champion lineage and never reset to the target when the constant changed (e.g. a Qwen2.5-3B champ never reset to a Qwen2.5-7B target).

Resolve and store the winner's actual foundation base instead. Now when the champion's real base differs from ENV_TARGET_TOURN_MODEL, the boss round trains from scratch on the target; when it matches, it keeps continuing the lineage.