### PR TITLE
model_prep: fix YaRN model load crash (head_dim None)

### DIFF
--- a/trainer/model_prep/entrypoint.py
+++ b/trainer/model_prep/entrypoint.py
@@ -17,6 +17,7 @@ from huggingface_hub import HfApi
 from huggingface_hub import hf_hub_download
 from huggingface_hub import repo_exists
 from peft import PeftModel
+from transformers import AutoConfig
 from transformers import AutoModelForCausalLM
 from transformers import AutoTokenizer
 
@@ -226,6 +227,23 @@ def upload_augmented_model(model, tokenizer, repo_id: str, hf_token: str) -> Non
     print(f"Upload complete: {repo_id}")
 
 
+def _load_config_with_yarn_fix(model_path: str, hf_token: str):
+    """Load the model config, working around a transformers crash on YaRN models.
+
+    transformers' `_compute_yarn_parameters` resolves head_dim with a getattr fallback,
+    but some configs (e.g. Mistral) set `head_dim` to None, so the fallback never fires
+    and `None * partial_rotary_factor` raises TypeError. Only the YaRN rope path reads
+    head_dim, so non-YaRN models are unaffected. Set it to the value transformers itself
+    would derive (hidden_size // num_attention_heads).
+    """
+    config = AutoConfig.from_pretrained(model_path, token=hf_token)
+    head_dim = config.head_dim if hasattr(config, "head_dim") else None
+    if head_dim is None and hasattr(config, "hidden_size") and hasattr(config, "num_attention_heads"):
+        config.head_dim = config.hidden_size // config.num_attention_heads
+        print(f"[model_prep] set head_dim={config.head_dim} (was None) to avoid YaRN rope crash", flush=True)
+    return config
+
+
 def main():
     t_total = time.time()
     args = parse_args()
@@ -242,18 +260,19 @@ def main():
     t0 = time.time()
     n_gpus = torch.cuda.device_count()
     print(f"[model_prep] Loading model: {model_path} (gpus={n_gpus})", flush=True)
+    model_config = _load_config_with_yarn_fix(model_path, hf_token)
     if n_gpus > 1:
         print(f"[model_prep] Multi-GPU detected ({n_gpus}), using device_map=auto", flush=True)
         model = AutoModelForCausalLM.from_pretrained(
-            model_path, torch_dtype=torch.float16, token=hf_token, device_map="auto",
+            model_path, config=model_config, torch_dtype=torch.float16, token=hf_token, device_map="auto",
         )
     elif torch.cuda.is_available():
         model = AutoModelForCausalLM.from_pretrained(
-            model_path, torch_dtype=torch.float16, token=hf_token,
+            model_path, config=model_config, torch_dtype=torch.float16, token=hf_token,
         )
         model.to("cuda")
     else:
-        model = AutoModelForCausalLM.from_pretrained(model_path, token=hf_token)
+        model = AutoModelForCausalLM.from_pretrained(model_path, config=model_config, token=hf_token)
     tokenizer = AutoTokenizer.from_pretrained(model_path, token=hf_token)
     num_params = sum(p.numel() for p in model.parameters())
     print(f"[model_prep] Model loaded in {time.time() - t0:.1f}s ({num_params / 1e9:.1f}B params)", flush=True)


### PR DESCRIPTION
## Problem
YaRN base models (e.g. `NousResearch/Yarn-Mistral-7b-128k`) crash model-prep:
```
TypeError: unsupported operand type(s) for *: 'NoneType' and 'float'
  _compute_yarn_parameters → dim = int(head_dim * partial_rotary_factor)
```
`transformers` resolves `head_dim` via `getattr(config, "head_dim", hidden_size // num_attention_heads)`, but Mistral configs set `head_dim = None`, so `getattr` returns `None` (not the fallback) and `None * 1.0` raises. Only the **YaRN** rope path reads `head_dim`, so non-YaRN models never hit it.

This caused recurring model-prep **HTTP 500s** and forced manual `replace`-task each time a YaRN base was rolled (hit R2 and R3 of a live text tournament).

## Fix
Load the config first and set `head_dim` explicitly (`hidden_size // num_attention_heads` — exactly what transformers would derive) before `from_pretrained`. Safe for all models; only changes behaviour for configs where `head_dim` was `None`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)