### PR TITLE
Fix migration timestamp collision: rename add_kl to 20260602120001

### DIFF
--- a/validator/db/migrations/20260602120000_add_kl_to_instruct_tasks.sql
+++ b/validator/db/migrations/20260602120000_add_kl_to_instruct_tasks.sql
@@ -1,9 +1,0 @@
--- migrate:up
-ALTER TABLE instruct_text_tasks
-    ADD COLUMN use_kl BOOLEAN NOT NULL DEFAULT FALSE,
-    ADD COLUMN kl_coef DOUBLE PRECISION DEFAULT NULL;
-
--- migrate:down
-ALTER TABLE instruct_text_tasks
-    DROP COLUMN IF EXISTS use_kl,
-    DROP COLUMN IF EXISTS kl_coef;

--- a/validator/db/migrations/20260602120001_add_kl_to_instruct_tasks.sql
+++ b/validator/db/migrations/20260602120001_add_kl_to_instruct_tasks.sql
@@ -1,0 +1,10 @@
+-- migrate:up
+-- Timestamp ...120001 to not collide with 20260602120000_add_evaluation_gpu_count.sql.
+ALTER TABLE instruct_text_tasks
+    ADD COLUMN IF NOT EXISTS use_kl BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS kl_coef DOUBLE PRECISION DEFAULT NULL;
+
+-- migrate:down
+ALTER TABLE instruct_text_tasks
+    DROP COLUMN IF EXISTS use_kl,
+    DROP COLUMN IF EXISTS kl_coef;


### PR DESCRIPTION
Two migrations shared timestamp 20260602120000 (add_evaluation_gpu_count and add_kl_to_instruct_tasks). dbmate keys on the leading timestamp, so only one ran and the other was silently skipped while still recorded as applied. This left instruct_text_tasks.use_kl/kl_coef (or evaluations.gpu_count) missing on migrated DBs. Rename the KL migration to a unique timestamp and make its ALTERs idempotent (ADD COLUMN IF NOT EXISTS) so it re-applies safely.