### PR TITLE
fix: make task_nodes baseline_stats migration idempotent

### DIFF
--- a/validator/db/migrations/20260530120000_add_baseline_stats_to_task_nodes.sql
+++ b/validator/db/migrations/20260530120000_add_baseline_stats_to_task_nodes.sql
@@ -1,6 +1,6 @@
 -- migrate:up
 ALTER TABLE task_nodes
-    ADD COLUMN baseline_stats JSONB DEFAULT NULL;
+    ADD COLUMN IF NOT EXISTS baseline_stats JSONB DEFAULT NULL;
 
 -- migrate:down
 ALTER TABLE task_nodes


### PR DESCRIPTION
## Problem

Applying migrations fails with:

```
Applying: 20260530120000_add_baseline_stats_to_task_nodes.sql
Error: pq: column "baseline_stats" of relation "task_nodes" already exists (42701)
```

This migration was retroactively added (#1164, "fix: add missing migration") for a column that already existed on running DBs. On any such DB, plain `ADD COLUMN` errors with 42701 and — since dbmate runs each migration in a transaction — rolls back, which also blocks every later migration (`20260602…` onward).

## Fix

Use `ADD COLUMN IF NOT EXISTS`, matching the convention already used across the repo's migrations. No-op where the column exists, normal create on a fresh DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)