### PR TITLE
tournament: GRPO training-hours model + small-task rounding fix

### DIFF
--- a/validator/core/constants.py
+++ b/validator/core/constants.py
@@ -96,15 +96,24 @@ MEASURED_THROUGHPUT_MINER_RATIO = 1.0
 # Guard rails on measured throughput: clamp to this band around the analytic
 # estimate so a bad measurement can't produce absurd hours.
 MEASURED_THROUGHPUT_CLAMP = (0.33, 3.0)
-# FLOPs-per-token multiplier relative to plain fwd+bwd on total_tokens.
-# DPO: ref-model forward on chosen+rejected adds ~1/3. GRPO: rollout generation
-# cost is not captured by prompt token counts; crude multiplier, tune with data.
+# FLOPs-per-token multiplier on total_tokens (token-coverage-driven types only).
+# DPO: ref-model forward on chosen+rejected adds ~1/3. GRPO is excluded — it is
+# step-budgeted, not token-proportional (see GRPO_HOURS_BY_PARAMS_B).
 TASK_TYPE_HOURS_MULTIPLIER: dict[TaskType, float] = {
     TaskType.INSTRUCTTEXTTASK: 1.0,
     TaskType.CHATTASK: 1.0,
     TaskType.DPOTASK: 1.4,
-    TaskType.GRPOTASK: 1.5,
 }
+
+# GRPO hours: fixed per model size, independent of dataset size (RL saturates on
+# steps, not coverage). (upper_bound_billions, hours); first matching band wins.
+# Calibrate against trainer run history.
+GRPO_HOURS_BY_PARAMS_B: list[tuple[float, float]] = [
+    (4.0, 1.5),
+    (12.0, 2.5),
+    (40.0, 4.0),
+    (float("inf"), 6.0),
+]
 
 # text augmentation synth
 TEXT_SYNTH_MODEL = "Qwen/Qwen3-32B"

--- a/validator/core/constants.py
+++ b/validator/core/constants.py
@@ -103,7 +103,7 @@ TASK_TYPE_HOURS_MULTIPLIER: dict[TaskType, float] = {
     TaskType.INSTRUCTTEXTTASK: 1.0,
     TaskType.CHATTASK: 1.0,
     TaskType.DPOTASK: 1.4,
-    TaskType.GRPOTASK: 1.3,
+    TaskType.GRPOTASK: 1.5,
 }
 
 # text augmentation synth

--- a/validator/core/constants.py
+++ b/validator/core/constants.py
@@ -96,18 +96,16 @@ MEASURED_THROUGHPUT_MINER_RATIO = 1.0
 # Guard rails on measured throughput: clamp to this band around the analytic
 # estimate so a bad measurement can't produce absurd hours.
 MEASURED_THROUGHPUT_CLAMP = (0.33, 3.0)
-# FLOPs-per-token multiplier on total_tokens (token-coverage-driven types only).
-# DPO: ref-model forward on chosen+rejected adds ~1/3. GRPO is excluded — it is
-# step-budgeted, not token-proportional (see GRPO_HOURS_BY_PARAMS_B).
+# Per-token FLOPs multiplier (DPO adds a ref-model forward). GRPO is excluded —
+# it is step-budgeted, not token-proportional (see GRPO_HOURS_BY_PARAMS_B).
 TASK_TYPE_HOURS_MULTIPLIER: dict[TaskType, float] = {
     TaskType.INSTRUCTTEXTTASK: 1.0,
     TaskType.CHATTASK: 1.0,
     TaskType.DPOTASK: 1.4,
 }
 
-# GRPO hours: fixed per model size, independent of dataset size (RL saturates on
-# steps, not coverage). (upper_bound_billions, hours); first matching band wins.
-# Calibrate against trainer run history.
+# GRPO hours, fixed per model size (RL saturates on steps, not dataset coverage).
+# (upper_bound_billions, hours); first matching band wins. Calibrate from runs.
 GRPO_HOURS_BY_PARAMS_B: list[tuple[float, float]] = [
     (4.0, 1.5),
     (12.0, 2.5),
@@ -115,8 +113,7 @@ GRPO_HOURS_BY_PARAMS_B: list[tuple[float, float]] = [
     (float("inf"), 6.0),
 ]
 
-# GRPO time is fixed per size, so the dataset must hold enough prompts that the
-# miner's epoch cap doesn't exhaust the data before that budget is spent.
+# Floor so the miner's epoch cap can't exhaust the data before the budget.
 GRPO_MIN_SYNTH_ROWS = 20_000
 
 # text augmentation synth

--- a/validator/core/constants.py
+++ b/validator/core/constants.py
@@ -115,6 +115,10 @@ GRPO_HOURS_BY_PARAMS_B: list[tuple[float, float]] = [
     (float("inf"), 6.0),
 ]
 
+# GRPO time is fixed per size, so the dataset must hold enough prompts that the
+# miner's epoch cap doesn't exhaust the data before that budget is spent.
+GRPO_MIN_SYNTH_ROWS = 20_000
+
 # text augmentation synth
 TEXT_SYNTH_MODEL = "Qwen/Qwen3-32B"
 TEXT_SYNTH_MODEL_TEMPERATURE = 0.6

--- a/validator/tasks/synthetic_scheduler.py
+++ b/validator/tasks/synthetic_scheduler.py
@@ -351,10 +351,14 @@ async def get_dataset(
     task_type: TaskType | None = None,
     keypair: Keypair | None = None,
     psql_db: PSQLDB | None = None,
+    min_rows: int | None = None,
 ) -> Dataset:
     """Get a single dataset from the generator, validating column availability."""
     while True:
         dataset = await anext(datasets_generator)
+
+        if min_rows and dataset.num_rows < min_rows:
+            continue
 
         if task_type and psql_db:
             if await _is_dataset_degenerate(dataset.dataset_id, task_type, psql_db):
@@ -468,7 +472,9 @@ async def create_synthetic_grpo_task(
 ) -> RawTask:
     model_id = await anext(models)
 
-    dataset = await get_dataset(datasets, task_type=TaskType.GRPOTASK, keypair=config.keypair)
+    dataset = await get_dataset(
+        datasets, task_type=TaskType.GRPOTASK, keypair=config.keypair, min_rows=vcst.GRPO_MIN_SYNTH_ROWS
+    )
 
     number_of_hours = _get_training_hours_from_num_rows(dataset.num_rows, model_id, task_type=TaskType.GRPOTASK)
     columns = await _get_columns_for_instruct_dataset(dataset.dataset_id, config.keypair)

--- a/validator/tasks/synthetic_scheduler.py
+++ b/validator/tasks/synthetic_scheduler.py
@@ -247,6 +247,13 @@ def compute_training_hours(
     return min(hours, vcst.MAX_TRAINING_HOURS)
 
 
+def get_grpo_training_hours(num_params: float | None) -> float:
+    """GRPO budget: fixed per model-size band, independent of dataset size."""
+    params_b = (num_params or vcst.DEFAULT_MODEL_PARAMS_FOR_HOURS) / 1e9
+    hours = next(h for bound_b, h in vcst.GRPO_HOURS_BY_PARAMS_B if params_b <= bound_b)
+    return min(vcst.MAX_TRAINING_HOURS, max(vcst.TRAINING_HOURS_MIN, hours))
+
+
 def _get_training_hours_from_num_rows(num_rows: int, model_id: str | None = None, task_type: TaskType | None = None) -> float:
     """Pre-prep estimate: tokens are unknown, so assume ASSUMED_TOKENS_PER_ROW.
 
@@ -256,6 +263,8 @@ def _get_training_hours_from_num_rows(num_rows: int, model_id: str | None = None
     num_params = get_model_num_params(model_id) if model_id is not None else None
     if not num_params:
         num_params = vcst.DEFAULT_MODEL_PARAMS_FOR_HOURS
+    if task_type == TaskType.GRPOTASK:
+        return get_grpo_training_hours(num_params)
     tokens_per_epoch = num_rows * vcst.ASSUMED_TOKENS_PER_ROW
     return compute_training_hours(tokens_per_epoch, num_params, task_type or TaskType.INSTRUCTTEXTTASK)
 
@@ -274,13 +283,18 @@ def compute_hours_from_baseline_stats(
     """
     if isinstance(baseline_stats, EnvBaselineStats) or baseline_stats is None:
         return current_hours
-    dataset_stats = baseline_stats.dataset
-    if not dataset_stats.total_tokens or not dataset_stats.num_records:
-        return current_hours
 
     num_params = model_params_count or (get_model_num_params(model_id) if model_id else None)
     if not num_params:
         num_params = vcst.DEFAULT_MODEL_PARAMS_FOR_HOURS
+
+    # GRPO is fixed per model size; tokens/throughput don't refine it.
+    if task_type == TaskType.GRPOTASK:
+        return get_grpo_training_hours(num_params)
+
+    dataset_stats = baseline_stats.dataset
+    if not dataset_stats.total_tokens or not dataset_stats.num_records:
+        return current_hours
 
     # Miner stacks are row-bound on short sequences (padding + per-step
     # overhead), so each record costs at least EFFECTIVE_MIN_TOKENS_PER_ROW.

--- a/validator/tasks/synthetic_scheduler.py
+++ b/validator/tasks/synthetic_scheduler.py
@@ -1,4 +1,5 @@
 import asyncio
+import math
 import random
 from datetime import datetime
 from datetime import timedelta
@@ -238,7 +239,11 @@ def compute_training_hours(
     train_seconds = vcst.TARGET_TRAINING_EPOCHS * tokens_per_epoch * type_mult / (per_gpu_tps * gpus)
     hours = train_seconds / 3600 + vcst.TRAINING_OVERHEAD_HOURS
 
-    hours = max(vcst.TRAINING_HOURS_MIN, round(hours * 4) / 4)
+    # Ceil to the 0.25h grid: never grant less wall-clock than the formula
+    # computed. Rounding down used to shave up to 7.5 min, which on small tasks
+    # (where the fixed overhead is half the budget) could drop a run below 2
+    # full epochs.
+    hours = max(vcst.TRAINING_HOURS_MIN, math.ceil(hours * 4) / 4)
     return min(hours, vcst.MAX_TRAINING_HOURS)
 
 

--- a/validator/tasks/synthetic_scheduler.py
+++ b/validator/tasks/synthetic_scheduler.py
@@ -239,10 +239,7 @@ def compute_training_hours(
     train_seconds = vcst.TARGET_TRAINING_EPOCHS * tokens_per_epoch * type_mult / (per_gpu_tps * gpus)
     hours = train_seconds / 3600 + vcst.TRAINING_OVERHEAD_HOURS
 
-    # Ceil to the 0.25h grid: never grant less wall-clock than the formula
-    # computed. Rounding down used to shave up to 7.5 min, which on small tasks
-    # (where the fixed overhead is half the budget) could drop a run below 2
-    # full epochs.
+    # Ceil to the 0.25h grid so we never grant less than the computed budget.
     hours = max(vcst.TRAINING_HOURS_MIN, math.ceil(hours * 4) / 4)
     return min(hours, vcst.MAX_TRAINING_HOURS)
 


### PR DESCRIPTION
Reworks how text-comp training time is budgeted, after review against the actual miner config.

**GRPO: fixed per model size, not dataset-proportional.** GRPO saturates on update steps, not dataset coverage, so budgeting it as `2 epochs × tokens` was the wrong shape (and under-counted rollouts/generation). Route GRPO through a size-banded table (`GRPO_HOURS_BY_PARAMS_B`) in both pre- and post-prep; drop it from `TASK_TYPE_HOURS_MULTIPLIER`.

**GRPO dataset floor (20k rows).** With time now fixed per size, a too-small prompt set lets the miner hit its epoch cap before spending the budget. R1 already floors at 20k; later-round bins start at 8k, so add a `min_rows` filter on the GRPO path.

**Ceil instead of round-to-nearest.** Round-to-nearest shaved up to 7.5 min off the computed budget — on small tasks (where fixed overhead is half the budget) that could drop a run below 2 epochs. Ceil never grants less than computed; negligible on large jobs.

SFT/DPO token-throughput model is unchanged (they are coverage-driven). Band values are placeholders pending calibration against trainer run history.