### PR TITLE
tournament scoring: no emissions for round 1 (entry/group round)

### DIFF
--- a/validator/evaluation/tournament_scoring.py
+++ b/validator/evaluation/tournament_scoring.py
@@ -255,6 +255,12 @@ def calculate_tournament_type_scores_from_data(
         round_number = round_result.round_number
         is_final_round = round_result.is_final_round
 
+        # Round 1 is the entry/group round: it decides who advances but must NOT
+        # earn tournament emissions. Only results from later rounds (round_number > 1)
+        # accumulate points toward weights.
+        if round_number <= 1:
+            continue
+
         for task in round_result.tasks:
             winner = task.winner
 


### PR DESCRIPTION
Round-1 (group/entry round) per-task winners were earning points (round_number * type_weight) and thus emissions, even though round 1 only decides who advances. Skip round_number <= 1 in score accumulation so only results from later rounds (knockouts / boss round) earn tournament weight.