### PR TITLE
boss round: fix performance_difference for negative scores

### DIFF
--- a/validator/tournament/performance_calculator.py
+++ b/validator/tournament/performance_calculator.py
@@ -150,14 +150,15 @@ async def calculate_boss_round_performance_differences(tournament_id: str, psql_
             perf_diff = calculate_env_perf_diff_from_win_pct(win_pct)
             challenger_won = challenger_score > boss_score
         elif is_higher_better:
-            if boss_score > 0:
-                perf_diff = (challenger_score - boss_score) / boss_score
+            # abs() so the relative margin keeps its sign for negative scores (e.g. GRPO rewards)
+            if boss_score != 0:
+                perf_diff = (challenger_score - boss_score) / abs(boss_score)
             else:
                 perf_diff = 0.0
             challenger_won = challenger_score > boss_score * (1 + threshold)
         else:
-            if challenger_score > 0:
-                perf_diff = (boss_score - challenger_score) / challenger_score
+            if challenger_score != 0:
+                perf_diff = (boss_score - challenger_score) / abs(challenger_score)
             else:
                 perf_diff = 0.0
             challenger_won = challenger_score < boss_score * (1 - threshold)


### PR DESCRIPTION
For higher-is-better tasks (GRPO, environment) the relative margin was computed as (challenger - boss) / boss only when boss_score > 0, and silently returned 0.0 otherwise. GRPO boss tasks with negative rewards therefore reported a 0% margin alongside a challenger win, and a 0.0 would be fed into the median used for the winning performance difference on a dethrone. Use abs() denominators so the margin keeps the correct sign regardless of score sign, in both the higher- and lower-is-better branches. Positive-score results are unchanged ((c - b) / abs(b) == (c - b) / b for b > 0).