### PR TITLE
Add othello to the PvP game suite

### DIFF
--- a/core/config/pvp_game_prompts.yml
+++ b/core/config/pvp_game_prompts.yml
@@ -76,3 +76,25 @@ gin_rummy_rules: >
   Card Values: A=1, 2-10=face value, J=10, Q=10, K=10
 
   IMPORTANT: Always respond with the action ID number ONLY, never card names.
+
+othello_rules: >
+  OTHELLO (REVERSI) RULES:
+
+  Board: 8x8 grid. Columns are labelled a-h (left to right), rows 1-8 (top to bottom).
+  Discs are two-sided: x = Black, o = White. Empty squares show as '-'. Black (x) moves first.
+
+  Goal: Have more of your discs on the board than your opponent when the game ends.
+
+  Making a move: Place one disc of your colour on an EMPTY square so that it
+  brackets one or more of the opponent's discs in a straight line (horizontal,
+  vertical, or diagonal) between the disc you place and another of your own discs.
+  Every opponent disc in each bracketed line is flipped to your colour. A move is
+  only legal if it flips at least one opponent disc. A single placement may flip
+  discs in several directions at once.
+
+  Passing: If you have no legal move, you must pass (a pass action will be the
+  only legal action offered).
+
+  Game end: The game ends when neither player can move (the board is full or no
+  legal moves remain for either side). The player with more discs wins; an equal
+  count is a draw.

--- a/core/constants.py
+++ b/core/constants.py
@@ -45,6 +45,7 @@ class EnvironmentName(str, Enum):
     GIN_RUMMY = "gin_rummy"
     LIARS_DICE = "liars_dice"
     LEDUC_POKER = "leduc_poker"
+    OTHELLO = "othello"
     INTERCODE = "intercode"
 
 
@@ -106,6 +107,22 @@ ENVIRONMENT_CONFIGS: dict[EnvironmentName, EnvironmentConfig] = {
         task_id_min=300_000_000,
         task_id_max=399_999_999,
         num_seeds=1000,
+        num_baseline_episodes=25,
+        eval_type=EvalType.PVP,
+        env_image=MCTS_API_DOCKER_IMAGE,
+        tournament_eval_image=VALIDATOR_DOCKER_IMAGE_PVP,
+        gpu_multiplier=4,
+        eval_payload_extra={
+            "opponent": "mcts",
+            "mcts_max_simulations": 50,
+            "mcts_num_rollouts": 1,
+            "api_key": "dummy-key",
+        },
+    ),
+    EnvironmentName.OTHELLO: EnvironmentConfig(
+        task_id_min=400_000_000,
+        task_id_max=499_999_999,
+        num_seeds=10_000,
         num_baseline_episodes=25,
         eval_type=EvalType.PVP,
         env_image=MCTS_API_DOCKER_IMAGE,

--- a/core/pvp/agents.py
+++ b/core/pvp/agents.py
@@ -5,6 +5,7 @@ Rules text is loaded from core/config/pvp_game_prompts.yml.
 """
 
 import functools
+import random
 import re
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -40,6 +41,16 @@ class BaseGameAgent(ABC):
         """Generate pyspiel game parameters from a config variant ID."""
         ...
 
+    def setup_initial_state(self, state: pyspiel.State, seed: int) -> None:
+        """Advance the fresh state before the models take over. Default: no-op.
+
+        Games with chance nodes (dice, card deals) get their per-game variety for
+        free from the seed passed to evaluate_bots. Deterministic games with no
+        chance nodes (e.g. othello) override this to inject seeded variety so the
+        same seed reproduces the same start while different seeds diverge.
+        """
+        return None
+
     def get_rules(self) -> str:
         return load_prompts()[self.rules_key]
 
@@ -61,28 +72,6 @@ class BaseGameAgent(ABC):
         prompts = load_prompts()
         return prompts["system_prompt_template"].format(
             game_name=self.game_name, rules=self.get_rules()
-        )
-
-    def generate_user_prompt(
-        self,
-        state: pyspiel.State,
-        player_id: int,
-        legal_actions: list[int],
-    ) -> str:
-        state_desc = self.format_state(state, player_id)
-        actions_desc = []
-        for action in legal_actions:
-            try:
-                action_str = state.action_to_string(player_id, action)
-                actions_desc.append(f"{action} -> {action_str}")
-            except (RuntimeError, AttributeError):
-                actions_desc.append(str(action))
-
-        return (
-            f"Current State:\n{state_desc}\n\n"
-            f"You are Player {player_id}.\n"
-            f"Legal Actions:\n" + "\n".join(actions_desc) + "\n\n"
-            "Your choice (ID only):"
         )
 
 
@@ -243,3 +232,41 @@ class GinRummyAgent(BaseGameAgent):
 
     def format_state(self, state: pyspiel.State, player_id: int) -> str:
         return state.observation_string(player_id)
+
+
+# Number of seeded random opening plies applied to an othello game, sampled from
+# this inclusive range. Enough to diverge the opening tree for variety, few
+# enough that positions stay balanced and game-like.
+_OTHELLO_OPENING_PLIES = (2, 6)
+
+
+class OthelloAgent(BaseGameAgent):
+
+    @property
+    def game_name(self) -> str:
+        return "othello"
+
+    @property
+    def rules_key(self) -> str:
+        return "othello_rules"
+
+    def generate_params(self, config_id: int) -> dict[str, int]:
+        return {}
+
+    def setup_initial_state(self, state: pyspiel.State, seed: int) -> None:
+        """Apply a seeded number of uniformly-random legal opening moves.
+
+        Othello is deterministic with no chance nodes, so every game would start
+        from the identical board. Deriving the opening plies from the instance
+        seed keeps games reproducible (same seed -> same start) while giving each
+        seed a distinct mid-game position to play from.
+        """
+        rng = random.Random(seed)
+        num_plies = rng.randint(*_OTHELLO_OPENING_PLIES)
+        for _ in range(num_plies):
+            if state.is_terminal():
+                break
+            legal_actions = state.legal_actions()
+            if not legal_actions:
+                break
+            state.apply_action(rng.choice(legal_actions))

--- a/core/pvp/baseline.py
+++ b/core/pvp/baseline.py
@@ -119,6 +119,7 @@ def run_mcts_baseline(
         bots[mcts_seat] = _make_mcts_bot(game, simulations, seed + mcts_seat)
 
         state = game.new_initial_state()
+        agent.setup_initial_state(state, seed)
         evaluation = _evaluate_game_with_timeout(state, bots, seed)
         outcome = determine_outcome(
             GameScoringContext(

--- a/core/pvp/game_eval.py
+++ b/core/pvp/game_eval.py
@@ -17,6 +17,7 @@ from core.pvp.agents import BaseGameAgent
 from core.pvp.agents import GinRummyAgent
 from core.pvp.agents import LeducPokerAgent
 from core.pvp.agents import LiarsDiceAgent
+from core.pvp.agents import OthelloAgent
 from core.pvp.bot import ContextOverflowError
 from core.pvp.bot import EmptyLegalActionsError
 from core.pvp.bot import InvalidActionForfeitError
@@ -31,6 +32,7 @@ _AGENT_REGISTRY: dict[EnvironmentName, type[BaseGameAgent]] = {
     EnvironmentName.LIARS_DICE: LiarsDiceAgent,
     EnvironmentName.LEDUC_POKER: LeducPokerAgent,
     EnvironmentName.GIN_RUMMY: GinRummyAgent,
+    EnvironmentName.OTHELLO: OthelloAgent,
 }
 
 

--- a/dockerfiles/environment_functions/othello.py
+++ b/dockerfiles/environment_functions/othello.py
@@ -1,0 +1,188 @@
+def rollout_first_prompt_and_completion(prompts: list[str], trainer, max_turns: int = 30) -> dict[str, list]:
+    from trl.experimental.openenv import generate_rollout_completions
+    import os
+    import random
+    import requests
+    import json
+    DEBUG = False
+
+    games_to_task_id_range = {
+        "goofspiel": (0, 99999999),
+        "liars_dice": (100000000, 199999999),
+        "leduc_poker": (200000000, 299999999),
+        "gin_rummy": (300000000, 399999999),
+        "othello": (400000000, 499999999),
+        "backgammon": (500000000, 599999999),
+        "hex": (600000000, 699999999),
+        "clobber": (700000000, 799999999),
+    }
+
+    selected_game = "othello"
+
+    # --- 1. Static Initialization (Once per Rank) ---
+    # We check if the function has already established a connection for this worker
+    if not getattr(rollout_first_prompt_and_completion, "initialized", False):
+        # Get local rank
+        rank = int(os.environ.get("LOCAL_RANK", "0"))
+
+        # Get env server for that local rank
+        raw_urls = os.environ.get("ENVIRONMENT_SERVER_URLS", "")
+        server_list = [url.strip() for url in raw_urls.split(",") if url.strip()]
+
+        # Determine endpoint
+        if not server_list:
+            # Fallback (though likely fatal for the task)
+            base_url = ""
+            print("Warning: No ENVIRONMENT_SERVER_URLS found.")
+        else:
+            base_url = server_list[rank % len(server_list)]
+
+        # Store endpoint on the function to avoid re-parsing
+        rollout_first_prompt_and_completion.base_url = base_url
+
+        # Create environment (POST /create) - ONLY ONCE
+        try:
+            print(f"Initializing environment on rank {rank} at {base_url}...")
+            payload = {"task_id": games_to_task_id_range[selected_game][0], "seed": 42, "opponent": "mcts", "mcts_max_simulations": 25, "mcts_num_rollouts": 1}
+            create_res = requests.post(f"{base_url}/reset", json=payload, timeout=300)
+            create_res.raise_for_status()
+            rollout_first_prompt_and_completion.initialized = True
+            print(f"Environment initialized. Rank: {rank}.")
+        except Exception as e:
+            print(f"CRITICAL: Failed to create environment on rank {rank}: {e}")
+            raise e
+
+    # Retrieve static variables
+    env_endpoint = rollout_first_prompt_and_completion.base_url
+
+    # --- 2. Rollout Setup ---
+    all_episode_prompt_ids: list[list[int]] = []
+    all_episode_completion_ids: list[list[int]] = []
+    all_episode_logprobs: list[list[float]] = []
+    all_episode_rewards: list[float] = []
+
+    tokenizer = trainer.processing_class
+    TIMEOUT = 2400
+
+    # --- 3. Batch Loop ---
+    # We use a random game_id for the batch, or you could sample per item if preferred
+    game_id = random.randint(games_to_task_id_range[selected_game][0], games_to_task_id_range[selected_game][1])
+
+    for i, prompt in enumerate(prompts):
+        episode_prompt_ids: list[int] = []
+        episode_completion_ids: list[int] = []
+        episode_logprobs: list[float] = []
+        done = False
+        solved = False
+        train_reward = 0
+        turn_number = 0
+
+        # --- Reset Environment (POST /reset) ---
+        # Reuse existing env_id, just change the game
+        payload = {"task_id": game_id, "seed": game_id, "opponent": "mcts", "mcts_max_simulations": 25, "mcts_num_rollouts": 1}
+
+        try:
+            reset_res = requests.post(f"{env_endpoint}/reset", json=payload, timeout=TIMEOUT)
+            reset_res.raise_for_status()
+            reset_data = reset_res.json()
+            result_block = reset_data["result"]
+
+            # Get episode id for rest of interactions
+            episode_id = result_block.get("episode_id", "")
+
+            # Construct Initial Observation
+            current_observation = result_block.get("observation", "")
+            format_instructions = 'Your output must strictly follow this format: "Thought:\nyour thoughts ONLY in text.\n\nAction:\nONLY your action ID (a single number)."'
+            current_observation += format_instructions
+
+            if DEBUG:
+                print(f"Env Reset. Observation: {current_observation}", flush=True)
+
+        except Exception as e:
+            print(f"Failed to reset environment (Game {game_id}): {e}")
+            continue
+
+        # --- Build Conversation History ---
+        messages = []
+
+        messages.append({"role": "user", "content": current_observation})
+
+        # --- Interaction Loop ---
+        while not done and (turn_number < max_turns):
+            # Generate Rollout Completion
+            rollout_outputs = generate_rollout_completions(trainer, prompts=[messages], as_chat=True)[0]
+            prompt_ids = rollout_outputs.get("prompt_ids", [])
+            completion_ids = rollout_outputs.get("completion_ids", [])
+            logprobs = rollout_outputs.get("logprobs", [])
+            completion_text = tokenizer.decode(completion_ids, skip_special_tokens=True).strip()
+
+            if turn_number == 0:
+                episode_prompt_ids = prompt_ids
+                episode_completion_ids = completion_ids
+                episode_logprobs = logprobs
+
+            messages.append({"role": "assistant", "content": completion_text})
+
+            # --- Parse Action ---
+            action_to_send = completion_text
+            if action_to_send.endswith("</s>"):
+                action_to_send = action_to_send[:-5]
+
+            # Parse ReAct format
+            if "Action:" in action_to_send:
+                action_to_send = action_to_send.split("Action:")[-1].strip()
+
+            # --- Step Environment (POST /step) ---
+            if DEBUG:
+                print(f"Sending Action to Env: {action_to_send}", flush=True)
+
+            try:
+                formatted_observation = ""
+                step_payload = {"action": action_to_send, "episode_id": episode_id}
+                step_res = requests.post(f"{env_endpoint}/step", json=step_payload, timeout=TIMEOUT)
+                step_res.raise_for_status()
+                step_data = step_res.json()
+                step_block = step_data["result"]
+
+                if DEBUG:
+                    print(f"Env Step Response: {step_data}", flush=True)
+
+                # Extract response data
+                step_state = step_block.get("observation", "")
+                step_reward = step_block.get("reward", 0)
+                done = step_block.get("done", False)
+
+                # Format next observation
+                formatted_observation = step_state
+
+            except Exception as e:
+                if DEBUG:
+                    print(f"Step failed: {e}")
+                formatted_observation = "Invalid Action.\n\n" + formatted_observation
+                step_reward = -0.01
+                done = False
+
+            if done:
+                train_reward = step_reward
+            else:
+                messages.append({"role": "user", "content": formatted_observation})
+
+            turn_number += 1
+
+        all_episode_prompt_ids.append(episode_prompt_ids)
+        all_episode_completion_ids.append(episode_completion_ids)
+        all_episode_logprobs.append(episode_logprobs)
+        all_episode_rewards.append(train_reward)
+
+
+
+    return {
+        "prompt_ids": all_episode_prompt_ids,
+        "completion_ids": all_episode_completion_ids,
+        "logprobs": all_episode_logprobs,
+        "env_rewards": all_episode_rewards
+    }
+
+def rollout_reward_func(completions, **kwargs):
+    rewards = kwargs.get("env_rewards") if kwargs else None
+    return [float(r) for r in rewards] if rewards is not None else [0.0] * len(completions)

--- a/scripts/text_trainer.py
+++ b/scripts/text_trainer.py
@@ -27,7 +27,8 @@ from core.config.config_handler import update_flash_attention
 from core.dataset_utils import adapt_columns_for_dpo_dataset
 from core.dataset_utils import adapt_columns_for_grpo_dataset
 from core.dataset_utils import adapt_columns_for_environment_dataset
-from core.constants import EnvironmentName
+from core.constants import ENVIRONMENT_CONFIGS
+from core.constants import EvalType
 from core.models.utility_models import ChatTemplateDatasetType
 from core.models.utility_models import DpoDatasetType
 from core.models.utility_models import FileFormat
@@ -114,7 +115,7 @@ def create_config(task_id, model, dataset, dataset_type, file_format, output_dir
         config["trl"]["reward_weights"] = [reward_function.reward_weight for reward_function in dataset_type.reward_functions]
     elif isinstance(dataset_type, EnvironmentDatasetType):
         env = (dataset_type.environment_names or [None])[0]
-        if env in (EnvironmentName.GIN_RUMMY, EnvironmentName.LIARS_DICE, EnvironmentName.LEDUC_POKER):
+        if env is not None and ENVIRONMENT_CONFIGS[env].eval_type == EvalType.PVP:
             config["trl"]["rollout_func"] = f"{env.value}.rollout_first_prompt_and_completion"
             config["trl"]["reward_funcs"] = [f"{env.value}.rollout_reward_func"]
             config["trl"]["reward_weights"] = [1.0]

--- a/tests/test_pvp_coverage_gaps.py
+++ b/tests/test_pvp_coverage_gaps.py
@@ -770,22 +770,6 @@ class TestGameAgentPrompts:
         assert len(prompt) > 50
         assert "leduc" in prompt.lower() or "poker" in prompt.lower()
 
-    def test_liars_dice_user_prompt_has_legal_actions(self):
-        from validator.evaluation.pvp.agents import LiarsDiceAgent
-        agent = LiarsDiceAgent()
-        game = pyspiel.load_game("liars_dice", {"players": 2, "numdice": 5})
-        state = game.new_initial_state()
-        while state.is_chance_node():
-            outcomes = state.chance_outcomes()
-            actions, _ = zip(*outcomes)
-            state.apply_action(actions[0])
-
-        legal = state.legal_actions(state.current_player())
-        prompt = agent.generate_user_prompt(state, state.current_player(), legal)
-
-        assert "Legal Actions:" in prompt
-        assert "Player" in prompt
-
     def test_gin_rummy_format_state_doesnt_crash(self):
         from validator.evaluation.pvp.agents import GinRummyAgent
         agent = GinRummyAgent()

--- a/tests/test_pvp_game_instances.py
+++ b/tests/test_pvp_game_instances.py
@@ -18,9 +18,12 @@ try:
     if importlib.util.find_spec("pyspiel") is None:
         raise ImportError
 
+    import pyspiel
+
     from validator.evaluation.pvp.agents import GinRummyAgent
     from validator.evaluation.pvp.agents import LeducPokerAgent
     from validator.evaluation.pvp.agents import LiarsDiceAgent
+    from validator.evaluation.pvp.agents import OthelloAgent
     from validator.evaluation.pvp.game_runner import PlayedGame
     from validator.evaluation.pvp.game_runner import _build_instances
     from validator.evaluation.pvp.game_runner import _execute_matchup
@@ -116,6 +119,46 @@ class TestConfigIdVariation:
         p0 = agent.generate_params(0)
         p1 = agent.generate_params(99)
         assert p0 == p1 == {"players": 2}
+
+    def test_othello_params_empty(self):
+        """Othello takes no pyspiel parameters regardless of config_id."""
+        agent = OthelloAgent()
+        assert agent.generate_params(0) == agent.generate_params(99) == {}
+
+
+# --- 3c': Othello seeded opening plies (deterministic game needs injected variety) ---
+
+
+@needs_pyspiel
+class TestOthelloOpeningPlies:
+    def _opened_board(self, seed: int) -> str:
+        """Fresh othello state advanced by the agent's seeded opening plies."""
+        agent = OthelloAgent()
+        state = pyspiel.load_game("othello").new_initial_state()
+        agent.setup_initial_state(state, seed)
+        return state.observation_string(0)
+
+    def test_same_seed_same_opening(self):
+        assert self._opened_board(42) == self._opened_board(42)
+
+    def test_different_seed_different_opening(self):
+        """Across a spread of seeds, openings should diverge (not all identical)."""
+        boards = {self._opened_board(seed) for seed in range(20)}
+        assert len(boards) > 1, "All seeds produced the identical opening board"
+
+    def test_opening_leaves_playable_nonterminal_state(self):
+        agent = OthelloAgent()
+        for seed in range(20):
+            state = pyspiel.load_game("othello").new_initial_state()
+            agent.setup_initial_state(state, seed)
+            assert not state.is_terminal()
+            assert state.current_player() in (0, 1)
+            assert state.legal_actions()
+
+    def test_opening_diverges_from_fresh_board(self):
+        """At least some seeds move the board off the standard starting position."""
+        fresh = pyspiel.load_game("othello").new_initial_state().observation_string(0)
+        assert any(self._opened_board(seed) != fresh for seed in range(20))
 
 
 # --- 3d: _tally correctness ---

--- a/trainer/image_manager.py
+++ b/trainer/image_manager.py
@@ -648,6 +648,7 @@ FALLBACK_ENV_IMAGES: dict[core_cst.EnvironmentName, str] = {
     core_cst.EnvironmentName.GIN_RUMMY: core_cst.MCTS_API_DOCKER_IMAGE,
     core_cst.EnvironmentName.LIARS_DICE: core_cst.MCTS_API_DOCKER_IMAGE,
     core_cst.EnvironmentName.LEDUC_POKER: core_cst.MCTS_API_DOCKER_IMAGE,
+    core_cst.EnvironmentName.OTHELLO: core_cst.MCTS_API_DOCKER_IMAGE,
 }
 
 

--- a/validator/evaluation/pvp/agents.py
+++ b/validator/evaluation/pvp/agents.py
@@ -4,7 +4,8 @@ from core.pvp.agents import BaseGameAgent
 from core.pvp.agents import GinRummyAgent
 from core.pvp.agents import LeducPokerAgent
 from core.pvp.agents import LiarsDiceAgent
+from core.pvp.agents import OthelloAgent
 from core.pvp.agents import load_prompts
 
 
-__all__ = ["BaseGameAgent", "GinRummyAgent", "LeducPokerAgent", "LiarsDiceAgent", "load_prompts"]
+__all__ = ["BaseGameAgent", "GinRummyAgent", "LeducPokerAgent", "LiarsDiceAgent", "OthelloAgent", "load_prompts"]

--- a/validator/evaluation/pvp/game_runner.py
+++ b/validator/evaluation/pvp/game_runner.py
@@ -321,6 +321,7 @@ def _play_game(
     bots[model_b_player_id] = bot_b
 
     state = game.new_initial_state()
+    agent.setup_initial_state(state, instance.seed)
     evaluation = _evaluate_game_with_timeout(state, bots, instance.seed)
 
     def _outcome_for(player_id: int):


### PR DESCRIPTION
Wire othello (OpenSpiel) as a PvP environment across eval, scoring, and training paths:

- EnvironmentName.OTHELLO + ENVIRONMENT_CONFIGS entry (task_id 400M-499M, PVP, MCTS baseline payload)
- OthelloAgent + a setup_initial_state hook on BaseGameAgent. Othello is deterministic with no chance nodes, so the hook applies 2-6 seeded random opening plies: same seed reproduces the same start, different seeds diverge. Paired base/swapped instances share a seed, preserving seat fairness.
- Register in _AGENT_REGISTRY; othello_rules in pvp_game_prompts.yml
- Call setup_initial_state in game_runner and baseline after new_initial_state
- Reference trainer rollout fn (dockerfiles/environment_functions/othello.py)
- text_trainer: drive rollout_func wiring off eval_type == PVP instead of a hardcoded game tuple, so othello (and future PvP games) are covered
- Add othello to FALLBACK_ENV_IMAGES for consistency

Cleanup: drop the dead BaseGameAgent.generate_user_prompt (the runtime uses LLMBot._user_prompt) and its test; OthelloAgent relies on the base format_state rather than re-overriding observation_string.