### PR TITLE
eval: don't count GPU-capacity failures as a retry attempt

### DIFF
--- a/validator/evaluation/scoring.py
+++ b/validator/evaluation/scoring.py
@@ -50,6 +50,7 @@ from validator.db.sql.submissions_and_scoring import set_task_node_quality_score
 from validator.db.sql.tasks import get_env_task_eval_seed
 from validator.db.sql.tasks import get_expected_repo_name
 from validator.db.sql.tasks import get_nodes_assigned_to_task
+from validator.evaluation.basilica import EvaluationRetryableError
 from validator.evaluation.docker_evaluation import run_evaluation_basilica_image
 from validator.evaluation.docker_evaluation import run_evaluation_basilica_text
 from validator.evaluation.docker_evaluation import run_evaluation_individual
@@ -636,6 +637,11 @@ async def process_miners_pool(
                 else:
                     raise ValueError(f"Unknown task type: {task.task_type}")
 
+        except EvaluationRetryableError:
+            # Transient infra failure (e.g. no eval GPU capacity). Propagate so the
+            # task is reset to pending and retried WITHOUT consuming an eval attempt,
+            # rather than being recorded as a permanent per-miner failure.
+            raise
         except Exception as e:
             logger.error(f"Error during batch evaluation: {e}", exc_info=True)
             results.extend(


### PR DESCRIPTION
## Problem

We saw eval rows finalized as `failure` with:

```
Evaluation failed: Not enough evaluation GPU capacity for deployment 27ad34ad-... (1 GPUs)
```

A GPU-capacity shortage is **transient infra**, not a model failure — but it was burning one of the `MAX_EVAL_ATTEMPTS` (4) retries for the task.

## Root cause

`EvaluationCapacityUnavailable` is a subclass of `EvaluationRetryableError`, and `run_basilica_eval_repos` correctly **re-raises** it (`basilica.py:696`). For text/image tasks the call chain is:

```
process_miners_pool            (scoring.py:512)
  └─ _evaluate_submissions
       └─ run_evaluation_basilica_text/image
            └─ run_basilica_eval_repos   ← raises EvaluationRetryableError
```

But `process_miners_pool`'s batch-eval block wraps everything in a bare `except Exception` (`scoring.py:639`), which swallowed the retryable error and converted it into per-miner `Evaluation failed: ...` results. Those rows were then marked `failure` and `n_eval_attempts` was incremented (`process_tasks.py:250/267`).

The PvP branch already guards against this by re-raising `PvPIncompleteError` (`scoring.py:554`); the text/image branch had no equivalent.

## Fix

Re-raise `EvaluationRetryableError` from `process_miners_pool` before the generic handler. It then propagates up to `_evaluate_and_update_hotkeys` (`process_tasks.py:294`), which resets the evals to `pending` and clears deployments — retrying **without consuming an attempt**, exactly like the PvP path.

## Scope

- Affects text and image (batch) evaluation. PvP was already handled.
- No behavior change for genuine eval failures — only transient `EvaluationRetryableError`s (capacity unavailable, deployment-not-ready) now avoid counting toward retries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)