### PR TITLE
Soften model augmentation toward realistic starting points

### DIFF
--- a/validator/core/constants.py
+++ b/validator/core/constants.py
@@ -410,13 +410,13 @@ MODEL_PREP_ENABLED_BY_TASK_TYPE: dict[TaskType, bool] = {
 AUGMENTATION_ENABLED_TEXT = True  # Enable augmentations for text tasks
 AUGMENTATION_ENABLED_IMAGE = False  # Enable augmentations for image tasks
 AUGMENTATION_ENABLED_ENV = False  # Enable augmentations for environment tasks
-AUGMENTATION_PROBABILITY = 0.65  # Probability that a task gets any augmentation at all
+AUGMENTATION_PROBABILITY = 0.5  # Probability that a task gets any augmentation at all
 
 # Weighted distribution over augmentation types (normalised at runtime)
 # When an augmentation is applied, one type is chosen according to these weights
 AUGMENTATION_TYPE_WEIGHTS: dict[AugmentationType, float] = {
-    AugmentationType.GAUSSIAN_NOISE: 0.10,
-    AugmentationType.WEIGHT_SCALING: 0.50,
+    AugmentationType.GAUSSIAN_NOISE: 0.20,
+    AugmentationType.WEIGHT_SCALING: 0.40,
     AugmentationType.MAGNITUDE_PRUNING: 0.25,
     AugmentationType.LAYER_REINIT: 0.15,
 }
@@ -433,7 +433,7 @@ AUGMENTATION_SCOPE_WEIGHTS: dict[AugmentationScope, float] = {
 # Intensity ranges per augmentation type (min, max) — sampled uniformly
 AUGMENTATION_INTENSITY_RANGES: dict[AugmentationType, tuple[float, float]] = {
     AugmentationType.GAUSSIAN_NOISE: (0.01, 0.3),
-    AugmentationType.WEIGHT_SCALING: (0.3, 1.7),
+    AugmentationType.WEIGHT_SCALING: (0.5, 1.5),
     AugmentationType.MAGNITUDE_PRUNING: (0.25, 0.50),
     AugmentationType.LAYER_REINIT: (0.05, 0.15),
 }


### PR DESCRIPTION
- Probability 0.65 -> 0.5: more tasks run on a clean base model
- WEIGHT_SCALING intensity 1.7 -> 1.5 upper bound: keep fp16 forward pass out of the overflow/NaN regime
- Rebalance type weights toward smooth, information-preserving ops (noise 0.10 -> 0.20, scaling 0.50 -> 0.40)

Goal: augmentation should shift the optimal LR / training dynamics, not approximate training from scratch.