### PR TITLE
Combine env tournament scores by rank normalization

### DIFF
--- a/core/models/scoring_models.py
+++ b/core/models/scoring_models.py
@@ -95,6 +95,17 @@ class IndividualScoresByEnv(BaseModel):
         return incomplete
 
 
+class EnvMinerScores(BaseModel):
+    """Continuous per-miner scores for a single environment, before rank normalization.
+
+    Holds either a PvP env's win-rates or an INDIVIDUAL env's raw scores — both are
+    just a higher-is-better number per hotkey, combined downstream by rank.
+    """
+
+    environment: EnvironmentName
+    scores_by_hotkey: dict[str, float]
+
+
 class EvalHotkeyResults(BaseModel):
     """Outcome of evaluating a batch of hotkeys."""
 

--- a/tests/test_rank_weighted_scoring.py
+++ b/tests/test_rank_weighted_scoring.py
@@ -1,0 +1,135 @@
+"""Tests for rank-normalized environment combination (rank_weighted_standings).
+
+Covers the two properties that motivated replacing the dispersion-weighted scheme:
+  1. A tightly-clustered env (e.g. intercode ~[0.7, 0.8]) keeps its configured say
+     instead of being drowned out by a wide-spread PvP env.
+  2. A single per-env failure (score 0.0 in a cluster) is a bounded last-place penalty,
+     not a weight explosion that lets the failing env dominate.
+"""
+
+import pytest
+
+from core.constants import EnvironmentName
+from core.models.pvp_models import PvPEvalMetadata
+from core.models.pvp_models import PvPGroupResults
+from core.models.pvp_models import PvPPairResult
+from core.models.pvp_models import PvPEnvironmentResult
+from core.models.scoring_models import EnvironmentWeight
+from core.models.scoring_models import EnvMinerScores
+from validator.evaluation.tournament_scoring import _rank_quantiles
+from validator.evaluation.tournament_scoring import pvp_results_to_winrates
+from validator.evaluation.tournament_scoring import rank_weighted_standings
+
+
+INTERCODE = EnvironmentName.INTERCODE
+LIARS = EnvironmentName.LIARS_DICE
+
+
+def _points(standings):
+    return {s.hotkey: s.points for s in standings}
+
+
+class TestRankQuantiles:
+    def test_spreads_evenly(self) -> None:
+        q = _rank_quantiles({"a": 0.1, "b": 0.2, "c": 0.3}, ["a", "b", "c"])
+        assert q == {"a": 0.0, "b": 0.5, "c": 1.0}
+
+    def test_clustering_is_irrelevant(self) -> None:
+        """A 0.001-wide cluster ranks identically to a full-range spread."""
+        tight = _rank_quantiles({"a": 0.700, "b": 0.701, "c": 0.702}, ["a", "b", "c"])
+        wide = _rank_quantiles({"a": 0.0, "b": 0.5, "c": 1.0}, ["a", "b", "c"])
+        assert tight == wide
+
+    def test_ties_share_mean_quantile(self) -> None:
+        q = _rank_quantiles({"a": 0.5, "b": 0.5, "c": 0.9}, ["a", "b", "c"])
+        assert q["a"] == q["b"] == 0.25  # mean of ranks 0 and 1, over (n-1)=2
+        assert q["c"] == 1.0
+
+    def test_all_tied_is_neutral_half(self) -> None:
+        q = _rank_quantiles({"a": 0.0, "b": 0.0, "c": 0.0}, ["a", "b", "c"])
+        assert q == {"a": 0.5, "b": 0.5, "c": 0.5}
+
+    def test_single_miner(self) -> None:
+        assert _rank_quantiles({"a": 0.42}, ["a"]) == {"a": 0.5}
+
+    def test_missing_hotkey_sorts_last(self) -> None:
+        q = _rank_quantiles({"a": 0.7, "b": 0.8}, ["a", "b", "missing"])
+        assert q["missing"] == 0.0
+        assert q["b"] == 1.0
+
+
+class TestRankWeightedStandings:
+    def test_clustered_env_still_counts(self) -> None:
+        """Equal-weighted clustered intercode + wide liars: a miner that loses liars
+        but wins intercode is pulled up, not erased (unlike dispersion weighting)."""
+        hotkeys = ["x", "y"]
+        env_scores = [
+            EnvMinerScores(environment=INTERCODE, scores_by_hotkey={"x": 0.80, "y": 0.70}),
+            EnvMinerScores(environment=LIARS, scores_by_hotkey={"x": 0.10, "y": 0.90}),
+        ]
+        pts = _points(rank_weighted_standings(env_scores, hotkeys))
+        # x is rank-1 in intercode (q=1) but rank-0 in liars (q=0): mean 0.5.
+        # y is the mirror: also 0.5. Equal weight -> exact tie, intercode NOT drowned out.
+        assert pts["x"] == pytest.approx(0.5)
+        assert pts["y"] == pytest.approx(0.5)
+
+    def test_dispersion_would_have_let_liars_dominate(self) -> None:
+        """Same data, but make intercode the tie-breaker via a stronger configured weight.
+        Under rank-normalization the configured weight actually bites; the wide spread of
+        liars cannot override it the way raw-score dispersion weighting did."""
+        hotkeys = ["x", "y"]
+        env_scores = [
+            EnvMinerScores(environment=INTERCODE, scores_by_hotkey={"x": 0.80, "y": 0.70}),
+            EnvMinerScores(environment=LIARS, scores_by_hotkey={"x": 0.10, "y": 0.90}),
+        ]
+        weights = [
+            EnvironmentWeight(environment=INTERCODE, weight=2.0),
+            EnvironmentWeight(environment=LIARS, weight=1.0),
+        ]
+        pts = _points(rank_weighted_standings(env_scores, hotkeys, weights))
+        # x: (2*1 + 1*0)/3 = 0.667 ; y: (2*0 + 1*1)/3 = 0.333
+        assert pts["x"] == pytest.approx(2 / 3)
+        assert pts["y"] == pytest.approx(1 / 3)
+
+    def test_failure_is_bounded_not_a_weight_explosion(self) -> None:
+        """One miner fails intercode (0.0) inside a [0.7,0.8] cluster. It must land last
+        in intercode, and the standings must still be driven by genuine performance —
+        the failure does not hand intercode outsized influence."""
+        hotkeys = ["good", "mid", "failed"]
+        env_scores = [
+            EnvMinerScores(environment=INTERCODE, scores_by_hotkey={"good": 0.75, "mid": 0.72, "failed": 0.0}),
+            EnvMinerScores(environment=LIARS, scores_by_hotkey={"good": 0.9, "mid": 0.5, "failed": 0.4}),
+        ]
+        standings = rank_weighted_standings(env_scores, hotkeys)
+        order = [s.hotkey for s in standings]
+        assert order == ["good", "mid", "failed"]
+        pts = _points(standings)
+        # 'failed' is last in both envs -> q=0 both -> exactly 0.0, a bounded floor.
+        assert pts["failed"] == pytest.approx(0.0)
+
+    def test_empty_envs(self) -> None:
+        assert rank_weighted_standings([], ["a", "b"]) == sorted(
+            rank_weighted_standings([], ["a", "b"]), key=lambda s: s.points, reverse=True
+        )
+        pts = _points(rank_weighted_standings([], ["a", "b"]))
+        assert pts == {"a": 0.0, "b": 0.0}
+
+
+class TestPvPResultsToWinrates:
+    def test_winrate_with_draws(self) -> None:
+        group = PvPGroupResults(
+            base_model="m",
+            hotkeys=["a", "b"],
+            pair_results=[
+                PvPPairResult(
+                    hotkey_a="a",
+                    hotkey_b="b",
+                    results={LIARS: PvPEnvironmentResult(model_a_wins=120, model_b_wins=60, draws=20, total_games=200)},
+                )
+            ],
+            metadata=PvPEvalMetadata(seed=0, temperature=0.0, wall_time_seconds=0),
+        )
+        out = {e.environment: e.scores_by_hotkey for e in pvp_results_to_winrates(group)}
+        # a: (120 + 0.5*20)/200 = 0.65 ; b: (60 + 0.5*20)/200 = 0.35
+        assert out[LIARS]["a"] == pytest.approx(0.65)
+        assert out[LIARS]["b"] == pytest.approx(0.35)

--- a/validator/evaluation/scoring.py
+++ b/validator/evaluation/scoring.py
@@ -21,11 +21,11 @@ from core.models.pvp_models import PvPPairDbRow
 from core.models.pvp_models import PvPPairResult
 from core.models.pvp_models import _canonical_pair_key
 from core.models.scoring_models import EvalHotkeyResults
+from core.models.scoring_models import EnvMinerScores
 from core.models.scoring_models import GroupStagePoints
 from core.models.scoring_models import IndividualEvalResult
 from core.models.scoring_models import IndividualScoresByEnv
 from core.models.scoring_models import MinerRepos
-from core.models.scoring_models import PairwiseOutcome
 from core.models.utility_models import ChatTemplateDatasetType
 from core.models.utility_models import DpoDatasetType
 from core.models.utility_models import EnvironmentDatasetType
@@ -53,9 +53,8 @@ from validator.evaluation.docker_evaluation import run_evaluation_basilica_image
 from validator.evaluation.docker_evaluation import run_evaluation_basilica_text
 from validator.evaluation.docker_evaluation import run_evaluation_individual
 from validator.evaluation.docker_evaluation import run_evaluation_pvp_pair
-from validator.evaluation.tournament_scoring import accumulate_points
-from validator.evaluation.tournament_scoring import individual_scores_to_pairwise
-from validator.evaluation.tournament_scoring import pvp_results_to_pairwise
+from validator.evaluation.tournament_scoring import pvp_results_to_winrates
+from validator.evaluation.tournament_scoring import rank_weighted_standings
 from validator.utils.logging import LogContext
 from validator.utils.logging import get_logger
 from validator.utils.minio import async_minio_client
@@ -697,21 +696,21 @@ async def _run_env_tournament_eval(
         f"pvp_envs={[e.value for e in pvp_envs]}, individual_envs={[e.value for e in individual_envs]}"
     )
 
-    all_outcomes: list[PairwiseOutcome] = []
+    env_scores: dict[core_cst.EnvironmentName, dict[str, float]] = {}
 
     if pvp_envs:
-        all_outcomes.extend(await _eval_pvp_envs(
+        env_scores.update(await _eval_pvp_envs(
             task_id=str(task.task_id), pvp_envs=pvp_envs, miners=miners,
             base_model=base_model, seed=seed, config=config,
         ))
 
     if individual_envs:
-        all_outcomes.extend(await _eval_individual_envs(
+        env_scores.update(await _eval_individual_envs(
             task_id=task.task_id, individual_envs=individual_envs, miners=miners,
             base_model=base_model, model_params=model_params, seed=seed, config=config,
         ))
 
-    standings = accumulate_points(all_outcomes, miners.hotkeys, weights=task.environment_weights or None)
+    standings = rank_weighted_standings(env_scores, miners.hotkeys, weights=task.environment_weights or None)
     return _standings_to_results(standings, miners, task)
 
 
@@ -770,8 +769,8 @@ async def _eval_pvp_envs(
     base_model: str,
     seed: int,
     config: Config,
-) -> list[PairwiseOutcome]:
-    """Run pairwise PvP eval for PVP-type environments, return pairwise outcomes."""
+) -> list[EnvMinerScores]:
+    """Run pairwise PvP eval for PVP-type environments, return per-env win-rates."""
     env_config = _get_shared_env_config(pvp_envs)
 
     group_results = await _get_or_run_pvp_pairs(
@@ -781,7 +780,7 @@ async def _eval_pvp_envs(
         gpu_count=cts.PVP_BASILICA_GPU_COUNT, config=config,
     )
 
-    return pvp_results_to_pairwise(group_results)
+    return pvp_results_to_winrates(group_results)
 
 
 async def _get_or_run_pvp_pairs(
@@ -901,8 +900,8 @@ async def _eval_individual_envs(
     model_params: int,
     seed: int,
     config: Config,
-) -> list[PairwiseOutcome]:
-    """Run per-miner containers for INDIVIDUAL-type envs, return synthetic pairwise outcomes."""
+) -> list[EnvMinerScores]:
+    """Run per-miner containers for INDIVIDUAL-type envs, return per-env raw scores."""
     task_id_str = str(task_id)
     env_name_strs = [e.value for e in individual_envs]
 
@@ -951,11 +950,10 @@ async def _eval_individual_envs(
                 f"Individual eval {env.value}: assigned score=0 for exhausted hotkeys: {[hk[:8] for hk in missing_hks]}"
             )
 
-    outcomes: list[PairwiseOutcome] = []
-    for env in individual_envs:
-        result = scores.results[env]
-        outcomes.extend(individual_scores_to_pairwise(result.scores_by_hotkey, env))
-    return outcomes
+    return [
+        EnvMinerScores(environment=env, scores_by_hotkey=dict(scores.results[env].scores_by_hotkey))
+        for env in individual_envs
+    ]
 
 
 def _build_scores_from_db(

--- a/validator/evaluation/tournament_scoring.py
+++ b/validator/evaluation/tournament_scoring.py
@@ -1,10 +1,12 @@
 
 import itertools
+from collections import defaultdict
 
 import validator.core.constants as cts
 from core.constants import EnvironmentName
 from core.models.pvp_models import PvPGroupResults
 from core.models.scoring_models import EnvironmentWeight
+from core.models.scoring_models import EnvMinerScores
 from core.models.scoring_models import GroupStagePoints
 from core.models.scoring_models import PairwiseOutcome
 from core.models.scoring_models import TournamentScore
@@ -47,6 +49,99 @@ def accumulate_points(
     standings = [GroupStagePoints(hotkey=hk, points=pts) for hk, pts in points.items()]
     standings.sort(key=lambda s: s.points, reverse=True)
     return standings
+
+
+# --- Rank-normalized environment combination ---
+
+
+def _rank_quantiles(scores: dict[str, float], hotkeys: list[str]) -> dict[str, float]:
+    """Map per-miner scores to average-rank quantiles in [0, 1] within one environment.
+
+    The lowest scorer gets 0.0, the highest 1.0, the rest spread evenly by rank.
+    Ties share their mean quantile. A single miner (or an environment where every
+    miner is tied — e.g. all failed) gets 0.5 for everyone, i.e. a neutral constant
+    that cannot change the ordering.
+    """
+    n = len(hotkeys)
+    if n <= 1:
+        return {hk: 0.5 for hk in hotkeys}
+
+    ordered = sorted(hotkeys, key=lambda hk: scores.get(hk, 0.0))
+    quantiles: dict[str, float] = {}
+    i = 0
+    while i < n:
+        j = i
+        while j + 1 < n and scores.get(ordered[j + 1], 0.0) == scores.get(ordered[i], 0.0):
+            j += 1
+        avg_rank = (i + j) / 2.0
+        for k in range(i, j + 1):
+            quantiles[ordered[k]] = avg_rank / (n - 1)
+        i = j + 1
+    return quantiles
+
+
+def rank_weighted_standings(
+    env_scores: list[EnvMinerScores],
+    hotkeys: list[str],
+    weights: list[EnvironmentWeight] | None = None,
+) -> list[GroupStagePoints]:
+    """Combine per-environment, per-miner scores into group standings via rank normalization.
+
+    Each environment contributes a continuous score per miner (PvP win-rate, or an
+    INDIVIDUAL env's raw score). Those are converted to rank-quantiles within the
+    environment before combining, which strips away scale and spread differences:
+    a tightly-clustered env (e.g. intercode at ~[0.7, 0.8]) gets exactly the same
+    configured say as a wide-spread PvP env, instead of being drowned out by it.
+
+    The combined score is the configured-weight average of each miner's per-env
+    quantiles, so it stays on a [0, 1] scale. Miners absent from an environment are
+    treated as scoring 0.0 there, which sorts them to last place in that env — a
+    bounded penalty that, unlike a raw-score combination, cannot distort the env's
+    influence on everyone else.
+    """
+    weight_map = {w.environment: w.weight for w in weights} if weights else {}
+    quantiles = {env.environment: _rank_quantiles(env.scores_by_hotkey, hotkeys) for env in env_scores}
+
+    total_weight = sum(weight_map.get(env.environment, 1.0) for env in env_scores) or 1.0
+    points: dict[str, float] = {}
+    for hk in hotkeys:
+        points[hk] = sum(
+            weight_map.get(env.environment, 1.0) * quantiles[env.environment][hk] for env in env_scores
+        ) / total_weight
+
+    standings = [GroupStagePoints(hotkey=hk, points=points[hk]) for hk in hotkeys]
+    standings.sort(key=lambda s: s.points, reverse=True)
+    return standings
+
+
+def pvp_results_to_winrates(group_results: PvPGroupResults) -> list[EnvMinerScores]:
+    """Per-environment win-rate for each hotkey across all of its round-robin games.
+
+    Win-rate (games won, counting draws as a half-win, over games played) preserves
+    margin of victory — a 200-0 sweep yields 1.0 while a 101-99 squeaker yields ~0.5 —
+    so that the rank normalization downstream orders miners by how decisively they won.
+    """
+    wins: dict[EnvironmentName, dict[str, float]] = defaultdict(lambda: defaultdict(float))
+    games: dict[EnvironmentName, dict[str, float]] = defaultdict(lambda: defaultdict(float))
+
+    for pair in group_results.pair_results:
+        for env_name, result in pair.results.items():
+            played = result.model_a_wins + result.model_b_wins + result.draws
+            wins[env_name][pair.hotkey_a] += result.model_a_wins + 0.5 * result.draws
+            wins[env_name][pair.hotkey_b] += result.model_b_wins + 0.5 * result.draws
+            games[env_name][pair.hotkey_a] += played
+            games[env_name][pair.hotkey_b] += played
+
+    return [
+        EnvMinerScores(
+            environment=env_name,
+            scores_by_hotkey={
+                hk: (wins[env_name][hk] / env_games[hk] if env_games[hk] else 0.0)
+                for hk in group_results.hotkeys
+            },
+        )
+        for env_name, env_games in games.items()
+    ]
 
 
 # --- PvP → pairwise ---


### PR DESCRIPTION
Replace the pairwise 3/1/0 accumulation for env tournaments with per-env rank normalization. Each environment's raw scores (PvP win-rate or INDIVIDUAL raw score) are mapped to rank-quantiles in [0,1] before combining with the configured weights.

This fixes two failures of raw-score / dispersion combination, confirmed on the last env tournament:
- A tightly-clustered env (intercode ~[0.7,0.8]) no longer gets drowned out by a wide-spread PvP env; configured weights actually bite.
- A single per-env failure (0.0 in a cluster) is now a bounded last-place penalty instead of inflating that env's influence.

env_scores flow as typed EnvMinerScores rather than nested dicts.