### PR TITLE
model_prep: load models in native dtype, not forced fp16

### DIFF
--- a/trainer/model_prep/entrypoint.py
+++ b/trainer/model_prep/entrypoint.py
@@ -93,7 +93,7 @@ def detect_and_merge_lora(model_id: str, hf_token: str) -> ModelPrepResult:
         print(f"Merging LoRA chain into base: {real_base} (depth {len(chain)})", flush=True)
 
         base_model = AutoModelForCausalLM.from_pretrained(
-            real_base, torch_dtype=torch.float16, token=hf_token,
+            real_base, torch_dtype="auto", token=hf_token,
             device_map="cuda:0" if torch.cuda.is_available() else "auto",
         )
         base_tokenizer = AutoTokenizer.from_pretrained(real_base, token=hf_token)
@@ -261,18 +261,20 @@ def main():
     n_gpus = torch.cuda.device_count()
     print(f"[model_prep] Loading model: {model_path} (gpus={n_gpus})", flush=True)
     model_config = _load_config_with_yarn_fix(model_path, hf_token)
+    # Load in the model's native dtype ("auto" reads config.torch_dtype) rather than forcing
+    # fp16: bf16-native models (e.g. Qwen3) overflow in fp16, producing NaN baseline stats.
     if n_gpus > 1:
         print(f"[model_prep] Multi-GPU detected ({n_gpus}), using device_map=auto", flush=True)
         model = AutoModelForCausalLM.from_pretrained(
-            model_path, config=model_config, torch_dtype=torch.float16, token=hf_token, device_map="auto",
+            model_path, config=model_config, torch_dtype="auto", token=hf_token, device_map="auto",
         )
     elif torch.cuda.is_available():
         model = AutoModelForCausalLM.from_pretrained(
-            model_path, config=model_config, torch_dtype=torch.float16, token=hf_token,
+            model_path, config=model_config, torch_dtype="auto", token=hf_token,
         )
         model.to("cuda")
     else:
-        model = AutoModelForCausalLM.from_pretrained(model_path, config=model_config, token=hf_token)
+        model = AutoModelForCausalLM.from_pretrained(model_path, config=model_config, torch_dtype="auto", token=hf_token)
     tokenizer = AutoTokenizer.from_pretrained(model_path, token=hf_token)
     num_params = sum(p.numel() for p in model.parameters())
     print(f"[model_prep] Model loaded in {time.time() - t0:.1f}s ({num_params / 1e9:.1f}B params)", flush=True)


### PR DESCRIPTION
## Problem
Model-prep hardcoded `torch_dtype=torch.float16` when loading the base model. **bf16-native models overflow in fp16** → the baseline-stats *training-dynamics* forward pass returns `loss=nan`.

Hit live on a boss-round DPO task: `Qwen/Qwen3-8B-Base` (config `torch_dtype: bfloat16`):
```
[stats] BPB done (bpb=1.0057)                     ← ok
[stats] Eval loop done (loss=nan, 2000 batches)   ← fp16 overflow
```

## Fix
Use `torch_dtype="auto"` so each model loads in the dtype it was saved in — bf16 stays bf16 (no overflow), fp16 stays fp16 (unchanged). All trainers are H100, so bf16 is fully supported. Applied to the main load path (multi-GPU / single-GPU / CPU) and the LoRA base-merge load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)