### PR TITLE
PvP eval: don't burn a pair retry attempt on capacity-unavailable fai…

### DIFF
--- a/validator/core/constants.py
+++ b/validator/core/constants.py
@@ -552,11 +552,6 @@ PVP_PERF_DIFF_SLOPE = 0.125  # Linear map: 60% win rate → emission threshold, 
 PVP_BASILICA_TTL_SECONDS = 28800
 PVP_BASILICA_GPU_COUNT = 2
 INDIVIDUAL_BASILICA_GPU_COUNT = 1
-# Max PvP pair deployments in flight at once, across all tasks. Sized to the eval GPU
-# pool so it stays saturated without over-subscribing: every ready task may dispatch,
-# but only this many pairs deploy concurrently; the rest wait their turn rather than
-# flooding Basilica and bouncing off capacity.
-MAX_CONCURRENT_PVP_PAIRS = EVAL_MAX_GPUS // PVP_BASILICA_GPU_COUNT
 PVP_BASILICA_PORT = 8000
 
 # HuggingFace container env vars (shared across all eval containers)

--- a/validator/core/constants.py
+++ b/validator/core/constants.py
@@ -194,6 +194,11 @@ FIRST_PLACE_SCORE = 3
 MAX_CONCURRENT_MINER_ASSIGNMENTS = 5
 MAX_CONCURRENT_TASK_PREPS = 3
 EVAL_MAX_GPUS = 10
+# How many environment (PvP) tasks may be evaluated at once. A single env task fans out
+# all its PvP pairs in parallel, which can already saturate the eval GPU pool; running
+# multiple env tasks concurrently floods Basilica and most pair deployments bounce off
+# capacity. Keep at 1 so env tasks drain one at a time. Non-env tasks are unaffected.
+MAX_CONCURRENT_ENV_EVAL_TASKS = 1
 
 PERCENTAGE_OF_TASKS_THAT_SHOULD_BE_INSTRUCT_TEXT = 0.75
 PERCENTAGE_OF_INSTRUCT_TASKS_THAT_SHOULD_BE_CHAT = 0.5

--- a/validator/core/constants.py
+++ b/validator/core/constants.py
@@ -488,6 +488,14 @@ EVAL_BASILICA_MAX_RETRIES = 3
 EVAL_BASILICA_RETRY_DELAY_SECONDS = 900
 EVAL_BASILICA_POLL_INTERVAL_SECONDS = 300
 EVAL_BASILICA_MAX_POLL_SECONDS = 16000
+# When the result poll keeps failing (deployment gone / 404 / connection refused), give
+# up after this many *consecutive* failures instead of polling a dead endpoint until the
+# overall deadline. A single transient blip won't trip it; it needs this many in a row.
+EVAL_BASILICA_MAX_CONSECUTIVE_POLL_FAILURES = 5
+# After a failed poll, re-check this soon (instead of the full interval) to confirm death
+# quickly. Lets a dead deployment be abandoned in ~minutes while live evals keep their
+# normal cadence and the overall poll deadline.
+EVAL_BASILICA_FAILED_POLL_RECHECK_SECONDS = 30
 EVAL_DEPLOYMENT_READY_TIMEOUT_SECONDS = 600
 EVAL_DB_MAX_CONCURRENT_WRITES = 2
 EVAL_DB_RETRY_ATTEMPTS = 4

--- a/validator/core/constants.py
+++ b/validator/core/constants.py
@@ -194,11 +194,6 @@ FIRST_PLACE_SCORE = 3
 MAX_CONCURRENT_MINER_ASSIGNMENTS = 5
 MAX_CONCURRENT_TASK_PREPS = 3
 EVAL_MAX_GPUS = 10
-# How many environment (PvP) tasks may be evaluated at once. A single env task fans out
-# all its PvP pairs in parallel, which can already saturate the eval GPU pool; running
-# multiple env tasks concurrently floods Basilica and most pair deployments bounce off
-# capacity. Keep at 1 so env tasks drain one at a time. Non-env tasks are unaffected.
-MAX_CONCURRENT_ENV_EVAL_TASKS = 1
 
 PERCENTAGE_OF_TASKS_THAT_SHOULD_BE_INSTRUCT_TEXT = 0.75
 PERCENTAGE_OF_INSTRUCT_TASKS_THAT_SHOULD_BE_CHAT = 0.5
@@ -549,6 +544,11 @@ PVP_PERF_DIFF_SLOPE = 0.125  # Linear map: 60% win rate → emission threshold, 
 PVP_BASILICA_TTL_SECONDS = 28800
 PVP_BASILICA_GPU_COUNT = 2
 INDIVIDUAL_BASILICA_GPU_COUNT = 1
+# Max PvP pair deployments in flight at once, across all tasks. Sized to the eval GPU
+# pool so it stays saturated without over-subscribing: every ready task may dispatch,
+# but only this many pairs deploy concurrently; the rest wait their turn rather than
+# flooding Basilica and bouncing off capacity.
+MAX_CONCURRENT_PVP_PAIRS = EVAL_MAX_GPUS // PVP_BASILICA_GPU_COUNT
 PVP_BASILICA_PORT = 8000
 
 # HuggingFace container env vars (shared across all eval containers)

--- a/validator/cycle/process_tasks.py
+++ b/validator/cycle/process_tasks.py
@@ -471,6 +471,12 @@ async def _get_tasks_ready_for_evaluation(config: Config) -> list[RawTask]:
     return list(tasks_by_id.values())
 
 
+# Env (PvP) tasks each fan out all their pair deployments at once, which can already
+# saturate the eval GPU pool. Serialise env-task evaluation so they drain one at a time
+# instead of many tasks flooding Basilica simultaneously. Non-env tasks are unaffected.
+_ENV_EVAL_TASK_SEM = asyncio.Semaphore(cst.MAX_CONCURRENT_ENV_EVAL_TASKS)
+
+
 async def evaluate_tasks_loop(config: Config):
     processing_task_ids: set[str] = set()
 
@@ -501,7 +507,12 @@ async def _run_and_cleanup(
 ):
     try:
         num_gpus = compute_required_gpus(task)
-        await _evaluate_pending_pairs_for_task(task, num_gpus, config)
+        if task.task_type == TaskType.ENVIRONMENTTASK:
+            # One env task at a time — it fans out all its PvP pairs internally.
+            async with _ENV_EVAL_TASK_SEM:
+                await _evaluate_pending_pairs_for_task(task, num_gpus, config)
+        else:
+            await _evaluate_pending_pairs_for_task(task, num_gpus, config)
     except Exception as e:
         logger.error(f"Error evaluating task {task.task_id}: {e}", exc_info=True)
     finally:

--- a/validator/cycle/process_tasks.py
+++ b/validator/cycle/process_tasks.py
@@ -471,12 +471,6 @@ async def _get_tasks_ready_for_evaluation(config: Config) -> list[RawTask]:
     return list(tasks_by_id.values())
 
 
-# Env (PvP) tasks each fan out all their pair deployments at once, which can already
-# saturate the eval GPU pool. Serialise env-task evaluation so they drain one at a time
-# instead of many tasks flooding Basilica simultaneously. Non-env tasks are unaffected.
-_ENV_EVAL_TASK_SEM = asyncio.Semaphore(cst.MAX_CONCURRENT_ENV_EVAL_TASKS)
-
-
 async def evaluate_tasks_loop(config: Config):
     processing_task_ids: set[str] = set()
 
@@ -507,12 +501,7 @@ async def _run_and_cleanup(
 ):
     try:
         num_gpus = compute_required_gpus(task)
-        if task.task_type == TaskType.ENVIRONMENTTASK:
-            # One env task at a time — it fans out all its PvP pairs internally.
-            async with _ENV_EVAL_TASK_SEM:
-                await _evaluate_pending_pairs_for_task(task, num_gpus, config)
-        else:
-            await _evaluate_pending_pairs_for_task(task, num_gpus, config)
+        await _evaluate_pending_pairs_for_task(task, num_gpus, config)
     except Exception as e:
         logger.error(f"Error evaluating task {task.task_id}: {e}", exc_info=True)
     finally:

--- a/validator/evaluation/basilica.py
+++ b/validator/evaluation/basilica.py
@@ -78,10 +78,12 @@ async def _poll_basilica_result(
     deadline = started_monotonic + max_poll_seconds
     next_poll_at = started_monotonic
     deployment_name = getattr(deployment, "name", "unknown")
+    consecutive_failures = 0
     while time.monotonic() < deadline:
         now = time.monotonic()
         if now < next_poll_at:
             await asyncio.sleep(next_poll_at - now)
+        poll_failed = False
         try:
             await asyncio.to_thread(log_basilica_logs_block, eval_logger, repo, deployment_name, deployment)
             response = await asyncio.to_thread(
@@ -101,10 +103,27 @@ async def _poll_basilica_result(
                 if status == "failed":
                     return payload.get("error", "Basilica eval reported failure")
                 eval_logger.info(f"[{repo}] Poll ping: status={status}.")
+            else:
+                # Non-200 (e.g. 404 deployment-not-found) — the deployment may be gone.
+                poll_failed = True
+                eval_logger.warning(f"[{repo}] poll got HTTP {response.status_code} from {deployment_name}")
         except Exception as e:
+            # Connection refused / DNS failure — the deployment is likely gone.
+            poll_failed = True
             eval_logger.error(f"[{repo}] error polling Basilica result: {e}", exc_info=True)
-            pass
 
+        if poll_failed:
+            consecutive_failures += 1
+            if consecutive_failures >= vcst.EVAL_BASILICA_MAX_CONSECUTIVE_POLL_FAILURES:
+                return (
+                    f"Deployment {deployment_name} appears dead: "
+                    f"{consecutive_failures} consecutive failed polls"
+                )
+            # Re-check soon to confirm death quickly rather than waiting a full interval.
+            next_poll_at += vcst.EVAL_BASILICA_FAILED_POLL_RECHECK_SECONDS
+            continue
+
+        consecutive_failures = 0
         eval_logger.info(
             f"[{repo}] result not ready yet (status may be running/in_progress), "
             f"polling again in {poll_interval_seconds}s..."

--- a/validator/evaluation/docker_evaluation.py
+++ b/validator/evaluation/docker_evaluation.py
@@ -440,6 +440,15 @@ async def _deploy_pvp_eval(
                 max_poll_seconds=vcst.PVP_BASILICA_TTL_SECONDS,
             )
             if isinstance(result, dict):
+                # Pair finished — free its GPU reservation now instead of waiting for the
+                # whole task's cleanup, so the slot is reusable immediately.
+                await _release_reserved_gpus(
+                    task_id=task_id,
+                    psql_db=psql_db,
+                    hotkeys=hotkeys,
+                    deployment_name=deployment_name,
+                    ctx=ctx,
+                )
                 return result
             eval_logger.error("PvP %s resume returned non-dict result; redeploying: %s", label, result)
         await _release_reserved_gpus(
@@ -561,6 +570,15 @@ async def _deploy_pvp_eval(
                 max_poll_seconds=vcst.PVP_BASILICA_TTL_SECONDS,
             )
             if isinstance(result, dict):
+                # Pair finished — free its GPU reservation now instead of waiting for the
+                # whole task's cleanup, so the slot is reusable immediately.
+                await _release_reserved_gpus(
+                    task_id=task_id,
+                    psql_db=psql_db,
+                    hotkeys=hotkeys,
+                    deployment_name=resolved_deployment_name,
+                    ctx=ctx,
+                )
                 return result
 
             raise RuntimeError(str(result))

--- a/validator/evaluation/scoring.py
+++ b/validator/evaluation/scoring.py
@@ -50,6 +50,7 @@ from validator.db.sql.submissions_and_scoring import set_task_node_quality_score
 from validator.db.sql.tasks import get_env_task_eval_seed
 from validator.db.sql.tasks import get_expected_repo_name
 from validator.db.sql.tasks import get_nodes_assigned_to_task
+from validator.evaluation.basilica import EvaluationRetryableError
 from validator.evaluation.docker_evaluation import run_evaluation_basilica_image
 from validator.evaluation.docker_evaluation import run_evaluation_basilica_text
 from validator.evaluation.docker_evaluation import run_evaluation_individual
@@ -834,7 +835,6 @@ async def _get_or_run_pvp_pairs(
 
         async def _run_and_persist(pair_key: str) -> None:
             hk_a, hk_b = pair_key.split(":")
-            await tournament_sql.increment_pvp_pair_attempts(task_id, hk_a, hk_b, config.psql_db)
             try:
                 pair_group = await run_evaluation_pvp_pair(
                     model_a_repo=miners.by_hotkey[hk_a],
@@ -849,19 +849,31 @@ async def _get_or_run_pvp_pairs(
                     task_id=task_uuid,
                     psql_db=config.psql_db,
                 )
-                for pair_result in pair_group.pair_results:
-                    for env_name, env_result in pair_result.results.items():
-                        await tournament_sql.save_pvp_pair_result(
-                            task_id=task_id,
-                            result=pair_result,
-                            environment_name=env_name.value,
-                            env_result=env_result,
-                            psql_db=config.psql_db,
-                        )
-                logger.info(f"Pair {pair_key} completed and persisted")
+            except EvaluationRetryableError as exc:
+                # Transient infra failure (e.g. no eval GPU capacity) — not the pair's
+                # fault. Do NOT consume a retry attempt; leave the pair pending so it is
+                # retried next cycle instead of exhausting and being scored as a 0-0 draw.
+                logger.info(f"Pair {pair_key} deferred, eval capacity unavailable: {exc}")
+                failed_pairs.append(pair_key)
+                return
             except Exception as exc:
+                # Genuine eval failure — count the attempt so the pair can eventually exhaust.
+                await tournament_sql.increment_pvp_pair_attempts(task_id, hk_a, hk_b, config.psql_db)
                 logger.error(f"Pair {pair_key} failed: {exc}", exc_info=True)
                 failed_pairs.append(pair_key)
+                return
+
+            await tournament_sql.increment_pvp_pair_attempts(task_id, hk_a, hk_b, config.psql_db)
+            for pair_result in pair_group.pair_results:
+                for env_name, env_result in pair_result.results.items():
+                    await tournament_sql.save_pvp_pair_result(
+                        task_id=task_id,
+                        result=pair_result,
+                        environment_name=env_name.value,
+                        env_result=env_result,
+                        psql_db=config.psql_db,
+                    )
+            logger.info(f"Pair {pair_key} completed and persisted")
 
         logger.info(f"Dispatching {len(remaining_keys)} PvP pairs in parallel")
         await asyncio.gather(*[_run_and_persist(pair_key) for pair_key in remaining_keys])

--- a/validator/evaluation/scoring.py
+++ b/validator/evaluation/scoring.py
@@ -788,6 +788,12 @@ async def _eval_pvp_envs(
     return pvp_results_to_winrates(group_results)
 
 
+# Caps how many PvP pair deployments are in flight at once, across every task. Sized to
+# the eval GPU pool so it stays saturated without over-subscribing: pairs beyond the cap
+# wait here instead of being dispatched and bouncing off GPU capacity.
+_PVP_DISPATCH_SEM = asyncio.Semaphore(cts.MAX_CONCURRENT_PVP_PAIRS)
+
+
 async def _get_or_run_pvp_pairs(
     task_id: str,
     pvp_envs: list[core_cst.EnvironmentName],
@@ -836,19 +842,20 @@ async def _get_or_run_pvp_pairs(
         async def _run_and_persist(pair_key: str) -> None:
             hk_a, hk_b = pair_key.split(":")
             try:
-                pair_group = await run_evaluation_pvp_pair(
-                    model_a_repo=miners.by_hotkey[hk_a],
-                    model_b_repo=miners.by_hotkey[hk_b],
-                    hotkey_a=hk_a,
-                    hotkey_b=hk_b,
-                    base_model=base_model,
-                    environment_names=pvp_envs,
-                    seed=seed,
-                    image=image,
-                    gpu_count=gpu_count,
-                    task_id=task_uuid,
-                    psql_db=config.psql_db,
-                )
+                async with _PVP_DISPATCH_SEM:
+                    pair_group = await run_evaluation_pvp_pair(
+                        model_a_repo=miners.by_hotkey[hk_a],
+                        model_b_repo=miners.by_hotkey[hk_b],
+                        hotkey_a=hk_a,
+                        hotkey_b=hk_b,
+                        base_model=base_model,
+                        environment_names=pvp_envs,
+                        seed=seed,
+                        image=image,
+                        gpu_count=gpu_count,
+                        task_id=task_uuid,
+                        psql_db=config.psql_db,
+                    )
             except EvaluationRetryableError as exc:
                 # Transient infra failure (e.g. no eval GPU capacity) — not the pair's
                 # fault. Do NOT consume a retry attempt; leave the pair pending so it is

--- a/validator/evaluation/scoring.py
+++ b/validator/evaluation/scoring.py
@@ -788,12 +788,6 @@ async def _eval_pvp_envs(
     return pvp_results_to_winrates(group_results)
 
 
-# Caps how many PvP pair deployments are in flight at once, across every task. Sized to
-# the eval GPU pool so it stays saturated without over-subscribing: pairs beyond the cap
-# wait here instead of being dispatched and bouncing off GPU capacity.
-_PVP_DISPATCH_SEM = asyncio.Semaphore(cts.MAX_CONCURRENT_PVP_PAIRS)
-
-
 async def _get_or_run_pvp_pairs(
     task_id: str,
     pvp_envs: list[core_cst.EnvironmentName],
@@ -842,20 +836,19 @@ async def _get_or_run_pvp_pairs(
         async def _run_and_persist(pair_key: str) -> None:
             hk_a, hk_b = pair_key.split(":")
             try:
-                async with _PVP_DISPATCH_SEM:
-                    pair_group = await run_evaluation_pvp_pair(
-                        model_a_repo=miners.by_hotkey[hk_a],
-                        model_b_repo=miners.by_hotkey[hk_b],
-                        hotkey_a=hk_a,
-                        hotkey_b=hk_b,
-                        base_model=base_model,
-                        environment_names=pvp_envs,
-                        seed=seed,
-                        image=image,
-                        gpu_count=gpu_count,
-                        task_id=task_uuid,
-                        psql_db=config.psql_db,
-                    )
+                pair_group = await run_evaluation_pvp_pair(
+                    model_a_repo=miners.by_hotkey[hk_a],
+                    model_b_repo=miners.by_hotkey[hk_b],
+                    hotkey_a=hk_a,
+                    hotkey_b=hk_b,
+                    base_model=base_model,
+                    environment_names=pvp_envs,
+                    seed=seed,
+                    image=image,
+                    gpu_count=gpu_count,
+                    task_id=task_uuid,
+                    psql_db=config.psql_db,
+                )
             except EvaluationRetryableError as exc:
                 # Transient infra failure (e.g. no eval GPU capacity) — not the pair's
                 # fault. Do NOT consume a retry attempt; leave the pair pending so it is


### PR DESCRIPTION
…lures

EvaluationCapacityUnavailable (no eval GPU capacity) is an EvaluationRetryableError raised before any games run. _run_and_persist incremented the per-pair attempt counter unconditionally, before dispatch, so transient capacity failures consumed the MAX_TOURNAMENT_EVAL_ATTEMPTS=3 budget. Once exhausted, _try_build_pair_result scores the pair as a 0-0 draw and the task finalizes as success on phantom results.

Only count an attempt when the eval actually ran (success or genuine failure); retryable infra failures leave the pair pending to retry next cycle.