### PR TITLE
Add goofspiel as a PvP env + scope model-prep to a task's games

### DIFF
--- a/core/config/pvp_game_prompts.yml
+++ b/core/config/pvp_game_prompts.yml
@@ -98,3 +98,34 @@ othello_rules: >
   Game end: The game ends when neither player can move (the board is full or no
   legal moves remain for either side). The player with more discs wins; an equal
   count is a draw.
+
+goofspiel_rules: >
+  GOOFSPIEL RULES (the Game of Pure Strategy):
+
+  Setup: Two players. Each holds an identical hand of bidding cards numbered
+  1..N. A separate deck of N point cards (also 1..N) is shuffled; one point card
+  is revealed each round.
+
+  Each round: A point card is turned face up. Both players SIMULTANEOUSLY and
+  SECRETLY choose one card from their hand to bid on it — you do not see the
+  opponent's bid before committing yours. The higher bid wins that round and
+  takes the point card's value in points; on a tie the point card is split (no
+  one scores it). Both bid cards are then discarded and cannot be reused.
+
+  Information: You see the point cards revealed so far, the running scores, your
+  own remaining hand, and which player won each past round (the win sequence) —
+  but NOT the opponent's hand or their current bid. Infer their remaining cards
+  from the rounds already played.
+
+  Goal / game end: After all N rounds every card is spent. The player with more
+  total points wins; equal points is a draw.
+
+  Strategy tips:
+  - Spend high cards to win high-value point cards; don't waste your N on a
+    low point card.
+  - Bidding one above what you expect the opponent to play wins cheaply — but
+    they reason the same way, so mix up your play.
+  - Track which high cards the opponent has already used; once their big cards
+    are gone, your remaining cards dominate.
+  - Sometimes "sacrifice" your lowest card on a point card you concede, keeping
+    stronger cards for later rounds.

--- a/core/constants.py
+++ b/core/constants.py
@@ -46,6 +46,7 @@ class EnvironmentName(str, Enum):
     LIARS_DICE = "liars_dice"
     LEDUC_POKER = "leduc_poker"
     OTHELLO = "othello"
+    GOOFSPIEL = "goofspiel"
     INTERCODE = "intercode"
 
 
@@ -122,6 +123,22 @@ ENVIRONMENT_CONFIGS: dict[EnvironmentName, EnvironmentConfig] = {
     EnvironmentName.OTHELLO: EnvironmentConfig(
         task_id_min=400_000_000,
         task_id_max=499_999_999,
+        num_seeds=10_000,
+        num_baseline_episodes=25,
+        eval_type=EvalType.PVP,
+        env_image=MCTS_API_DOCKER_IMAGE,
+        tournament_eval_image=VALIDATOR_DOCKER_IMAGE_PVP,
+        gpu_multiplier=4,
+        eval_payload_extra={
+            "opponent": "mcts",
+            "mcts_max_simulations": 50,
+            "mcts_num_rollouts": 1,
+            "api_key": "dummy-key",
+        },
+    ),
+    EnvironmentName.GOOFSPIEL: EnvironmentConfig(
+        task_id_min=0,
+        task_id_max=99_999_999,
         num_seeds=10_000,
         num_baseline_episodes=25,
         eval_type=EvalType.PVP,

--- a/core/models/pvp_models.py
+++ b/core/models/pvp_models.py
@@ -5,6 +5,7 @@ Defines input configuration and output result contracts.
 
 import json
 from enum import Enum
+from typing import Annotated
 from typing import Literal
 from typing import Protocol
 
@@ -50,11 +51,61 @@ class GameScoringContext(BaseModel):
     max_utility: float = Field(description="Maximum possible return value")
 
 
+class GameParams(BaseModel):
+    """Base for a game's pyspiel.load_game() parameters.
+
+    Each game has its own subclass with just the fields it accepts; the `game`
+    discriminator makes them a tagged union so a GameInstance round-trips to the
+    right subclass. to_pyspiel() renders the kwargs dict, dropping the tag (which
+    is ours, not a pyspiel parameter). Subclasses declare the `game` tag; the
+    base omits it so each subclass owns its literal.
+    """
+
+    def to_pyspiel(self) -> dict[str, int | str | bool]:
+        return self.model_dump(exclude={"game"})
+
+
+class LiarsDiceParams(GameParams):
+    game: Literal["liars_dice"] = "liars_dice"
+    players: int = 2
+    numdice: int = 5
+
+
+class LeducPokerParams(GameParams):
+    game: Literal["leduc_poker"] = "leduc_poker"
+    players: int = 2
+
+
+class GinRummyParams(GameParams):
+    game: Literal["gin_rummy"] = "gin_rummy"
+    hand_size: int
+    knock_card: int
+
+
+class OthelloParams(GameParams):
+    game: Literal["othello"] = "othello"
+
+
+class GoofspielParams(GameParams):
+    game: Literal["goofspiel"] = "goofspiel"
+    players: int = 2
+    num_cards: int
+    imp_info: bool = True
+    points_order: Literal["random", "ascending", "descending"] = "random"
+    returns_type: Literal["win_loss", "total_points", "point_difference"] = "win_loss"
+
+
+AnyGameParams = Annotated[
+    LiarsDiceParams | LeducPokerParams | GinRummyParams | OthelloParams | GoofspielParams,
+    Field(discriminator="game"),
+]
+
+
 class GameInstance(PvPBaseModel):
     """Configuration for a single game to be played."""
 
     game_name: str = Field(description="OpenSpiel game identifier (e.g. 'liars_dice')")
-    game_params: dict[str, int] = Field(description="Parameters passed to pyspiel.load_game()")
+    game_params: AnyGameParams = Field(description="Parameters passed to pyspiel.load_game()")
     model_a_player_id: int = Field(description="Player index assigned to model A (0 or 1)")
     seed: int = Field(description="Random seed for this game instance")
     is_zero_sum: bool = Field(description="Whether the game is zero-sum")

--- a/core/pvp/agents.py
+++ b/core/pvp/agents.py
@@ -13,6 +13,13 @@ from pathlib import Path
 import pyspiel
 import yaml
 
+from core.models.pvp_models import GameParams
+from core.models.pvp_models import GinRummyParams
+from core.models.pvp_models import GoofspielParams
+from core.models.pvp_models import LeducPokerParams
+from core.models.pvp_models import LiarsDiceParams
+from core.models.pvp_models import OthelloParams
+
 _PROMPTS_PATH = Path(__file__).resolve().parents[2] / "core" / "config" / "pvp_game_prompts.yml"
 
 
@@ -37,7 +44,7 @@ class BaseGameAgent(ABC):
         ...
 
     @abstractmethod
-    def generate_params(self, config_id: int) -> dict[str, int]:
+    def generate_params(self, config_id: int) -> GameParams:
         """Generate pyspiel game parameters from a config variant ID."""
         ...
 
@@ -50,6 +57,15 @@ class BaseGameAgent(ABC):
         same seed reproduces the same start while different seeds diverge.
         """
         return None
+
+    def load_game(self, params: GameParams) -> pyspiel.Game:
+        """Build the pyspiel game this agent plays.
+
+        Default: load game_name with params directly. Games whose native dynamics
+        are simultaneous (e.g. goofspiel) override this to wrap the game so the
+        sequential LLMBot/evaluate_bots harness can drive it.
+        """
+        return pyspiel.load_game(self.game_name, params.to_pyspiel())
 
     def get_rules(self) -> str:
         return load_prompts()[self.rules_key]
@@ -88,8 +104,8 @@ class LiarsDiceAgent(BaseGameAgent):
     def rules_key(self) -> str:
         return "liars_dice_rules"
 
-    def generate_params(self, config_id: int) -> dict[str, int]:
-        return {"players": 2, "numdice": 5}
+    def generate_params(self, config_id: int) -> GameParams:
+        return LiarsDiceParams(players=2, numdice=5)
 
     def format_state(self, state: pyspiel.State, player_id: int) -> str:
         try:
@@ -140,8 +156,8 @@ class LeducPokerAgent(BaseGameAgent):
     def rules_key(self) -> str:
         return "leduc_poker_rules"
 
-    def generate_params(self, config_id: int) -> dict[str, int]:
-        return {"players": 2}
+    def generate_params(self, config_id: int) -> GameParams:
+        return LeducPokerParams(players=2)
 
     def format_state(self, state: pyspiel.State, player_id: int) -> str:
         try:
@@ -222,13 +238,10 @@ class GinRummyAgent(BaseGameAgent):
     def rules_key(self) -> str:
         return "gin_rummy_rules"
 
-    def generate_params(self, config_id: int) -> dict[str, int]:
+    def generate_params(self, config_id: int) -> GameParams:
         hand_var = (config_id // 3) % 3
         knock_var = config_id % 3
-        return {
-            "hand_size": 7 + hand_var,
-            "knock_card": 10 - knock_var,
-        }
+        return GinRummyParams(hand_size=7 + hand_var, knock_card=10 - knock_var)
 
     def format_state(self, state: pyspiel.State, player_id: int) -> str:
         return state.observation_string(player_id)
@@ -250,8 +263,8 @@ class OthelloAgent(BaseGameAgent):
     def rules_key(self) -> str:
         return "othello_rules"
 
-    def generate_params(self, config_id: int) -> dict[str, int]:
-        return {}
+    def generate_params(self, config_id: int) -> GameParams:
+        return OthelloParams()
 
     def format_state(self, state: pyspiel.State, player_id: int) -> str:
         """Prefix the board with the player's colour.
@@ -280,3 +293,51 @@ class OthelloAgent(BaseGameAgent):
             if not legal_actions:
                 break
             state.apply_action(rng.choice(legal_actions))
+
+
+# Deck sizes goofspiel is played with, selected per game from the config id so
+# each game varies board size (and thus length) for SFT/eval diversity. 5 is a
+# short sharp game; 13 is the full standard deck.
+_GOOFSPIEL_NUM_CARDS = (5, 8, 10, 13)
+
+
+class GoofspielAgent(BaseGameAgent):
+    """Goofspiel (a.k.a. the Game of Pure Strategy).
+
+    OpenSpiel's goofspiel is a SIMULTANEOUS-move game; the sequential harness
+    drives it via convert_to_turn_based, which hides each player's concurrent
+    bid from the other (so simultaneity and fairness are preserved). Played with
+    imp_info=True (opponent hand hidden) and returns_type=win_loss so terminal
+    returns are zero-sum {-1, 0, 1}, mapping straight to win/loss/draw.
+    """
+
+    @property
+    def game_name(self) -> str:
+        return "goofspiel"
+
+    @property
+    def rules_key(self) -> str:
+        return "goofspiel_rules"
+
+    def generate_params(self, config_id: int) -> GameParams:
+        num_cards = _GOOFSPIEL_NUM_CARDS[config_id % len(_GOOFSPIEL_NUM_CARDS)]
+        return GoofspielParams(
+            players=2,
+            num_cards=num_cards,
+            imp_info=True,
+            points_order="random",
+            returns_type="win_loss",
+        )
+
+    def load_game(self, params: GameParams) -> pyspiel.Game:
+        """Load goofspiel and wrap its simultaneous moves into sequential turns."""
+        return pyspiel.convert_to_turn_based(pyspiel.load_game(self.game_name, params.to_pyspiel()))
+
+    def format_state(self, state: pyspiel.State, player_id: int) -> str:
+        """Render the player's own view; imp_info keeps the opponent's hand hidden.
+
+        observation_string already reports the current point card, the remaining
+        point cards, both running scores, this player's hand and the win sequence.
+        Prefix the player's identity since the board labels are absolute (P0/P1).
+        """
+        return f"You are Player {player_id} (P{player_id}).\n{state.observation_string(player_id)}"

--- a/core/pvp/baseline.py
+++ b/core/pvp/baseline.py
@@ -117,7 +117,7 @@ def run_mcts_baseline(
             break
         seed = seed_rng.randint(1, cst.PVP_SEED_RANGE_MAX)
         config_id = config_id_for_seed(seed, env_config)
-        game = pyspiel.load_game(agent.game_name, agent.generate_params(config_id))
+        game = agent.load_game(agent.generate_params(config_id))
         game_type = game.get_type()
 
         model_seat = i % 2

--- a/core/pvp/game_eval.py
+++ b/core/pvp/game_eval.py
@@ -20,6 +20,7 @@ from core.constants import EvalType
 from core.pvp import constants as cst
 from core.pvp.agents import BaseGameAgent
 from core.pvp.agents import GinRummyAgent
+from core.pvp.agents import GoofspielAgent
 from core.pvp.agents import LeducPokerAgent
 from core.pvp.agents import LiarsDiceAgent
 from core.pvp.agents import OthelloAgent
@@ -38,6 +39,7 @@ _AGENT_REGISTRY: dict[EnvironmentName, type[BaseGameAgent]] = {
     EnvironmentName.LEDUC_POKER: LeducPokerAgent,
     EnvironmentName.GIN_RUMMY: GinRummyAgent,
     EnvironmentName.OTHELLO: OthelloAgent,
+    EnvironmentName.GOOFSPIEL: GoofspielAgent,
 }
 
 # Every PVP env must have an agent: image_manager skips env sidecars for PVP

--- a/core/whitelisted_sft_datasets.json
+++ b/core/whitelisted_sft_datasets.json
@@ -9,5 +9,6 @@
     "gradients-io-tournaments/ArkadiumGinrummy",
     "the-acorn-ai/textarena-player-game-traces",
     "gradients-io-tournaments/env_training_gradients",
-    "gradients-io-tournaments/intercode_bigcode_combined_12k"
+    "gradients-io-tournaments/intercode_bigcode_combined_12k",
+    "gradients-io-tournaments/pvp-tool-calling-sft"
 ]

--- a/scripts/pvp_play.py
+++ b/scripts/pvp_play.py
@@ -20,8 +20,6 @@ import pickle
 import random
 import sys
 
-import pyspiel
-
 from core.models.pvp_models import ChatCompletionConfig
 from core.models.pvp_models import ChatResult
 from core.models.pvp_models import MemoryArea
@@ -83,7 +81,8 @@ def _save(bundle: dict) -> None:
 
 
 def _rehydrate(bundle: dict):
-    game = pyspiel.load_game(bundle["game_name"], bundle["params"])
+    agent = _agent_for(_env(bundle["env"]))
+    game = agent.load_game(bundle["params"])
     state = game.deserialize_state(bundle["state_str"])
     rng = random.Random()
     rng.setstate(bundle["rng_state"])
@@ -113,7 +112,7 @@ def cmd_new(args) -> None:
     env = _env(args.env)
     agent = _agent_for(env)
     params = agent.generate_params(args.seed)
-    game = pyspiel.load_game(agent.game_name, params)
+    game = agent.load_game(params)
     state = game.new_initial_state()
     agent.setup_initial_state(state, args.seed)  # seeded opening plies, as in eval
     rng = random.Random(args.seed)

--- a/scripts/sft_dataset_gen/harness_capture.py
+++ b/scripts/sft_dataset_gen/harness_capture.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Generate SFT cold-start data by playing Claude vs Claude through the *real*
+PvP tool-calling harness, capturing every model turn as an OpenAI messages+tools
+sample.
+
+Why this and not the old plain-text generator: games are now played as a
+tool-calling memory loop (the model commits its move via the game_action tool
+and edits memory slots via memory tools), so cold-start data must be in that
+exact format. We reuse run_matchup + the Anthropic chat adapter, wrap each
+player's chat_fn, and dump every (system+user -> assistant tool_calls) exchange.
+Per-turn context is rebuilt fresh by the harness, so each captured turn is a
+self-contained training example.
+
+Long-term memory: run_matchup carries one long-term SlotMemory per player across
+all games of a matchup (consolidated by a reflection turn after each game), so we
+run several independent matchups per env — each a fresh long-term arc — and tag
+samples with the matchup index.
+
+  ANTHROPIC_API_KEY must be set.
+  python -m scripts.sft_dataset_gen.harness_capture \
+      --model claude-sonnet-4-6 --model-b claude-haiku-4-5 \
+      --matchups-per-env 2 --games-per-matchup 25 --output-dir output/pvp_sft \
+      --repo-id <namespace>/<dataset> --upload
+"""
+
+import argparse
+import functools
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+
+import anthropic
+
+from core.constants import ENVIRONMENT_CONFIGS
+from core.constants import EnvironmentName
+from core.constants import EvalType
+from core.models.pvp_models import ChatCompletionConfig
+from core.models.pvp_models import ChatMessage
+from core.models.pvp_models import ChatResult
+from core.models.pvp_models import ChatRole
+from core.models.pvp_models import PvPMatchupConfig
+from core.models.pvp_models import ToolSchema
+from core.pvp.tools import GAME_ACTION_TOOL_NAME
+from validator.core import constants as vcst
+from validator.evaluation.pvp.game_runner import Player
+from validator.evaluation.pvp.game_runner import run_matchup
+from scripts.pvp_anthropic_match import anthropic_chat
+
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s - %(message)s",
+                    handlers=[logging.StreamHandler(sys.stderr)])
+logger = logging.getLogger("harness_capture")
+
+# Data-gen-only guidance appended to the system prompt on move turns. Claude does
+# sequential tool use (edits memory, then waits for a result) so under the
+# harness's single-call contract it omits game_action and forfeits. Spelling out
+# "one response, no follow-up, game_action required now, parallel calls allowed"
+# plus a worked example makes it co-emit reliably. Only added when a game_action
+# tool is offered (i.e. a move turn, not a reflection turn).
+_MOVE_TURN_GUIDANCE = (
+    "IMPORTANT — single-response turn: You get EXACTLY ONE response this turn and "
+    "there is NO follow-up message, so you cannot act in a later step. In this one "
+    "response you MUST call game_action with a legal action id to commit your move. "
+    "You MAY also call memory tools in the SAME response — parallel tool calls are "
+    "supported and encouraged. If you only edit memory and omit game_action, you "
+    "forfeit the turn.\n"
+    "Example of one correct response (two tool calls together): "
+    "working_memory_rewrite(slot=1, content=\"opponent opened aggressively; conserve high cards\") "
+    "AND game_action(action_id=3)."
+)
+
+
+def pvp_envs() -> list[EnvironmentName]:
+    """Every model-vs-model env (excludes intercode, which is not PvP)."""
+    return [name for name, cfg in ENVIRONMENT_CONFIGS.items() if cfg.eval_type == EvalType.PVP]
+
+
+def _count_lines(path: Path) -> int:
+    with open(path) as f:
+        return sum(1 for _ in f)
+
+
+def _trim_jsonl(path: Path, n: int) -> None:
+    """Keep only the first n lines, so every env ends with the same count."""
+    lines = path.read_text().splitlines()
+    if len(lines) > n:
+        path.write_text("\n".join(lines[:n]) + "\n")
+
+
+def _stamp_ordering(path: Path) -> None:
+    """Add seq / arc / turn_in_arc so order survives shuffling and reload.
+
+    File line order is the chronological play order (each turn is written as it
+    happens). seq is that order; arc is a unique long-term-memory arc id (it
+    increments whenever `matchup` changes, so append runs that restart matchup at
+    0 get distinct arcs); turn_in_arc orders turns within an arc.
+    """
+    if not path.exists():
+        return
+    rows = [json.loads(line) for line in path.read_text().splitlines()]
+    arc, prev_matchup, turn_in_arc = -1, object(), 0
+    for i, r in enumerate(rows):
+        if r.get("matchup") != prev_matchup:
+            arc += 1
+            turn_in_arc = 0
+            prev_matchup = r.get("matchup")
+        r["seq"], r["arc"], r["turn_in_arc"] = i, arc, turn_in_arc
+        turn_in_arc += 1
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+
+
+class SampleCollector:
+    """Wraps a ChatFn to dump each call as an SFT sample.
+
+    A sample is the exact prompt the harness built (system + user messages) plus
+    the assistant response (text + tool_calls) and the tool schemas — i.e. what a
+    tokenizer.apply_chat_template(messages, tools=tools) would consume. Quality
+    gate: turn samples are kept only when a legal-looking game_action was emitted
+    (no forfeits as training targets); reflection samples need >=1 memory call.
+    """
+
+    def __init__(self, env: str, model: str, fh):
+        self.env = env
+        self.model = model
+        self.fh = fh
+        self.matchup = 0  # set per matchup so long-term arcs are distinguishable
+        self.kept = 0
+        self.skipped = 0
+        self.long_term_writes = 0
+
+    def wrap(self, chat_fn):
+        @functools.wraps(chat_fn)
+        def wrapped(config, messages, tools=None):
+            result = chat_fn(config, messages, tools)
+            self._record(messages, tools, result)
+            return result
+        return wrapped
+
+    def _record(self, messages: list[ChatMessage], tools: list[ToolSchema] | None, result: ChatResult) -> None:
+        tool_names = {t.function.name for t in (tools or [])}
+        is_turn = GAME_ACTION_TOOL_NAME in tool_names
+        calls = result.tool_calls or []
+
+        if is_turn and not any(c.name == GAME_ACTION_TOOL_NAME for c in calls):
+            self.skipped += 1  # forfeit turn — bad training target
+            return
+        if not is_turn and not calls:
+            self.skipped += 1  # empty reflection — nothing learned
+            return
+
+        if any(c.name.startswith("long_term") for c in calls):
+            self.long_term_writes += 1
+
+        assistant = ChatMessage(role=ChatRole.ASSISTANT, content=result.content, tool_calls=result.tool_calls)
+        sample = {
+            "messages": [m.to_openai() for m in messages] + [assistant.to_openai()],
+            "tools": [t.to_openai() for t in (tools or [])],
+            "env": self.env,
+            "model": self.model,
+            "matchup": self.matchup,
+            "turn_type": "turn" if is_turn else "reflection",
+        }
+        self.fh.write(json.dumps(sample) + "\n")
+        self.fh.flush()
+        self.kept += 1
+
+
+def _inject_move_guidance(chat_fn):
+    """On move turns (game_action offered), append the strong single-response
+    guidance to the system message before recording/sending. Applied outside the
+    collector so the guidance is part of the captured sample (data-gen only)."""
+    @functools.wraps(chat_fn)
+    def wrapped(config, messages, tools=None):
+        if any(t.function.name == GAME_ACTION_TOOL_NAME for t in (tools or [])):
+            messages = list(messages)
+            for i, m in enumerate(messages):
+                if m.role == ChatRole.SYSTEM:
+                    messages[i] = m.model_copy(update={"content": f"{m.content or ''}\n\n{_MOVE_TURN_GUIDANCE}"})
+                    break
+        return chat_fn(config, messages, tools)
+    return wrapped
+
+
+def _player(client: anthropic.Anthropic, model: str, collector: SampleCollector) -> Player:
+    config = ChatCompletionConfig(inference_model=model, base_url="http://anthropic/v1")
+    chat = collector.wrap(functools.partial(anthropic_chat, client))
+    chat = _inject_move_guidance(chat)
+    return Player(client=client, config=config, chat_fn=chat)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--model", default="claude-sonnet-4-6", help="Claude model for both players (self-play)")
+    parser.add_argument("--model-b", default=None, help="Optional different model for player B (defaults to --model)")
+    parser.add_argument("--target-samples-per-env", type=int, default=None,
+                        help="Generate matchups until each env reaches AT LEAST this many kept samples (existing + new), "
+                             "then stop. Overshoot is kept (never discarded). Overrides --matchups-per-env.")
+    parser.add_argument("--trim-to-target", action="store_true",
+                        help="Also trim each env down to exactly --target-samples-per-env. OFF by default — trimming "
+                             "throws away already-generated (paid) samples.")
+    parser.add_argument("--max-matchups-per-env", type=int, default=40,
+                        help="Safety cap on matchups when chasing --target-samples-per-env")
+    parser.add_argument("--matchups-per-env", type=int, default=2,
+                        help="Independent matchups per env; each carries its own long-term memory arc")
+    parser.add_argument("--games-per-matchup", type=int, default=25,
+                        help="Seeds per matchup; each played twice (position swap). long-term memory continues across them")
+    parser.add_argument("--append", action="store_true",
+                        help="Keep existing per-env files and only ADD samples (top up to --target-samples-per-env); "
+                             "skip envs already at target. Default overwrites each env file.")
+    parser.add_argument("--keep-forfeit-truncation", action="store_true",
+                        help="Keep the eval-time matchup forfeit/early-stop truncation (off by default for data-gen, "
+                             "so all games play out and slow envs still yield data)")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--envs", nargs="+", default=None, help="Env subset (default: all PvP envs)")
+    parser.add_argument("--output-dir", default="output/pvp_sft")
+    parser.add_argument("--repo-id", default=None, help="HF dataset repo id to upload to, e.g. ns/name")
+    parser.add_argument("--private", action="store_true", help="Create the HF dataset as private")
+    parser.add_argument("--upload", action="store_true", help="Upload the output dir to --repo-id after generation")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    model_a = args.model
+    model_b = args.model_b or args.model
+    envs = [EnvironmentName(e) for e in args.envs] if args.envs else pvp_envs()
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    client = anthropic.Anthropic()
+
+    # Data-gen wants every game played: the eval-time matchup truncation (award
+    # remaining games once a model forfeits enough / loses a streak) starves slow,
+    # forfeit-prone envs like othello. Disable it unless explicitly kept.
+    if not args.keep_forfeit_truncation:
+        vcst.PVP_EPISODE_FORFEIT_THRESHOLD = 10**9
+        vcst.PVP_CONSECUTIVE_LOSS_FORFEIT = 10**9
+        logger.info("Matchup forfeit-truncation disabled for data-gen (all games play out)")
+
+    target = args.target_samples_per_env
+    start = time.time()
+    totals: dict[str, int] = {}
+    for env in envs:
+        env_path = out_dir / f"{env.value}.jsonl"
+        existing = _count_lines(env_path) if (args.append and env_path.exists()) else 0
+        if args.append and target and existing >= target:
+            logger.info("[%s] already has %d >= target %d — leaving untouched", env.value, existing, target)
+            totals[env.value] = existing
+            continue
+
+        # Append keeps what's already there and only adds the deficit; otherwise
+        # the file is rewritten from scratch.
+        with open(env_path, "a" if args.append else "w") as fh:
+            # One collector per player so each sample records the model that
+            # authored it (and we see per-model yield). existing samples count
+            # toward the target so append only generates the shortfall.
+            coll_a = SampleCollector(env.value, model_a, fh)
+            coll_b = SampleCollector(env.value, model_b, fh)
+            player_a = _player(client, model_a, coll_a)
+            player_b = _player(client, model_b, coll_b)
+            # Each matchup is a fresh long-term-memory arc (run_matchup makes new
+            # long-term SlotMemory per call); a distinct seed makes the arcs differ.
+            # In target mode, keep adding matchups until the env reaches the target.
+            # In append mode, offset the seed so new arcs differ from the originals.
+            max_matchups = args.max_matchups_per_env if target else args.matchups_per_env
+            seed_base = args.seed + (5_000_000 if args.append else 0)
+            for m in range(max_matchups):
+                coll_a.matchup = coll_b.matchup = m
+                total_so_far = existing + coll_a.kept + coll_b.kept
+                logger.info("[%s] matchup %d — %s vs %s, %d games (x2 swap) | have %d (existing %d + new %d)",
+                            env.value, m + 1, model_a, model_b, args.games_per_matchup,
+                            total_so_far, existing, coll_a.kept + coll_b.kept)
+                result = run_matchup(
+                    env_name=env,
+                    matchup_config=PvPMatchupConfig(num_games=args.games_per_matchup),
+                    player_a=player_a,
+                    player_b=player_b,
+                    base_seed=seed_base + m * 100_000,
+                )
+                logger.info("[%s] matchup %d done | games a=%d b=%d draws=%d",
+                            env.value, m + 1, result.model_a_wins, result.model_b_wins, result.draws)
+                if target and existing + coll_a.kept + coll_b.kept >= target:
+                    break
+            total = existing + coll_a.kept + coll_b.kept
+            logger.info("[%s] total=%d (existing %d + new %d: %s=%d, %s=%d) skipped=%d long_term_writes=%d",
+                        env.value, total, existing, coll_a.kept + coll_b.kept,
+                        model_a, coll_a.kept, model_b, coll_b.kept,
+                        coll_a.skipped + coll_b.skipped, coll_a.long_term_writes + coll_b.long_term_writes)
+            if target and total < target:
+                logger.warning("[%s] only %d/%d after %d matchups (cap hit)", env.value, total, target, max_matchups)
+
+        # Only trim when explicitly asked — trimming discards already-paid samples.
+        if target and args.trim_to_target:
+            _trim_jsonl(env_path, target)
+        _stamp_ordering(env_path)  # seq / arc / turn_in_arc, robust to later shuffling
+        totals[env.value] = _count_lines(env_path)
+
+    grand = sum(totals.values())
+    logger.info("=== Done in %.1f min — %d samples across %d envs: %s ===",
+                (time.time() - start) / 60, grand, len(envs), totals)
+
+    if args.upload:
+        if not args.repo_id:
+            raise SystemExit("--upload requires --repo-id")
+        _upload(out_dir, args.repo_id, args.private, model_a, model_b)
+
+
+def _write_readme(out_dir: Path, model_a: str, model_b: str) -> None:
+    """Describe the dataset from the actual files on disk (every env, not just the
+    envs touched by the last run — a partial run must not shrink the description)."""
+    counts = {p.stem: _count_lines(p) for p in sorted(out_dir.glob("*.jsonl"))}
+    total = sum(counts.values())
+    (out_dir / "README.md").write_text(
+        "# PvP tool-calling SFT cold-start data\n\n"
+        "Claude-vs-Claude games played through the G.O.D PvP tool-calling harness. "
+        "Each row is one model turn (or post-game reflection): the system+user prompt "
+        "the harness built, the assistant response (`content` + `tool_calls`), and the "
+        "`tools` schemas — i.e. the OpenAI messages+tools format consumed by "
+        "`tokenizer.apply_chat_template(messages, tools=tools)`. On a move turn the "
+        "assistant co-emits any memory-tool edits and a `game_action` committing a legal "
+        "move; reflection rows consolidate long-term memory after a game.\n\n"
+        f"Players: {model_a} vs {model_b} (positions swapped each seed, so both orderings appear).\n\n"
+        f"Total: {total} samples across {len(counts)} environments.\n\n"
+        "## Per-env sample counts\n\n"
+        + "\n".join(f"- `{env}`: {n}" for env, n in counts.items())
+        + "\n\n## Fields\n"
+        "- `messages`, `tools`: the training example (OpenAI chat + tools format)\n"
+        "- `env`: game name\n"
+        "- `model`: the Claude model that authored the sample\n"
+        "- `turn_type`: `turn` (commits `game_action`) or `reflection` (consolidates long-term memory)\n"
+        "- `seq`: chronological play order within the env file (stable across shuffling)\n"
+        "- `arc`: unique long-term-memory arc id — memory persists across the games within one arc\n"
+        "- `turn_in_arc`: order of the sample within its arc\n"
+        "- `matchup`: per-generation-run arc index (legacy; use `arc` for a globally-unique id)\n\n"
+        "To reconstruct a long-term-memory trajectory, take one `(env, arc)` group and sort by "
+        "`turn_in_arc` (or `seq`). For plain SFT this is unnecessary — each row is self-contained, "
+        "since the memory state at that turn is already rendered inside its prompt.\n"
+    )
+
+
+def _upload(out_dir: Path, repo_id: str, private: bool, model_a: str, model_b: str) -> None:
+    from huggingface_hub import HfApi
+
+    api = HfApi()
+    api.create_repo(repo_id, repo_type="dataset", private=private, exist_ok=True)
+    _write_readme(out_dir, model_a, model_b)
+    api.upload_folder(folder_path=str(out_dir), repo_id=repo_id, repo_type="dataset")
+    logger.info("Uploaded %s -> https://huggingface.co/datasets/%s", out_dir, repo_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_model_prep_intercode_sidecar.py
+++ b/tests/test_model_prep_intercode_sidecar.py
@@ -9,6 +9,23 @@ from core.constants import EnvironmentName
 from validator.utils.model_prep import _build_env_configs
 
 
+def test_build_env_configs_restricts_to_task_envs():
+    """Model prep should baseline only the task's own games, not every env."""
+    only = _build_env_configs([EnvironmentName.GOOFSPIEL])
+    assert set(only) == {EnvironmentName.GOOFSPIEL}
+
+    pair = _build_env_configs([EnvironmentName.GOOFSPIEL, EnvironmentName.OTHELLO])
+    assert set(pair) == {EnvironmentName.GOOFSPIEL, EnvironmentName.OTHELLO}
+
+
+def test_build_env_configs_defaults_to_all_envs():
+    """No restriction (or empty) falls back to every configured env."""
+    from core.constants import ENVIRONMENT_CONFIGS
+
+    assert set(_build_env_configs()) == set(ENVIRONMENT_CONFIGS)
+    assert set(_build_env_configs([])) == set(ENVIRONMENT_CONFIGS)
+
+
 def test_model_prep_configs_include_intercode_sidecar():
     cfg = _build_env_configs()[EnvironmentName.INTERCODE]
 

--- a/tests/test_pvp_game_instances.py
+++ b/tests/test_pvp_game_instances.py
@@ -11,6 +11,7 @@ import pytest
 from core.constants import EnvironmentName
 from core.models.pvp_models import GameInstance
 from core.models.pvp_models import GameOutcome
+from core.models.pvp_models import LeducPokerParams
 from core.models.pvp_models import PvPEnvironmentResult
 
 
@@ -96,7 +97,7 @@ class TestConfigIdVariation:
         params_set = set()
         for config_id in range(9):  # 3×3 = 9 unique combos from the formula
             p = agent.generate_params(config_id)
-            params_set.add((p["hand_size"], p["knock_card"]))
+            params_set.add((p.hand_size, p.knock_card))
 
         assert len(params_set) > 1, "All config_ids produced identical params"
 
@@ -104,26 +105,29 @@ class TestConfigIdVariation:
         agent = GinRummyAgent()
         for config_id in range(100):
             p = agent.generate_params(config_id)
-            assert 7 <= p["hand_size"] <= 9
-            assert 8 <= p["knock_card"] <= 10
+            assert 7 <= p.hand_size <= 9
+            assert 8 <= p.knock_card <= 10
 
     def test_liars_dice_params_constant(self):
         """Liar's dice has fixed params regardless of config_id."""
         agent = LiarsDiceAgent()
         p0 = agent.generate_params(0)
         p1 = agent.generate_params(99)
-        assert p0 == p1 == {"players": 2, "numdice": 5}
+        assert p0 == p1
+        assert p0.to_pyspiel() == {"players": 2, "numdice": 5}
 
     def test_leduc_poker_params_constant(self):
         agent = LeducPokerAgent()
         p0 = agent.generate_params(0)
         p1 = agent.generate_params(99)
-        assert p0 == p1 == {"players": 2}
+        assert p0 == p1
+        assert p0.to_pyspiel() == {"players": 2}
 
     def test_othello_params_empty(self):
         """Othello takes no pyspiel parameters regardless of config_id."""
         agent = OthelloAgent()
-        assert agent.generate_params(0) == agent.generate_params(99) == {}
+        assert agent.generate_params(0) == agent.generate_params(99)
+        assert agent.generate_params(0).to_pyspiel() == {}
 
 
 # --- 3c': Othello seeded opening plies (deterministic game needs injected variety) ---
@@ -212,7 +216,7 @@ def _make_test_instances(count: int) -> list[GameInstance]:
     return [
         GameInstance(
             game_name="leduc_poker",
-            game_params={"players": 2},
+            game_params=LeducPokerParams(players=2),
             model_a_player_id=i % 2,
             seed=i,
             is_zero_sum=True,

--- a/tests/test_pvp_goofspiel_agent.py
+++ b/tests/test_pvp_goofspiel_agent.py
@@ -1,0 +1,157 @@
+"""Tests for the Goofspiel PvP agent.
+
+Goofspiel is the only PvP game whose native OpenSpiel dynamics are SIMULTANEOUS,
+so the agent must wrap it via convert_to_turn_based to play under the sequential
+LLMBot/evaluate_bots harness. These tests pin that contract: the agent yields a
+sequential, zero-sum game, varies num_cards per game, hides the opponent's hand
+(imp_info), and plays out to a {-1, 0, 1} win_loss return.
+"""
+
+import importlib.util
+import random
+
+import pytest
+
+
+try:
+    if importlib.util.find_spec("pyspiel") is None:
+        raise ImportError
+
+    import numpy as np
+    import pyspiel
+    from open_spiel.python.algorithms import evaluate_bots
+
+    from core.constants import EnvironmentName
+    from core.constants import EvalType
+    from core.constants import ENVIRONMENT_CONFIGS
+    from core.pvp.agents import GoofspielAgent
+    from core.pvp.game_eval import _AGENT_REGISTRY
+    from core.pvp.game_eval import config_id_for_seed
+
+    HAS_PYSPIEL = True
+except ImportError:
+    HAS_PYSPIEL = False
+
+needs_pyspiel = pytest.mark.skipif(not HAS_PYSPIEL, reason="pyspiel not installed")
+
+
+@needs_pyspiel
+class TestGoofspielGameConstruction:
+    def test_load_game_is_sequential(self):
+        """The agent must convert the simultaneous game to turn-based."""
+        agent = GoofspielAgent()
+        game = agent.load_game(agent.generate_params(0))
+        assert game.get_type().dynamics == pyspiel.GameType.Dynamics.SEQUENTIAL
+
+    def test_load_game_is_zero_sum_win_loss(self):
+        """win_loss returns are zero-sum in [-1, 1] so determine_outcome maps cleanly."""
+        agent = GoofspielAgent()
+        game = agent.load_game(agent.generate_params(0))
+        assert game.get_type().utility == pyspiel.GameType.Utility.ZERO_SUM
+        assert game.min_utility() == -1.0
+        assert game.max_utility() == 1.0
+
+    def test_game_name_and_rules_key(self):
+        agent = GoofspielAgent()
+        assert agent.game_name == "goofspiel"
+        assert agent.rules_key == "goofspiel_rules"
+
+
+@needs_pyspiel
+class TestGoofspielParams:
+    def test_params_have_imp_info_and_win_loss(self):
+        agent = GoofspielAgent()
+        params = agent.generate_params(0)
+        assert params.imp_info is True
+        assert params.returns_type == "win_loss"
+        assert params.players == 2
+
+    def test_num_cards_varies_with_config_id(self):
+        """Different config ids select different deck sizes (per-game variety)."""
+        agent = GoofspielAgent()
+        sizes = {agent.generate_params(cid).num_cards for cid in range(50)}
+        assert len(sizes) > 1, "num_cards should vary across config ids"
+
+    def test_all_num_cards_options_load(self):
+        """Every deck size the agent can pick must load and convert cleanly."""
+        agent = GoofspielAgent()
+        for cid in range(50):
+            game = agent.load_game(agent.generate_params(cid))
+            assert game.get_type().dynamics == pyspiel.GameType.Dynamics.SEQUENTIAL
+
+    def test_config_id_for_seed_drives_variety(self):
+        """Seeds map through config_id_for_seed to a spread of deck sizes."""
+        agent = GoofspielAgent()
+        env_config = ENVIRONMENT_CONFIGS[EnvironmentName.GOOFSPIEL]
+        sizes = {
+            agent.generate_params(config_id_for_seed(seed, env_config)).num_cards
+            for seed in range(200)
+        }
+        assert len(sizes) > 1
+
+
+@needs_pyspiel
+class TestGoofspielStateFormatting:
+    def _fresh_state(self, agent, seed=1):
+        game = agent.load_game(agent.generate_params(0))
+        state = game.new_initial_state()
+        rng = random.Random(seed)
+        while state.is_chance_node():
+            outcomes = state.chance_outcomes()
+            state.apply_action(rng.choices([o for o, _ in outcomes], [p for _, p in outcomes])[0])
+        return state
+
+    def test_format_state_hides_opponent_hand(self):
+        """imp_info=True: player 0's view must not reveal player 1's hand."""
+        agent = GoofspielAgent()
+        state = self._fresh_state(agent)
+        rendered = agent.format_state(state, player_id=0)
+        assert "P1 hand" not in rendered
+        assert "P0 hand" in rendered or "your hand" in rendered.lower()
+
+    def test_format_state_shows_point_card(self):
+        agent = GoofspielAgent()
+        state = self._fresh_state(agent)
+        rendered = agent.format_state(state, player_id=0)
+        assert "point card" in rendered.lower()
+
+
+@needs_pyspiel
+class TestGoofspielPlaythrough:
+    def test_random_selfplay_terminates_win_loss(self):
+        """A full random game reaches terminal with returns in {-1, 0, 1}."""
+        agent = GoofspielAgent()
+        game = agent.load_game(agent.generate_params(0))
+        state = game.new_initial_state()
+        rng = random.Random(42)
+        while not state.is_terminal():
+            if state.is_chance_node():
+                outcomes = state.chance_outcomes()
+                state.apply_action(rng.choices([o for o, _ in outcomes], [p for _, p in outcomes])[0])
+            else:
+                player = state.current_player()
+                state.apply_action(rng.choice(state.legal_actions(player)))
+        returns = state.returns()
+        assert set(returns) <= {-1.0, 0.0, 1.0}
+        assert returns[0] == -returns[1]
+
+    def test_plays_through_evaluate_bots(self):
+        """The wrapped game runs end-to-end under OpenSpiel's evaluate_bots."""
+        agent = GoofspielAgent()
+        game = agent.load_game(agent.generate_params(0))
+        bots = [pyspiel.make_uniform_random_bot(p, 123 + p) for p in range(2)]
+        returns = evaluate_bots.evaluate_bots(game.new_initial_state(), bots, np.random.RandomState(7))
+        assert len(returns) == 2
+        assert set(returns) <= {-1.0, 0.0, 1.0}
+
+
+@needs_pyspiel
+class TestGoofspielRegistration:
+    def test_registered_as_pvp_env(self):
+        assert EnvironmentName.GOOFSPIEL in _AGENT_REGISTRY
+        assert _AGENT_REGISTRY[EnvironmentName.GOOFSPIEL] is GoofspielAgent
+        assert ENVIRONMENT_CONFIGS[EnvironmentName.GOOFSPIEL].eval_type == EvalType.PVP
+
+    def test_system_prompt_includes_rules(self):
+        prompt = GoofspielAgent().generate_system_prompt()
+        assert "goofspiel" in prompt.lower()

--- a/tests/test_pvp_goofspiel_agent.py
+++ b/tests/test_pvp_goofspiel_agent.py
@@ -24,6 +24,8 @@ try:
     from core.constants import EnvironmentName
     from core.constants import EvalType
     from core.constants import ENVIRONMENT_CONFIGS
+    from core.models.pvp_models import GameInstance
+    from core.models.pvp_models import GoofspielParams
     from core.pvp.agents import GoofspielAgent
     from core.pvp.game_eval import _AGENT_REGISTRY
     from core.pvp.game_eval import config_id_for_seed
@@ -155,3 +157,34 @@ class TestGoofspielRegistration:
     def test_system_prompt_includes_rules(self):
         prompt = GoofspielAgent().generate_system_prompt()
         assert "goofspiel" in prompt.lower()
+
+
+@needs_pyspiel
+class TestGameParamsRoundTrip:
+    """The discriminated union on GameInstance.game_params must survive JSON.
+
+    GameInstance only flows in-process today, so this is a safety property — but
+    pinning it means a future rename of the `game` tag can't silently degrade a
+    GoofspielParams to the base type without a test failing.
+    """
+
+    def test_goofspiel_params_round_trip_preserves_subclass(self):
+        inst = GameInstance(
+            game_name="goofspiel",
+            game_params=GoofspielParams(num_cards=13),
+            model_a_player_id=0,
+            seed=1,
+            is_zero_sum=True,
+            min_utility=-1.0,
+            max_utility=1.0,
+        )
+        restored = GameInstance.model_validate_json(inst.model_dump_json())
+        assert isinstance(restored.game_params, GoofspielParams)
+        assert restored.game_params.num_cards == 13
+        assert restored.game_params.to_pyspiel() == {
+            "players": 2,
+            "num_cards": 13,
+            "imp_info": True,
+            "points_order": "random",
+            "returns_type": "win_loss",
+        }

--- a/trainer/image_manager.py
+++ b/trainer/image_manager.py
@@ -688,6 +688,7 @@ FALLBACK_ENV_IMAGES: dict[core_cst.EnvironmentName, str] = {
     core_cst.EnvironmentName.LIARS_DICE: core_cst.MCTS_API_DOCKER_IMAGE,
     core_cst.EnvironmentName.LEDUC_POKER: core_cst.MCTS_API_DOCKER_IMAGE,
     core_cst.EnvironmentName.OTHELLO: core_cst.MCTS_API_DOCKER_IMAGE,
+    core_cst.EnvironmentName.GOOFSPIEL: core_cst.MCTS_API_DOCKER_IMAGE,
 }
 
 

--- a/validator/evaluation/pvp/agents.py
+++ b/validator/evaluation/pvp/agents.py
@@ -1,11 +1,9 @@
 """Back-compat shim: PvP agents moved to core.pvp.agents (shared with model-prep)."""
 
-from core.pvp.agents import BaseGameAgent
-from core.pvp.agents import GinRummyAgent
-from core.pvp.agents import LeducPokerAgent
-from core.pvp.agents import LiarsDiceAgent
-from core.pvp.agents import OthelloAgent
-from core.pvp.agents import load_prompts
-
-
-__all__ = ["BaseGameAgent", "GinRummyAgent", "LeducPokerAgent", "LiarsDiceAgent", "OthelloAgent", "load_prompts"]
+from core.pvp.agents import BaseGameAgent as BaseGameAgent
+from core.pvp.agents import GinRummyAgent as GinRummyAgent
+from core.pvp.agents import GoofspielAgent as GoofspielAgent
+from core.pvp.agents import LeducPokerAgent as LeducPokerAgent
+from core.pvp.agents import LiarsDiceAgent as LiarsDiceAgent
+from core.pvp.agents import OthelloAgent as OthelloAgent
+from core.pvp.agents import load_prompts as load_prompts

--- a/validator/evaluation/pvp/game_runner.py
+++ b/validator/evaluation/pvp/game_runner.py
@@ -105,7 +105,7 @@ def _build_instances(
         seed = seed_rng.randint(1, vcst.PVP_SEED_RANGE_MAX)
         game_params = agent.generate_params(config_id_for_seed(seed, env_config))
 
-        game = pyspiel.load_game(agent.game_name, game_params)
+        game = agent.load_game(game_params)
         game_type = game.get_type()
 
         base = GameInstance(
@@ -305,7 +305,7 @@ def _play_game(
     Each bot gets fresh working memory plus the player's persistent long-term
     memory; after the game both surviving bots reflect to consolidate it.
     """
-    game = pyspiel.load_game(instance.game_name, instance.game_params)
+    game = agent.load_game(instance.game_params)
     model_b_player_id = 1 - instance.model_a_player_id
 
     bot_a = LLMBot(

--- a/validator/tournament/orchestrator.py
+++ b/validator/tournament/orchestrator.py
@@ -1221,6 +1221,7 @@ async def process_awaiting_model_prep_tasks(config: Config):
                 reward_functions=reward_fns,
                 is_env_task=True,
                 hotkey=hotkey,
+                environment_names=getattr(task, "environment_names", None),
             )
             if prep_result is not None and prep_result.baseline_stats:
                 await task_sql.set_miner_baseline_stats(
@@ -1260,6 +1261,7 @@ async def process_awaiting_model_prep_tasks(config: Config):
             gpu_ids=gpu_ids,
             reward_functions=reward_fns,
             is_env_task=is_env_task,
+            environment_names=getattr(task, "environment_names", None) if is_env_task else None,
         )
 
     async def _run_task_prep(task, trainer_ip, gpu_ids):

--- a/validator/tournament/orchestrator.py
+++ b/validator/tournament/orchestrator.py
@@ -35,6 +35,7 @@ from validator.core.constants import PROXY_TRAINING_IMAGE_ENDPOINT
 from validator.core.constants import MODEL_PREP_STATUS_ENDPOINT
 from validator.core.constants import TASK_DETAILS_ENDPOINT
 from validator.core.models import AnyTypeRawTask
+from validator.core.models import EnvRawTask
 from validator.core.models import InstructTextRawTask
 from validator.db.sql import tasks as task_sql
 from validator.db.sql import tournaments as tournament_sql
@@ -1221,7 +1222,7 @@ async def process_awaiting_model_prep_tasks(config: Config):
                 reward_functions=reward_fns,
                 is_env_task=True,
                 hotkey=hotkey,
-                environment_names=getattr(task, "environment_names", None),
+                environment_names=task.environment_names if isinstance(task, EnvRawTask) else None,
             )
             if prep_result is not None and prep_result.baseline_stats:
                 await task_sql.set_miner_baseline_stats(
@@ -1261,7 +1262,7 @@ async def process_awaiting_model_prep_tasks(config: Config):
             gpu_ids=gpu_ids,
             reward_functions=reward_fns,
             is_env_task=is_env_task,
-            environment_names=getattr(task, "environment_names", None) if is_env_task else None,
+            environment_names=task.environment_names if isinstance(task, EnvRawTask) else None,
         )
 
     async def _run_task_prep(task, trainer_ip, gpu_ids):

--- a/validator/utils/model_prep.py
+++ b/validator/utils/model_prep.py
@@ -32,7 +32,9 @@ def _build_env_configs(
     prep only baselines the games that task actually plays — not every env. Falls
     back to all envs when no names are supplied.
     """
-    selected = set(environment_names) if environment_names else None
+    # Coerce to enum members: some code paths assign environment_names as raw
+    # strings (bypassing validation), which wouldn't match the enum keys below.
+    selected = {EnvironmentName(e) for e in environment_names} if environment_names else None
     return {
         env_name: EnvConfig(
             env_image=cfg.env_image,

--- a/validator/utils/model_prep.py
+++ b/validator/utils/model_prep.py
@@ -23,8 +23,16 @@ logger = get_logger(__name__)
 MODEL_PREP_TIMEOUT_SECONDS = 5400
 
 
-def _build_env_configs() -> dict[EnvironmentName, EnvConfig]:
-    """Build env_configs payload from the canonical ENVIRONMENT_CONFIGS."""
+def _build_env_configs(
+    environment_names: list[EnvironmentName] | None = None,
+) -> dict[EnvironmentName, EnvConfig]:
+    """Build the env_configs payload from the canonical ENVIRONMENT_CONFIGS.
+
+    Restricted to environment_names when given (the task's own games) so model
+    prep only baselines the games that task actually plays — not every env. Falls
+    back to all envs when no names are supplied.
+    """
+    selected = set(environment_names) if environment_names else None
     return {
         env_name: EnvConfig(
             env_image=cfg.env_image,
@@ -35,6 +43,7 @@ def _build_env_configs() -> dict[EnvironmentName, EnvConfig]:
             eval_payload_extra=cfg.eval_payload_extra,
         )
         for env_name, cfg in ENVIRONMENT_CONFIGS.items()
+        if selected is None or env_name in selected
     }
 
 
@@ -49,6 +58,7 @@ async def dispatch_augmentation_and_stats(
     reward_functions=None,
     is_env_task: bool = False,
     hotkey: str | None = None,
+    environment_names: list[EnvironmentName] | None = None,
 ) -> ModelPrepResponse | None:
     """Dispatch augmentation and stats collection to a trainer with GPU.
 
@@ -70,7 +80,7 @@ async def dispatch_augmentation_and_stats(
         augmentation_config=augmentation_config,
         gpu_ids=gpu_ids,
         reward_functions=reward_functions,
-        env_configs=_build_env_configs() if is_env_task else None,
+        env_configs=_build_env_configs(environment_names) if is_env_task else None,
         hotkey=hotkey,
     )
 


### PR DESCRIPTION
## What
- **Goofspiel as a first-class PvP env.** It's OpenSpiel's only simultaneous-move game, so `GoofspielAgent.load_game()` wraps it with `convert_to_turn_based` to run under the sequential tool-calling harness. `imp_info=True` hides the opponent's hand (and the wrapper hides the concurrent bid), `returns_type=win_loss` gives zero-sum {-1,0,1} that maps cleanly through `determine_outcome`, and `num_cards` varies per game for diversity.
- **`BaseGameAgent.load_game()`** now owns game construction (only goofspiel overrides it); the three load sites route through it.
- **Typed game params.** `GameParams` base + per-game subclasses as a discriminated union on `GameInstance.game_params`, replacing `dict[str, int]` (goofspiel needs str/bool params); `to_pyspiel()` renders the load_game kwargs.
- **Model-prep scoped to a task's games.** `_build_env_configs` takes the task's `environment_names` (all-envs fallback), threaded from the orchestrator — so prep baselines only the games a task plays, not every env.

## Validation
- 181 PvP tests green incl. new goofspiel suite; discriminated-union JSON round-trip; env-filter tests.
- Fresh-built pvp-eval + model-prep containers on H100s: goofspiel plays end-to-end. Qwen2.5-7B and Llama-3.1-8B → 0% forfeit with memory writes; weaker models forfeit (expected `tool_choice=auto` pressure). Model-prep ran goofspiel-only and scored a real baseline (Qwen2.5-7B mean=0.5 vs MCTS, 0 forfeits).

## Caveat (follow-up, not in this PR)
Eval + the in-harness MCTS baseline apply the turn-based wrap / hidden-info / win_loss config. Miner **training** rollouts use the separate `MCTS_API_DOCKER_IMAGE` REST server, whose goofspiel implementation isn't in this repo. Confirm that server's goofspiel matches this eval contract (turn-based, imp_info, observation rendering, returns type) before trusting goofspiel tournament scores — otherwise train/eval mismatch.