### PR TITLE
Refactor node fetching logic in refresh_nodes.py and weight_setting.py

### DIFF
--- a/validator/core/refresh_nodes.py
+++ b/validator/core/refresh_nodes.py
@@ -4,10 +4,12 @@ migrating the old nodes to history in the process
 """
 
 import asyncio
+import concurrent.futures
 from datetime import datetime
 from datetime import timedelta
 
 from fiber.chain import fetch_nodes
+from fiber.chain import interface
 from fiber.chain.models import Node
 
 from validator.core.config import Config
@@ -23,8 +25,19 @@ logger = get_logger(__name__)
 
 
 async def _fetch_nodes_from_substrate(config: Config) -> list[Node]:
-    # It won't cause issues with substrate, as it creates a new connection.
-    return await asyncio.to_thread(fetch_nodes.get_nodes_for_netuid, config.substrate, config.netuid)
+    substrate = None
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    try:
+        loop = asyncio.get_running_loop()
+        substrate = await loop.run_in_executor(executor, interface.get_substrate, None, config.substrate.url)
+        return await loop.run_in_executor(executor, fetch_nodes._get_nodes_for_uid, substrate, config.netuid)
+    finally:
+        if substrate is not None:
+            try:
+                substrate.close()
+            except Exception:
+                logger.debug("Failed to close temporary substrate connection", exc_info=True)
+        executor.shutdown(wait=False, cancel_futures=True)
 
 
 async def _is_recent_update(config: Config) -> bool:

--- a/validator/core/weight_setting.py
+++ b/validator/core/weight_setting.py
@@ -517,7 +517,7 @@ async def get_node_weights_from_tournament_audit_data(
     netuid: int,
     tournament_audit_data: TournamentAuditData,
 ) -> NodeWeightsResult:
-    all_nodes: list[Node] = fetch_nodes.get_nodes_for_netuid(substrate, netuid)
+    all_nodes: list[Node] = fetch_nodes._get_nodes_for_uid(substrate, netuid)
     hotkey_to_node_id: dict[str, int] = {node.hotkey: node.node_id for node in all_nodes}
 
     all_node_ids: list[int] = [node.node_id for node in all_nodes]
@@ -741,7 +741,7 @@ async def _get_and_set_weights(config: Config, validator_node_id: int) -> bool:
 
 
 async def _set_metagraph_weights(config: Config) -> None:
-    nodes: list[Node] = fetch_nodes.get_nodes_for_netuid(config.substrate, config.netuid)
+    nodes: list[Node] = fetch_nodes._get_nodes_for_uid(config.substrate, config.netuid)
     node_ids = [node.node_id for node in nodes]
     node_weights = [node.incentive for node in nodes]
     validator_node_id = await get_vali_node_id(config.substrate, config.keypair.ss58_address)


### PR DESCRIPTION
Updated the node fetching mechanism to utilize a temporary substrate connection and improved error handling. The changes include:
- In `refresh_nodes.py`, replaced direct calls to `fetch_nodes.get_nodes_for_netuid` with a more robust implementation using `asyncio` and `concurrent.futures` to manage the substrate connection.
- In `weight_setting.py`, modified calls to fetch nodes to use the new `_get_nodes_for_uid` method, ensuring consistency across the codebase.

These updates enhance the reliability and maintainability of the node fetching process.