### PR TITLE
Fix env tournament scoring crash: accumulate env scores as a list

### DIFF
--- a/validator/evaluation/scoring.py
+++ b/validator/evaluation/scoring.py
@@ -700,16 +700,16 @@ async def _run_env_tournament_eval(
         f"pvp_envs={[e.value for e in pvp_envs]}, individual_envs={[e.value for e in individual_envs]}"
     )
 
-    env_scores: dict[core_cst.EnvironmentName, dict[str, float]] = {}
+    env_scores: list[EnvMinerScores] = []
 
     if pvp_envs:
-        env_scores.update(await _eval_pvp_envs(
+        env_scores.extend(await _eval_pvp_envs(
             task_id=str(task.task_id), pvp_envs=pvp_envs, miners=miners,
             base_model=base_model, seed=seed, config=config,
         ))
 
     if individual_envs:
-        env_scores.update(await _eval_individual_envs(
+        env_scores.extend(await _eval_individual_envs(
             task_id=task.task_id, individual_envs=individual_envs, miners=miners,
             base_model=base_model, model_params=model_params, seed=seed, config=config,
         ))


### PR DESCRIPTION
`_run_env_tournament_eval` built `env_scores` as a dict and `.update()`d it with the results of `_eval_pvp_envs` / `_eval_individual_envs`, but both now return `list[EnvMinerScores]` (changed in #1185). `dict.update()` on a list of pydantic models unpacks each model's (field, value) pairs as keys/values, so `env_scores` became a dict keyed by tuples. `rank_weighted_standings` then iterated it expecting `list[EnvMinerScores]` and hit `'tuple' object has no attribute 'environment'`, failing every eval cycle and resetting tournament tasks to pending in an infinite loop.

Accumulate into a `list[EnvMinerScores]` via `.extend()` so the type matches `rank_weighted_standings`. Pure in-memory change; per-env scores are already DB-persisted and idempotent, so stuck tasks self-heal on the next cycle.