### PR TITLE
tournament: pay only top 2 ranks (80/20 boss/runner-up)

### DIFF
--- a/tests/test_tournament_scoring_pipeline.py
+++ b/tests/test_tournament_scoring_pipeline.py
@@ -307,16 +307,23 @@ class TestExponentialDeclineMapping:
         w2 = exponential_decline_mapping(5, 2)
         assert w1 > w2
 
-    def test_monotonic_decrease(self):
+    def test_non_increasing_by_rank(self):
         weights = [exponential_decline_mapping(5, r) for r in range(1, 6)]
         for i in range(len(weights) - 1):
-            assert weights[i] > weights[i + 1]
+            assert weights[i] >= weights[i + 1]
+
+    def test_only_top_two_ranks_paid(self):
+        """Only the top TOURNAMENT_PAID_RANKS (2) earn; the rest get exactly 0."""
+        assert exponential_decline_mapping(5, 1) == pytest.approx(0.8)
+        assert exponential_decline_mapping(5, 2) == pytest.approx(0.2)
+        assert exponential_decline_mapping(5, 3) == 0.0
+        assert exponential_decline_mapping(5, 5) == 0.0
 
     def test_single_participant(self):
         assert exponential_decline_mapping(1, 1) == 1.0
 
     def test_weights_sum_to_one(self):
-        """All ranks' weights should sum to approximately 1.0 (normalization)."""
+        """Paid ranks' weights should sum to approximately 1.0 (normalization)."""
         n = 10
         total = sum(exponential_decline_mapping(n, r) for r in range(1, n + 1))
         assert abs(total - 1.0) < 1e-9

--- a/validator/core/constants.py
+++ b/validator/core/constants.py
@@ -164,7 +164,7 @@ MIN_MINERS_FOR_TOURN = 4  # within the small-tournament band (3..9): round 1 is 
 TOURNAMENT_PARTICIPATION_WEIGHT = 0.0001  # Weight given to active participants
 
 # Tournament weight distribution
-TOURNAMENT_SIMPLE_DECAY_BASE = 0.3  # Base for simple exponential decay (1st=1.0, 2nd=0.2, 3rd=0.04, etc.)
+TOURNAMENT_SIMPLE_DECAY_BASE = 0.15  # Rank-share decay base; raw weights 1.0/0.15/0.0225 -> normalized ~85% / 13% / 2% for 1st/2nd/3rd
 
 
 # General miner pool sizes

--- a/validator/core/constants.py
+++ b/validator/core/constants.py
@@ -164,7 +164,10 @@ MIN_MINERS_FOR_TOURN = 4  # within the small-tournament band (3..9): round 1 is 
 TOURNAMENT_PARTICIPATION_WEIGHT = 0.0001  # Weight given to active participants
 
 # Tournament weight distribution
-TOURNAMENT_SIMPLE_DECAY_BASE = 0.15  # Rank-share decay base; raw weights 1.0/0.15/0.0225 -> normalized ~85% / 13% / 2% for 1st/2nd/3rd
+# Only the top TOURNAMENT_PAID_RANKS placements earn; within them the share decays
+# geometrically by TOURNAMENT_SIMPLE_DECAY_BASE. base 0.25 over 2 paid ranks -> 80% / 20%.
+TOURNAMENT_PAID_RANKS = 2
+TOURNAMENT_SIMPLE_DECAY_BASE = 0.25  # 1st/2nd share = 80% / 20%; ranks beyond TOURNAMENT_PAID_RANKS get 0
 
 
 # General miner pool sizes

--- a/validator/evaluation/tournament_scoring.py
+++ b/validator/evaluation/tournament_scoring.py
@@ -312,15 +312,24 @@ def calculate_tournament_type_scores_from_data(
 
 
 def exponential_decline_mapping(total_participants: int, rank: float) -> float:
-    """Exponential weight decay based on rank."""
+    """Exponential weight decay based on rank.
+
+    Only the top ``TOURNAMENT_PAID_RANKS`` placements earn; everyone below gets 0.
+    Within the paid ranks the share decays geometrically (base
+    ``TOURNAMENT_SIMPLE_DECAY_BASE``), normalized to sum to 1. With base 0.25 and
+    2 paid ranks this gives an 80% / 20% split between 1st and 2nd.
+    """
     if total_participants <= 1:
         return 1.0
 
-    # Calculate all weights for normalization
-    all_weights = [cts.TOURNAMENT_SIMPLE_DECAY_BASE ** (r - 1) for r in range(1, total_participants + 1)]
+    paid_ranks = min(total_participants, cts.TOURNAMENT_PAID_RANKS)
+    if rank > paid_ranks:
+        return 0.0
+
+    # Normalize only over the paid ranks so their shares sum to 1.
+    all_weights = [cts.TOURNAMENT_SIMPLE_DECAY_BASE ** (r - 1) for r in range(1, paid_ranks + 1)]
     total_sum = sum(all_weights)
 
-    # Return normalized weight to ensure sum = 1
     raw_weight = cts.TOURNAMENT_SIMPLE_DECAY_BASE ** (rank - 1)
     return raw_weight / total_sum
 


### PR DESCRIPTION
## What

Restricts the in-track tournament pool to the **top 2 placements only** and concentrates it on the winner:

| rank | share |
|---|---|
| 1st (boss/champion) | **80%** |
| 2nd (runner-up) | **20%** |
| 3rd and below | **0%** |

Previously the pool spread geometrically across all ranks (~70/21/6/2 at the old base of 0.3).

## How

- New `TOURNAMENT_PAID_RANKS = 2` — only the top N placements earn.
- `TOURNAMENT_SIMPLE_DECAY_BASE` 0.3 → 0.25, which over 2 paid ranks normalizes to exactly 80 / 20.
- `exponential_decline_mapping` now normalizes over the paid ranks only and returns 0 for ranks beyond the cap.

## Notes

- This is the in-track winner/runner-up split. Rank 1 is whoever holds the crown — the defending boss if they held, or the new champion who just dethroned. So this is "boss 80% / runner-up 20%".
- Independent of the emission-floor / burn-bar / dethrone-rule changes (separate PR).
- Mechanics caveat: the winner is paid from the (decaying) boosted pool while the runner-up is paid from the base pool, with any undistributed boosted weight going to burn. So the 80% only fully lands on the boss while their boosted pool is positive; for a fully time-decayed defending boss, share stripped from lower ranks falls to burn rather than to the boss.