### PR TITLE
dedup(T2): retry the pairwise judge 4x on unparseable verdict

### DIFF
--- a/validator/utils/repo_dedup.py
+++ b/validator/utils/repo_dedup.py
@@ -390,7 +390,7 @@ async def _judge_pair(cwd: Path, dir_a: str, dir_b: str, file_summary: str, runt
     )
 
     last_error: Exception | None = None
-    for attempt in range(2):
+    for attempt in range(4):
         result_text = ""
         async for message in query(prompt=prompt, options=options):
             if isinstance(message, ResultMessage):


### PR DESCRIPTION
A single unparseable Claude verdict (non-JSON reply) raised RuntimeError out of _judge_pair, which propagated through run_pairwise_dedup and tripped the gate's error path — adding the round to _GATE_FAILED and halting the whole tournament after only 2 attempts. Bump the per-pair retry budget from 2 to 4 so a transient malformed reply self-heals instead of killing the entire 28-pair gate run.