### PR TITLE
tournament: lower text/image min field size 8 → 4

### DIFF
--- a/validator/core/constants.py
+++ b/validator/core/constants.py
@@ -129,7 +129,7 @@ MIN_SUCCESSFUL_SCORES_FOR_HISTORICAL_TASK = 2
 
 # Tournament Start Requirements
 MIN_MINERS_FOR_ENV_TOURN = 5
-MIN_MINERS_FOR_TOURN = 8
+MIN_MINERS_FOR_TOURN = 4  # within the small-tournament band (3..9): round 1 is a single group, top 2 advance to a knockout
 
 
 TOURNAMENT_PARTICIPATION_WEIGHT = 0.0001  # Weight given to active participants


### PR DESCRIPTION
## What
`MIN_MINERS_FOR_TOURN` 8 → 4 (text/image tournament start gate).

## Why
A text tournament with **7** validated miners (`tourn_4231dffa5baf2bea_20260611`) was held back by the `>= 8` gate, looping a 30-minute wait despite the bracket already supporting small fields.

## Safety
The small-tournament path is purpose-built for this. For text/image at round 1, a field in the **3..9** band runs a single-group format (play `SMALL_TOURNAMENT_GROUP_TASKS`, advance `SMALL_TOURNAMENT_ADVANCE=2` into a knockout that decides the boss challenger), with a hard floor of `SMALL_TOURNAMENT_MIN_PARTICIPANTS=3`. **4 sits inside that band and above the floor**, so a 4+ field runs a proper bracket. Env tournaments are unaffected (own `MIN_MINERS_FOR_ENV_TOURN=5`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)