### PR TITLE
Smaller env tournament groups (≤4 incl. boss) + group-by-group training drain

### DIFF
--- a/tests/test_boss_group_selection.py
+++ b/tests/test_boss_group_selection.py
@@ -1,0 +1,24 @@
+"""Tests for select_boss_group_index — the boss (champion) is injected into the smallest
+group to minimise added PvP pairs and keep groups within the size cap.
+"""
+
+from core.models.tournament_models import Group
+from validator.tournament.tournament_manager import select_boss_group_index
+
+
+def _group(n: int) -> Group:
+    return Group(member_ids=[f"hk_{i}" for i in range(n)], task_ids=[])
+
+
+def test_picks_smallest_group():
+    groups = [_group(4), _group(2), _group(3)]
+    assert select_boss_group_index(groups) == 1
+
+
+def test_tie_picks_first_smallest():
+    groups = [_group(2), _group(2), _group(4)]
+    assert select_boss_group_index(groups) == 0
+
+
+def test_single_group():
+    assert select_boss_group_index([_group(4)]) == 0

--- a/tests/test_env_group_and_perf.py
+++ b/tests/test_env_group_and_perf.py
@@ -48,34 +48,34 @@ class TestEnvGroupFormation:
             round_number=1,
         )
 
-    def test_6_participants_one_group(self):
-        """6 participants → 1 group of 6 (fits in MAX)."""
+    def test_6_participants_small_field(self):
+        """6 (small field, max 3) + reserved boss slot (effective 7) → 3 groups of 2."""
         nodes = self._make_nodes(6)
         result = self._form_groups(nodes)
-        assert len(result.groups) == 1
-        assert len(result.groups[0].member_ids) == 6
+        assert len(result.groups) == 3
+        assert sorted(len(g.member_ids) for g in result.groups) == [2, 2, 2]
 
-    def test_7_participants_two_groups(self):
-        """7 participants → 2 groups (ceil(7/6)=2), sizes 4+3 or 3+4."""
+    def test_7_participants_small_field(self):
+        """7 (small field, max 3) + reserved boss slot (effective 8) → 3 groups sized [2, 2, 3]."""
         nodes = self._make_nodes(7)
         result = self._form_groups(nodes)
-        assert len(result.groups) == 2
-        sizes = sorted([len(g.member_ids) for g in result.groups])
-        assert sizes == [3, 4]
+        assert len(result.groups) == 3
+        assert sorted(len(g.member_ids) for g in result.groups) == [2, 2, 3]
 
-    def test_12_participants_two_groups(self):
-        """12 → 2 groups of 6."""
+    def test_12_participants_four_groups(self):
+        """12 (max 4) + reserved boss slot (effective 13) → 4 groups of 3."""
         nodes = self._make_nodes(12)
         result = self._form_groups(nodes)
-        assert len(result.groups) == 2
-        assert all(len(g.member_ids) == 6 for g in result.groups)
+        assert len(result.groups) == 4
+        assert all(len(g.member_ids) == 3 for g in result.groups)
 
-    def test_13_participants_three_groups(self):
-        """13 → 3 groups (ceil(13/6)=3), roughly balanced."""
+    def test_13_participants_four_groups(self):
+        """13 (max 4) + reserved boss slot (effective 14) → 4 groups sized [3, 3, 3, 4]."""
         nodes = self._make_nodes(13)
         result = self._form_groups(nodes)
-        assert len(result.groups) == 3
-        sizes = [len(g.member_ids) for g in result.groups]
+        assert len(result.groups) == 4
+        sizes = sorted(len(g.member_ids) for g in result.groups)
+        assert sizes == [3, 3, 3, 4]
         assert sum(sizes) == 13
         assert min(sizes) >= t_cst.MIN_ENVIRONMENT_GROUP_SIZE
 
@@ -111,6 +111,17 @@ class TestEnvGroupFormation:
                 assert len(g.member_ids) <= t_cst.MAX_ENVIRONMENT_GROUP_SIZE, (
                     f"n={n}: group has {len(g.member_ids)} > max {t_cst.MAX_ENVIRONMENT_GROUP_SIZE}"
                 )
+
+    def test_smallest_group_fits_boss(self):
+        """A boss slot is reserved at formation, so the boss (injected into the smallest group at
+        assignment time) keeps every group within the cap: min(sizes) + 1 <= MAX."""
+        for n in [2, 4, 5, 6, 7, 8, 11, 12, 13, 16, 18, 24, 30]:
+            nodes = self._make_nodes(n)
+            result = self._form_groups(nodes)
+            min_size = min(len(g.member_ids) for g in result.groups)
+            assert min_size + 1 <= t_cst.MAX_ENVIRONMENT_GROUP_SIZE, (
+                f"n={n}: smallest group {min_size} + boss exceeds max {t_cst.MAX_ENVIRONMENT_GROUP_SIZE}"
+            )
 
     def test_no_group_below_min(self):
         for n in [2, 3, 5, 6, 7, 11, 12, 18]:

--- a/validator/db/sql/tournaments.py
+++ b/validator/db/sql/tournaments.py
@@ -799,7 +799,9 @@ async def get_tournament_training_tasks(psql_db: PSQLDB, status: TrainingStatus)
                    {cst.REQUESTED_DATASETS}, {cst.TRAINER_IP}
             FROM {cst.TOURNAMENT_TASK_HOTKEY_TRAININGS_TABLE}
             WHERE {cst.TRAINING_STATUS} = $1
-            ORDER BY {cst.PRIORITY} ASC, {cst.CREATED_AT} DESC
+            -- task_id keeps a task/group's jobs contiguous (its hotkey rows share created_at) so the
+            -- scheduler drains one group before the next, without changing priority/created_at order.
+            ORDER BY {cst.PRIORITY} ASC, {cst.CREATED_AT} DESC, {cst.TASK_ID}
         """
         results = await connection.fetch(query, status)
 

--- a/validator/tournament/constants.py
+++ b/validator/tournament/constants.py
@@ -61,7 +61,10 @@ SMALL_TOURNAMENT_MAX_PARTICIPANTS = 14  # i.e. fewer than 15 at tournament start
 SMALL_TOURNAMENT_GROUP_TASKS = 3
 SMALL_TOURNAMENT_ADVANCE = 2
 MIN_ENVIRONMENT_GROUP_SIZE = 2
-MAX_ENVIRONMENT_GROUP_SIZE = 6
+# Round-1 group tasks evaluate every pair of miners head-to-head (PvP), so eval cost scales
+# with C(n,2). The champion (boss) is injected into the smallest group on top of its miners,
+# so the cap is enforced *including* the boss: <= 4 members => <= C(4,2) = 6 PvP pairs/group.
+MAX_ENVIRONMENT_GROUP_SIZE = 4
 # Small env tournaments collapse too fast (one big group advancing 1 contender). When the
 # field is smaller than SMALL_ENVIRONMENT_MAX_PARTICIPANTS, cap the group size lower so there
 # are more groups, more contenders survive each round, and the bracket plays out over more rounds.

--- a/validator/tournament/tournament_manager.py
+++ b/validator/tournament/tournament_manager.py
@@ -115,6 +115,7 @@ def organise_tournament_round(
     tournament_type: TournamentType | None = None,
     round_id: str = "",
     round_number: int = 1,
+    is_final_round: bool = False,
 ) -> Round:
     nodes_copy = nodes.copy()
     random.shuffle(nodes_copy)
@@ -133,7 +134,11 @@ def organise_tournament_round(
             if round_number == 1 and len(nodes_copy) <= t_cst.SMALL_ENVIRONMENT_MAX_PARTICIPANTS
             else t_cst.MAX_ENVIRONMENT_GROUP_SIZE
         )
-        num_groups = math.ceil(len(nodes_copy) / max_group_size)
+        # Reserve a slot for the boss injected into the smallest group (see assign_nodes_to_tournament_tasks)
+        # so that group still respects max_group_size, i.e. <= C(max,2) PvP pairs.
+        boss_will_be_injected = not is_final_round and EMISSION_BURN_HOTKEY not in {n.hotkey for n in nodes_copy}
+        effective_count = len(nodes_copy) + (1 if boss_will_be_injected else 0)
+        num_groups = math.ceil(effective_count / max_group_size)
         while num_groups > 1 and len(nodes_copy) // num_groups < t_cst.MIN_ENVIRONMENT_GROUP_SIZE:
             num_groups -= 1
 
@@ -205,7 +210,9 @@ async def _create_first_round(
 ):
     round_id = generate_round_id(tournament_id, 1)
     with LogContext(round_id=round_id):
-        round_structure = organise_tournament_round(nodes, config, tournament_type, round_id=round_id, round_number=1)
+        round_structure = organise_tournament_round(
+            nodes, config, tournament_type, round_id=round_id, round_number=1, is_final_round=False
+        )
 
         round_type = RoundType.KNOCKOUT if isinstance(round_structure, KnockoutRound) else RoundType.GROUP
 
@@ -342,6 +349,11 @@ async def _save_winner_model_repo(
         logger.warning(f"Could not find winner model repo for {winner_hotkey} in tournament {tournament_id}")
 
 
+def select_boss_group_index(groups: list[Group]) -> int:
+    """Index of the smallest group — the boss injection target (minimises added PvP pairs, keeps the cap)."""
+    return min(range(len(groups)), key=lambda i: len(groups[i].member_ids))
+
+
 async def assign_nodes_to_tournament_tasks(
     tournament_id: str, round_structure: Round, psql_db: PSQLDB, is_final_round: bool = False
 ) -> None:
@@ -353,21 +365,18 @@ async def assign_nodes_to_tournament_tasks(
     if isinstance(round_structure, GroupRound):
         all_round_tasks = await get_tournament_tasks(round_structure.round_id, psql_db)
 
-        # The boss (EMISSION_BURN_HOTKEY) may already be a real member of one of the
-        # groups (e.g. it advanced into a group this round). Detect that up front so we
-        # don't greedily append it to an earlier group as well — otherwise the boss gets
-        # assigned to two tasks in the same round.
-        boss_assigned = any(
-            EMISSION_BURN_HOTKEY in group.member_ids for group in round_structure.groups
+        # The boss may already be a competing member of a group this round; only inject it
+        # (into the smallest group) when it isn't, so it never gets assigned to two tasks.
+        boss_target_idx = (
+            None
+            if not is_environment_tournament or any(EMISSION_BURN_HOTKEY in g.member_ids for g in round_structure.groups)
+            else select_boss_group_index(round_structure.groups)
         )
         for i, group in enumerate(round_structure.groups):
             if is_environment_tournament:
                 group_participants = list(group.member_ids)
-                if EMISSION_BURN_HOTKEY in group_participants:
-                    boss_assigned = True
-                elif not boss_assigned:
+                if i == boss_target_idx and EMISSION_BURN_HOTKEY not in group_participants:
                     group_participants.append(EMISSION_BURN_HOTKEY)
-                    boss_assigned = True
                 participants_to_assign = group_participants
 
                 if is_final_round:
@@ -524,7 +533,7 @@ async def create_next_round(
         round_structure = organise_tournament_round(
             winner_nodes, config,
             tournament.tournament_type if tournament.tournament_type == TournamentType.ENVIRONMENT else None,
-            round_id=next_round_id, round_number=next_round_number,
+            round_id=next_round_id, round_number=next_round_number, is_final_round=next_round_is_final,
         )
 
         round_type = RoundType.KNOCKOUT if isinstance(round_structure, KnockoutRound) else RoundType.GROUP


### PR DESCRIPTION
## What

Three related changes to environment tournaments (the only PvP path — text/image groups score by loss and are untouched):

**A. Cap env group size at 4, including the boss.** Round-1 group tasks play every pair head-to-head, so eval cost is `C(n,2)`. `MAX_ENVIRONMENT_GROUP_SIZE` 6→4 (≤6 pairs/group). Because the champion (`EMISSION_BURN_HOTKEY`) is injected into a group at assignment time, `organise_tournament_round` now **reserves a boss slot** when the boss will be injected (env, non-final, not already a member) so the group it lands in still respects the cap.

**B. Boss → smallest group.** Injection moves from "first eligible group" to the **smallest** group (`select_boss_group_index`) — minimises added pairs and keeps groups balanced.

**C. Drain training group-by-group.** Pending training jobs are ordered `(priority, created_at DESC, task_id)`. A task's hotkey rows all share `created_at` (set to the immutable `task.created_at`; nothing updates it), so `task_id` only breaks ties — it keeps a task/group's jobs contiguous so they finish and free GPU + eval slots before the next group starts, instead of round-robining. Priority/created_at ordering and `MAX_TRAINING_ATTEMPTS`/spillover are unchanged.

## Why

Large groups make rounds slow to drain and amplify every eval hiccup (a group of 8 = 28 pairs; +boss = 36). Spreading training across all groups means none completes until the slowest job everywhere lands.

## Notes

- Scoring needs no change — pair generation already uses `itertools.combinations` and is group-size-agnostic for 2/3/4-member groups.
- No change to eval/scoring correctness or round-advancement semantics.
- Out of scope: PvP eval throughput fixes (timeouts, forfeit-on-chat-failure, deterministic-inference speed).

## Tests

`tests/test_env_group_and_perf.py` updated for the new cap + boss reservation; added `test_smallest_group_fits_boss` invariant (`min(group) + 1 ≤ cap`) and new `tests/test_boss_group_selection.py`. `pytest tests/test_env_group_and_perf.py tests/test_boss_group_selection.py` → 27 passed (2 pre-existing failures in unrelated winner-advancement tests, confirmed failing on a clean tree).