### PR TITLE
Fix continuation-round train/eval base mismatch (env/PvP tournaments)

### DIFF
--- a/core/models/pvp_models.py
+++ b/core/models/pvp_models.py
@@ -134,7 +134,19 @@ class PvPModelSpec(PvPBaseModel):
 
     repo: str = Field(description="HuggingFace model repository (e.g. 'org/model-name')")
     original_model: str = Field(
-        description="Base model repository, used for LoRA detection"
+        description="Foundation model repository (the root base), used for LoRA detection"
+    )
+    base_chain: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Continuation-round lineage: adapter repos to merge onto `original_model`, "
+            "bottom-to-top, to reconstruct the base the trainer actually trained `repo` "
+            "on. Empty for round-1 / from-scratch models. In practice this holds the "
+            "single previous-round repo (starting_model_repo): the trainer's upload patch "
+            "flattens adapter base pointers to the foundation, so round N's trainer merges "
+            "only R_{N-1} onto the foundation. Typed as a list so eval stays correct if "
+            "true multi-adapter chains are ever uploaded."
+        ),
     )
     gpu_id: int | None = Field(default=None, ge=0, description="GPU device ID. Defaults to 0 for model_a, 1 for model_b")
     port: int | None = Field(default=None, gt=0, description="SGLang server port. Defaults to 30000 for model_a, 30001 for model_b")

--- a/docs/continuation_base_mismatch.md
+++ b/docs/continuation_base_mismatch.md
@@ -1,0 +1,122 @@
+# Continuation-round train/eval base-model mismatch (env / PvP)
+
+## The bug
+
+Tournament round ≥ 2 env tasks use `TrainingStartPoint.CONTINUATION`. A miner is
+**trained** on one base but **evaluated** on a different one, silently dropping
+their earlier-round contribution.
+
+Mechanism, end to end:
+
+1. **Assignment.** Each continuation participant's per-miner `starting_model_repo`
+   is set to their previous-round output adapter
+   (`validator/tournament/tournament_manager.py`, the CONTINUATION block in node
+   assignment → `task_sql.set_starting_model_repo`).
+
+2. **Training.** `orchestrator.py` sets
+   `training_model = starting_model or task.augmented_model_id or task.model_id`, so
+   the trainer receives the miner's previous-round adapter `R_{N-1}`. The trainer
+   merges it into the foundation → a full model `M1 = foundation + ΔR_{N-1}`
+   (`trainer/utils/trainer_downloader.py:_detect_and_merge_lora`), then trains the
+   new LoRA `R_N` **on top of M1**. `R_N`'s weights are therefore relative to `M1`.
+
+3. **Upload.** `trainer/utils/hf_upload.py:patch_model_metadata` only rewrites the
+   adapter's `adapter_config.base_model_name_or_path` **string** to the resolved
+   foundation. It does **not** re-base the weights. (This same flattening defeats
+   the trainer's own chain walk on the *next* round: round N+1 loads `R_N`, follows
+   its base pointer straight to the foundation, and merges only `R_N` onto the
+   foundation. So the base any round actually trains on is
+   `foundation + merge(starting_model_repo)` — a **single** adapter, never a deep
+   chain.)
+
+4. **Eval.** `validator/evaluation/scoring.py` sets
+   `base_model = task.augmented_model_id or task.model_id` (the bare foundation for
+   env tasks) and passes that single shared base to
+   `run_evaluation_pvp_pair`. In the container,
+   `validator/evaluation/pvp/__main__.py:_prepare_model` serves
+   `base_model` + `R_N` adapter via `--enable-lora`, **dropping `ΔR_{N-1}`**.
+
+**Net:** trained on `foundation + ΔR_{N-1} + ΔR_N`, evaluated on
+`foundation + ΔR_N`. Earlier-round deltas often establish the tool-call / output
+format the later adapter assumes, so a model that plays correctly with its full
+weights can forfeit every turn once `R_{N-1}` is dropped. This can flip PvP results.
+
+## The fix (eval-side reconstruction)
+
+Reconstruct, at eval time, the exact base the trainer used:
+`foundation + merge(starting_model_repo)`, and serve the miner's own adapter on top.
+
+- `core/models/pvp_models.py` — `PvPModelSpec.base_chain: list[str]`: adapter repos
+  to merge onto `original_model` before applying `repo`. Empty for round-1 models.
+- `validator/evaluation/scoring.py:_get_continuation_base_chains` — per miner, reads
+  `starting_model_repo`; if present and ≠ foundation, sets `base_chain=[starting_repo]`.
+  Threaded through `_eval_pvp_envs` → `_get_or_run_pvp_pairs` →
+  `run_evaluation_pvp_pair` as per-miner `base_chain_a` / `base_chain_b`.
+- `validator/evaluation/pvp/materialize.py` — downloads the foundation and merges the
+  chain (reusing the env-eval merge primitives), returning a local base dir.
+- `validator/evaluation/pvp/__main__.py:_prepare_model` — for a continuation spec,
+  serves the materialized base + the miner's adapter (and resolves the tool-call
+  parser from the materialized dir's `config.json`, since a merged dir has no family
+  substring in its path).
+
+`base_chain` is typed as a list (not a single string) so eval stays correct if the
+upload-side flattening is ever removed and genuine multi-adapter chains appear; in
+practice scoring populates it with the single `starting_model_repo`.
+
+### Why eval-side, not upload-side
+
+The alternative — merge `R_N` into `M1 → M2` and upload the full model — makes eval
+trivially correct but multiplies upload size every round and requires reworking
+winner-lineage handling (`_resolve_winner_base_model`). The eval-side reconstruction
+keeps uploads as small adapters and reuses the existing per-model PvP serving path
+(each model already gets its own SGLang on its own GPU, and `_prepare_model` already
+accepts a per-model `original_model`). The cost is a per-miner merge at eval time —
+bounded to a single adapter merge because of the upload-side flattening above.
+
+## Blast radius
+
+| Path | Affected? | Status |
+|---|---|---|
+| **Env / PvP continuation** (`_create_environment_group_tasks`, round > 1) | Yes | **Fixed here** |
+| **Boss round task 1 — env CONTINUATION** (`_create_environment_boss_round_tasks`) | Yes | **Fixed here** — sets per-miner `starting_model_repo` and runs through the same `_run_env_tournament_eval` PvP path |
+| **Boss round task 2 — FROM_SCRATCH** | No | round-1-like, served on the foundation |
+| **Boss round task 3 — PREVIOUS_WINNER** | Yes, *if* the stored winner repo is a LoRA adapter | **Not fixed** — see below |
+| **Text tournaments (instruct / DPO / GRPO)** | Latent (same root cause) | **Not triggered today** — see below |
+
+### Boss round PREVIOUS_WINNER (not fixed)
+
+The `PREVIOUS_WINNER` boss task carries lineage through `task.model_id`
+(= `prev_tournament.winner_model_repo`), **not** through per-miner
+`starting_model_repo`, so `_get_continuation_base_chains` does not pick it up. If the
+stored winner repo is a full merged model (the common case via
+`_save_winner_model_repo` / `_resolve_winner_base_model`), eval serves it directly and
+there is no mismatch. If the winner repo is a LoRA adapter, the same drop occurs *and*
+serving an adapter repo as the SGLang base is itself wrong.
+
+Follow-up (deliberately out of scope for this PR — non-trivial): when `task.model_id`
+is itself an adapter, set `original_model` to its resolved foundation and
+`base_chain=[task.model_id]` for every miner on the task. This reuses the exact
+machinery added here.
+
+### Text tournaments (latent, not triggered)
+
+`validator/evaluation/eval_instruct_text.py` (and DPO/GRPO) load a LoRA submission via
+`load_finetuned_model` → `AutoPeftModelForCausalLM.from_pretrained`, which attaches the
+adapter to whatever `adapter_config.base_model_name_or_path` says — i.e. the *flattened*
+foundation. So **if** text tournaments ran LoRA continuation rounds, they would have the
+identical mismatch. They do not: the text task creators
+(`_create_group_text_tasks`, `_create_new_text_boss_round_tasks`, …) never set
+`TrainingStartPoint.CONTINUATION` or a per-miner `starting_model_repo`, so no text task
+is trained on a merged base today. This is documented as latent; if text continuation is
+ever enabled, the text eval load path needs the same foundation-reconstruction before
+attaching the new adapter.
+
+## Reproduction & regression tests
+
+- `tests/test_continuation_base_mismatch.py` — deterministic, GPU-free proof that
+  dropping the round-1 delta flips the model's argmax token, plus a real-code check
+  (`core.pvp.chat._parse_tool_calls`) that a missing/garbled tool call forfeits.
+- `tests/test_continuation_eval_base.py` — regression tests for the fix: per-miner
+  chain derivation, `_prepare_model` serving the reconstructed base (not the bare
+  foundation), and a real-transformer LoRA-merge check that sequential merge
+  reconstructs the trained model while dropping the prior adapter diverges.

--- a/tests/test_continuation_base_mismatch.py
+++ b/tests/test_continuation_base_mismatch.py
@@ -1,0 +1,129 @@
+"""Reproduction of the continuation-round train/eval base-model mismatch.
+
+Mechanism (env / PvP tournaments, round >= 2, TrainingStartPoint.CONTINUATION):
+
+  * The miner is TRAINED from their previous-round adapter merged into the
+    foundation -> a full model M1 = foundation + delta_R1. Their new LoRA delta_R2
+    is therefore learned *relative to M1*.
+  * At eval, the PvP path serves the bare foundation + delta_R2 only (delta_R1 is
+    dropped), because run_evaluation_pvp_pair passes a single shared
+    `base_model = task.augmented_model_id or task.model_id` (the foundation) and
+    pvp/__main__._prepare_model applies the adapter on top of that foundation.
+
+Net: trained on (foundation + delta_R1 + delta_R2) but evaluated on
+(foundation + delta_R2). The earlier-round delta is silently dropped.
+
+This module proves the bug WITHOUT a GPU or a live SGLang server (neither is
+available here, and live evals are out of scope):
+
+  1. A deterministic linear-algebra fixture shows that dropping delta_R1 changes
+     the model's argmax output token — i.e. the model emits a *different* token.
+  2. A statistical sweep shows the divergence is generic, not a hand-picked case.
+  3. A real-code check (`core.pvp.chat._parse_tool_calls`) shows that once the
+     emitted text is malformed / the structured tool call is missing, the turn
+     yields no action — which the PvP harness scores as a forfeit. This is the
+     concrete failure mode: a flipped token breaks the `<tool_call>` JSON the
+     later adapter learned to emit on top of M1, so the miner forfeits every turn.
+"""
+
+from types import SimpleNamespace
+
+import torch
+
+from core.models.pvp_models import ToolCall
+from core.pvp.chat import _parse_tool_calls
+
+
+def _lora_delta(out_dim: int, in_dim: int, rank: int, scale: float, seed: int) -> torch.Tensor:
+    """A low-rank update B @ A, the weight delta a LoRA adapter materialises."""
+    g = torch.Generator().manual_seed(seed)
+    a = torch.randn(rank, in_dim, generator=g)
+    b = torch.randn(out_dim, rank, generator=g)
+    return scale * (b @ a)
+
+
+def test_dropping_prior_round_delta_flips_argmax_token():
+    """Deterministic: (W0 + dR1 + dR2) and (W0 + dR2) pick different output tokens.
+
+    `W0` stands in for the foundation's final projection to vocab logits, `dR1`
+    for the round-1 delta the trainer merged into the foundation, and `dR2` for
+    the round-2 adapter trained on top. The eval bug evaluates `W0 + dR2`.
+    """
+    out_dim, in_dim, rank = 16, 8, 2
+
+    g = torch.Generator().manual_seed(0)
+    w0 = torch.randn(out_dim, in_dim, generator=g)
+    x = torch.randn(in_dim, generator=g)
+
+    dr2 = _lora_delta(out_dim, in_dim, rank, scale=0.05, seed=1)
+
+    # Construct dR1 so that, on this input, it decisively boosts one token (j) that
+    # is NOT what (W0 + dR2) would pick. This is exactly the round-1 contribution
+    # that establishes the later adapter's expected output token; dropping it must
+    # flip the choice.
+    buggy_logits = (w0 + dr2) @ x
+    j = int((-buggy_logits).argmax())  # a token the buggy base actively disfavours
+    boost = torch.zeros(out_dim, in_dim)
+    # e_j outer x_hat: adds (||x||) to logit j for this input, nothing structural elsewhere.
+    boost[j] = x / (x.norm() ** 2) * (buggy_logits.max() - buggy_logits.min() + 5.0)
+    dr1 = boost
+
+    trained_logits = (w0 + dr1 + dr2) @ x  # what the miner trained against
+    buggy_logits = (w0 + dr2) @ x          # what the current eval serves
+
+    trained_token = int(trained_logits.argmax())
+    buggy_token = int(buggy_logits.argmax())
+
+    assert trained_token == j, "fixture sanity: the full base should pick the boosted token"
+    assert trained_token != buggy_token, (
+        "dropping the round-1 delta must change the emitted token "
+        f"(trained picked {trained_token}, buggy eval picked {buggy_token})"
+    )
+
+
+def test_dropping_prior_round_delta_diverges_statistically():
+    """Across many random fixtures the dropped-delta model disagrees on the token.
+
+    Guards against the deterministic case being a fluke: with a non-trivial
+    round-1 delta, the foundation-only eval picks a different token a large
+    fraction of the time.
+    """
+    out_dim, in_dim, rank = 32, 16, 4
+    disagreements = 0
+    trials = 200
+
+    for seed in range(trials):
+        g = torch.Generator().manual_seed(seed)
+        w0 = torch.randn(out_dim, in_dim, generator=g)
+        x = torch.randn(in_dim, generator=g)
+        dr1 = _lora_delta(out_dim, in_dim, rank, scale=0.5, seed=10_000 + seed)
+        dr2 = _lora_delta(out_dim, in_dim, rank, scale=0.5, seed=20_000 + seed)
+
+        trained_token = int(((w0 + dr1 + dr2) @ x).argmax())
+        buggy_token = int(((w0 + dr2) @ x).argmax())
+        disagreements += trained_token != buggy_token
+
+    # A merged round-1 delta of comparable magnitude flips the token very often;
+    # require a clear majority so the assertion is robust, not knife-edge.
+    assert disagreements / trials > 0.5, (
+        f"expected frequent token divergence, got {disagreements}/{trials}"
+    )
+
+
+def test_missing_tool_call_forfeits_but_valid_one_acts():
+    """The downstream consequence: a missing/garbled tool call yields no action.
+
+    SGLang turns the model's raw text into structured `tool_calls`; when the text
+    is malformed the field is absent and `_parse_tool_calls` returns None. The PvP
+    harness has no move to play and the player forfeits the turn. A correctly
+    formatted call parses into a ToolCall the harness can execute.
+    """
+    no_call_message = SimpleNamespace(content="I think I'll play... 3?", tool_calls=None)
+    assert _parse_tool_calls(no_call_message) is None  # -> no action -> forfeit
+
+    valid_call = SimpleNamespace(
+        id="call_1",
+        function=SimpleNamespace(name="play_card", arguments='{"card": 3}'),
+    )
+    parsed = _parse_tool_calls(SimpleNamespace(content=None, tool_calls=[valid_call]))
+    assert parsed == [ToolCall(id="call_1", name="play_card", arguments={"card": 3})]

--- a/tests/test_continuation_eval_base.py
+++ b/tests/test_continuation_eval_base.py
@@ -1,0 +1,180 @@
+"""Regression tests for the continuation-round eval-base fix.
+
+These fail on the pre-fix code and pass after it:
+
+  * `_get_continuation_base_chains` derives each miner's previous-round lineage
+    (starting_model_repo) so eval can rebuild the base they trained on.
+  * `_prepare_model` serves that reconstructed base (foundation + previous adapter
+    merged) instead of the bare foundation for a continuation miner. Serving the
+    bare foundation is the bug — it drops the previous-round delta.
+  * A real-peft check proves the sequential LoRA merge actually reconstructs the
+    model the miner trained, and that dropping the previous-round adapter changes
+    the model's output (the failure the fix prevents).
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import validator.evaluation.pvp.__main__ as pvp_main
+from core.models.pvp_models import PvPModelSpec
+from core.models.scoring_models import MinerRepos
+from validator.evaluation import scoring
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# --------------------------------------------------------------------------- #
+# 1. Per-miner lineage derivation                                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_get_continuation_base_chains_only_for_real_continuations(monkeypatch):
+    foundation = "org/foundation"
+    starting = {
+        "hk_cont": "org/hk_cont-round1",   # genuine continuation -> chain
+        "hk_round1": None,                 # no starting repo -> no chain
+        "hk_foundation": foundation,       # starting repo IS foundation -> no chain
+    }
+
+    async def fake_get_starting_model_repo(task_id, hotkey, psql_db):
+        return starting[hotkey]
+
+    monkeypatch.setattr(scoring, "get_starting_model_repo", fake_get_starting_model_repo)
+
+    task = SimpleNamespace(task_id="task-1")
+    miners = MinerRepos(by_hotkey={hk: f"org/{hk}-out" for hk in starting})
+    config = SimpleNamespace(psql_db=None)
+
+    chains = _run(scoring._get_continuation_base_chains(task, miners, foundation, config))
+
+    assert chains == {"hk_cont": ["org/hk_cont-round1"]}, (
+        "only a miner whose starting repo differs from the foundation should get a "
+        "reconstruction chain"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 2. _prepare_model serves the reconstructed base, not the bare foundation     #
+# --------------------------------------------------------------------------- #
+
+
+def test_prepare_model_continuation_serves_reconstructed_base(monkeypatch):
+    foundation = "org/foundation"
+    materialized = "/tmp/base_chain_merged_0"
+    calls = {}
+
+    monkeypatch.setattr(pvp_main, "check_for_lora", lambda repo, local_files_only=False: True)
+    monkeypatch.setattr(pvp_main, "tool_call_parser_for", lambda path, **kw: "qwen25")
+
+    def fake_materialize(foundation_repo, base_chain):
+        calls["args"] = (foundation_repo, list(base_chain))
+        return materialized if base_chain else foundation_repo
+
+    monkeypatch.setattr(pvp_main, "materialize_base_model", fake_materialize)
+
+    spec = PvPModelSpec(repo="org/miner-round2", original_model=foundation, base_chain=["org/miner-round1"])
+    prepared = pvp_main._prepare_model(spec, "a")
+
+    # The bug: pre-fix this served `foundation`, dropping the round-1 delta.
+    assert prepared.sglang_model_path == materialized
+    assert prepared.sglang_model_path != foundation
+    assert calls["args"] == (foundation, ["org/miner-round1"])
+    # The miner's own adapter is still applied on top of the reconstructed base.
+    assert "org/miner-round2" in prepared.extra_sglang_args
+    assert "--enable-lora" in prepared.extra_sglang_args
+    assert prepared.tool_call_parser == "qwen25"
+
+
+def test_prepare_model_round1_unchanged(monkeypatch):
+    """A round-1 miner (empty chain) is served exactly as before: foundation + lora."""
+    foundation = "org/foundation"
+
+    monkeypatch.setattr(pvp_main, "check_for_lora", lambda repo, local_files_only=False: True)
+
+    spec = PvPModelSpec(repo="org/miner-round1", original_model=foundation, base_chain=[])
+    prepared = pvp_main._prepare_model(spec, "b")
+
+    assert prepared.sglang_model_path == foundation
+    assert "org/miner-round1" in prepared.extra_sglang_args
+    # No explicit parser override; the server resolves it from the foundation repo id.
+    assert prepared.tool_call_parser is None
+
+
+# --------------------------------------------------------------------------- #
+# 3. Real-peft proof: sequential merge reconstructs the trained model          #
+# --------------------------------------------------------------------------- #
+
+
+def _tiny_causal_lm():
+    from transformers import LlamaConfig
+    from transformers import LlamaForCausalLM
+
+    torch.manual_seed(0)
+    cfg = LlamaConfig(
+        vocab_size=64, hidden_size=32, intermediate_size=64,
+        num_hidden_layers=2, num_attention_heads=4, num_key_value_heads=4,
+    )
+    return LlamaForCausalLM(cfg).eval()
+
+
+def _attach_random_lora(model, seed, scale):
+    """Merge a deterministic LoRA adapter into the model's attention projections.
+
+    This is exactly what `peft`'s `merge_and_unload` does — add the low-rank delta
+    dW = (alpha / r) * (B @ A) into each target weight — implemented directly so the
+    adapter is byte-identical regardless of which base it is merged onto, and to
+    avoid an unrelated peft<->torchao version incompatibility in this environment.
+    A LoRA delta B @ A is base-independent, so "the same adapter" merged onto the
+    foundation vs onto M1 isolates exactly the dropped round-1 delta.
+    """
+    r, alpha = 8, 16
+    g = torch.Generator().manual_seed(seed)
+    with torch.no_grad():
+        for layer in model.model.layers:
+            for proj in (layer.self_attn.q_proj, layer.self_attn.v_proj):
+                out_dim, in_dim = proj.weight.shape
+                a = torch.randn(r, in_dim, generator=g) * scale
+                b = torch.randn(out_dim, r, generator=g) * scale
+                proj.weight.add_((alpha / r) * (b @ a))
+    return model.eval()
+
+
+def _logits(model, input_ids):
+    with torch.no_grad():
+        return model(input_ids).logits[0, -1]
+
+
+@pytest.mark.filterwarnings("ignore")
+def test_sequential_merge_reconstructs_trained_model_and_dropping_delta_diverges():
+    base = _tiny_causal_lm()
+    input_ids = torch.tensor([[1, 2, 3, 4, 5]])
+
+    # Round 1: adapter R1 on the foundation -> M1.
+    import copy
+
+    m1 = _attach_random_lora(copy.deepcopy(base), seed=11, scale=0.5)
+
+    # Round 2: adapter R2 trained ON TOP of M1 -> the model the miner actually produced.
+    trained = _attach_random_lora(copy.deepcopy(m1), seed=22, scale=0.1)
+
+    # The eval bug: apply the SAME round-2 adapter to the bare foundation (R1 dropped).
+    # Same seed/scale => byte-identical R2 delta, merged onto the foundation instead of M1.
+    buggy = _attach_random_lora(copy.deepcopy(base), seed=22, scale=0.1)
+
+    trained_logits = _logits(trained, input_ids)
+    buggy_logits = _logits(buggy, input_ids)
+
+    # Dropping the round-1 delta changes the model's output distribution and its
+    # argmax token — exactly what silently discards the miner's earlier contribution.
+    assert not torch.allclose(trained_logits, buggy_logits, atol=1e-3)
+    assert int(trained_logits.argmax()) != int(buggy_logits.argmax())
+
+    # The fix's reconstruction path (foundation -> merge R1 -> M1, then serve M1 + R2)
+    # rebuilds M1 identically to the base the miner trained on.
+    m1_reconstructed = _attach_random_lora(copy.deepcopy(base), seed=11, scale=0.5)
+    assert torch.allclose(_logits(m1, input_ids), _logits(m1_reconstructed, input_ids), atol=1e-5)

--- a/validator/evaluation/docker_evaluation.py
+++ b/validator/evaluation/docker_evaluation.py
@@ -700,10 +700,16 @@ async def run_evaluation_pvp_pair(
     temperature: float = 0.0,
     task_id: UUID | None = None,
     psql_db: PSQLDB | None = None,
+    base_chain_a: list[str] | None = None,
+    base_chain_b: list[str] | None = None,
 ) -> PvPGroupResults:
     """Run PvP 1v1 pair evaluation via Basilica.
 
     Returns PvPGroupResults (single pair) for consistent downstream processing.
+
+    base_chain_a/base_chain_b carry each miner's continuation lineage (adapter repos
+    to merge onto base_model before applying the miner's own adapter). Empty/None for
+    round-1 models — the eval then serves base_model + adapter as before.
     """
     matchups = {
         env: PvPMatchupConfig(num_games=vcst.PVP_NUM_GAMES_PER_ENV)
@@ -711,8 +717,8 @@ async def run_evaluation_pvp_pair(
     }
     pvp_config = PvPEvalConfig(
         mode=PvPMode.PAIR,
-        model_a=PvPModelSpec(repo=model_a_repo, original_model=base_model),
-        model_b=PvPModelSpec(repo=model_b_repo, original_model=base_model),
+        model_a=PvPModelSpec(repo=model_a_repo, original_model=base_model, base_chain=base_chain_a or []),
+        model_b=PvPModelSpec(repo=model_b_repo, original_model=base_model, base_chain=base_chain_b or []),
         matchups=matchups,
         seed=seed,
         temperature=temperature,

--- a/validator/evaluation/pvp/__main__.py
+++ b/validator/evaluation/pvp/__main__.py
@@ -28,6 +28,7 @@ from validator.evaluation.pvp.game_runner import Player
 from validator.evaluation.pvp.game_runner import create_player
 from validator.evaluation.pvp.game_runner import run_matchup
 from validator.evaluation.pvp.game_runner import warmup_player
+from validator.evaluation.pvp.materialize import materialize_base_model
 from validator.evaluation.pvp.server import start_sglang
 from validator.evaluation.pvp.server import wait_for_servers
 from validator.evaluation.utils import check_for_lora
@@ -79,14 +80,23 @@ def _prepare_model(spec: PvPModelSpec, label: str) -> PreparedModel:
     Passes HF repo IDs to SGLang which handles downloads internally.
     """
     is_lora = check_for_lora(spec.repo, local_files_only=False)
-    logger.info("Model %s: repo=%s is_lora=%s", label, spec.repo, is_lora)
+    logger.info("Model %s: repo=%s is_lora=%s base_chain=%s", label, spec.repo, is_lora, spec.base_chain)
 
     if is_lora:
+        # Continuation rounds: the adapter is relative to foundation + previous-round
+        # adapter(s), not the bare foundation (the upload patch flattened its base
+        # pointer). Rebuild that base so the previous-round delta isn't dropped at
+        # eval. Empty chain -> returns the foundation repo id, i.e. the old behaviour.
+        base_path = materialize_base_model(spec.original_model, spec.base_chain)
         lora_name = f"{label}_trained_lora"
         return PreparedModel(
-            sglang_model_path=spec.original_model,
-            inference_name=f"{spec.original_model}:{lora_name}",
+            sglang_model_path=base_path,
+            inference_name=f"{base_path}:{lora_name}",
             extra_sglang_args=f"--enable-lora --lora-paths {lora_name}={spec.repo} --lora-backend triton",
+            # A materialized base is an anonymous local dir with no family substring;
+            # resolve its parser from config.json model_type. Without base_chain,
+            # base_path is the foundation repo id and the server resolves it itself.
+            tool_call_parser=tool_call_parser_for(base_path) if spec.base_chain else None,
         )
 
     # A full-weight miner repo id is often opaque (no family substring), and the

--- a/validator/evaluation/pvp/materialize.py
+++ b/validator/evaluation/pvp/materialize.py
@@ -1,0 +1,52 @@
+"""Reconstruct a continuation miner's true base model for PvP evaluation.
+
+A round >= 2 (CONTINUATION) miner trains a new LoRA *on top of* the foundation with
+their previous-round adapter already merged in — call that merged base M1. The new
+adapter's weights are therefore relative to M1, but `hf_upload.patch_model_metadata`
+flattens the uploaded `adapter_config.base_model_name_or_path` to the bare
+foundation. Serving foundation + new-adapter (the default PvP path) consequently
+drops the previous-round delta, evaluating a model the miner never trained.
+
+This module rebuilds the base the trainer actually used: foundation + the
+previous-round adapter chain, merged bottom-to-top. In practice the chain holds a
+single repo (`starting_model_repo`), because the same upload flattening defeats the
+trainer's own chain walk, so round N merges only R_{N-1} onto the foundation. The
+loop handles longer chains for forward-compatibility.
+
+It reuses the env-eval merge primitives (runtime-installs peft/accelerate, merges a
+LoRA into a base on GPU), so PvP and individual env eval share one merge path.
+"""
+
+from validator.evaluation.eval_environment import _download_lora_with_retry
+from validator.evaluation.eval_environment import _download_model_with_retry
+from validator.evaluation.eval_environment import _merge_base_and_lora
+from validator.utils.logging import get_logger
+
+
+logger = get_logger(__name__)
+
+
+def materialize_base_model(foundation_repo: str, base_chain: list[str]) -> str:
+    """Return a local path to foundation_repo with base_chain adapters merged in.
+
+    With an empty chain the foundation repo id is returned unchanged (SGLang
+    downloads it itself, the existing behaviour). Otherwise the foundation is
+    downloaded and each adapter in `base_chain` is merged in order, the output of
+    one merge feeding the next, yielding the full pre-current-adapter base.
+    """
+    if not base_chain:
+        return foundation_repo
+
+    base_path = _download_model_with_retry(foundation_repo)
+    for idx, adapter_repo in enumerate(base_chain):
+        lora_dir = f"/tmp/base_chain_lora_{idx}"
+        _download_lora_with_retry(adapter_repo, lora_dir)
+        output_dir = f"/tmp/base_chain_merged_{idx}"
+        base_path = _merge_base_and_lora(base_path, lora_dir, output_dir=output_dir)
+        logger.info(
+            "Materialized continuation base step %d: merged adapter %s -> %s",
+            idx,
+            adapter_repo,
+            base_path,
+        )
+    return base_path

--- a/validator/evaluation/scoring.py
+++ b/validator/evaluation/scoring.py
@@ -49,6 +49,7 @@ from validator.db.sql.submissions_and_scoring import set_task_node_losses
 from validator.db.sql.submissions_and_scoring import set_task_node_quality_score
 from validator.db.sql.tasks import get_env_task_eval_seed
 from validator.db.sql.tasks import get_expected_repo_name
+from validator.db.sql.tasks import get_starting_model_repo
 from validator.db.sql.tasks import get_nodes_assigned_to_task
 from validator.evaluation.basilica import EvaluationRetryableError
 from validator.evaluation.docker_evaluation import run_evaluation_basilica_image
@@ -709,9 +710,11 @@ async def _run_env_tournament_eval(
     env_scores: list[EnvMinerScores] = []
 
     if pvp_envs:
+        base_chains = await _get_continuation_base_chains(task, miners, base_model, config)
         env_scores.extend(await _eval_pvp_envs(
             task_id=str(task.task_id), pvp_envs=pvp_envs, miners=miners,
             base_model=base_model, seed=seed, config=config,
+            base_chains=base_chains,
         ))
 
     if individual_envs:
@@ -772,6 +775,32 @@ def _get_shared_env_config(envs: list[core_cst.EnvironmentName]) -> core_cst.Env
     return configs[0]
 
 
+async def _get_continuation_base_chains(
+    task: AnyTypeRawTask,
+    miners: MinerRepos,
+    base_model: str,
+    config: Config,
+) -> dict[str, list[str]]:
+    """Per-miner adapter lineage needed to reconstruct the base each miner trained on.
+
+    A CONTINUATION miner trains from `starting_model_repo` (their previous-round
+    output) merged into the foundation — so their uploaded adapter is relative to
+    that merged base, not the bare foundation. We return {hotkey: [starting_repo]}
+    so eval rebuilds it; the merge is single-step because the trainer's upload patch
+    flattens adapter base pointers (round N merges only R_{N-1}). Round-1 miners
+    (no starting repo, or starting repo == foundation) map to an empty chain and are
+    served as before.
+    """
+    base_chains: dict[str, list[str]] = {}
+    for hotkey in miners.hotkeys:
+        starting_repo = await get_starting_model_repo(str(task.task_id), hotkey, config.psql_db)
+        if starting_repo and starting_repo != base_model:
+            base_chains[hotkey] = [starting_repo]
+    if base_chains:
+        logger.info(f"Continuation base chains for {len(base_chains)} miners on task {task.task_id}")
+    return base_chains
+
+
 async def _eval_pvp_envs(
     task_id: str,
     pvp_envs: list[core_cst.EnvironmentName],
@@ -779,6 +808,7 @@ async def _eval_pvp_envs(
     base_model: str,
     seed: int,
     config: Config,
+    base_chains: dict[str, list[str]] | None = None,
 ) -> list[EnvMinerScores]:
     """Run pairwise PvP eval for PVP-type environments, return per-env win-rates."""
     env_config = _get_shared_env_config(pvp_envs)
@@ -788,6 +818,7 @@ async def _eval_pvp_envs(
         base_model=base_model, seed=seed,
         image=env_config.tournament_eval_image,
         gpu_count=cts.PVP_BASILICA_GPU_COUNT, config=config,
+        base_chains=base_chains,
     )
 
     return pvp_results_to_winrates(group_results)
@@ -802,12 +833,15 @@ async def _get_or_run_pvp_pairs(
     image: str,
     gpu_count: int,
     config: Config,
+    base_chains: dict[str, list[str]] | None = None,
 ) -> PvPGroupResults:
     """Check DB for complete pair results; if missing, run missing 1v1 pairs."""
     env_name_strs = [e.value for e in pvp_envs]
     max_pair_attempts = cts.MAX_TOURNAMENT_EVAL_ATTEMPTS
     task_uuid = UUID(task_id)
     all_hotkeys = miners.hotkeys
+
+    base_chains = base_chains or {}
 
     db_rows = await tournament_sql.get_pvp_pair_results(task_id, config.psql_db)
     rows_by_pair = _group_db_rows_by_pair(db_rows)
@@ -853,6 +887,8 @@ async def _get_or_run_pvp_pairs(
                     gpu_count=gpu_count,
                     task_id=task_uuid,
                     psql_db=config.psql_db,
+                    base_chain_a=base_chains.get(hk_a, []),
+                    base_chain_b=base_chains.get(hk_b, []),
                 )
             except EvaluationRetryableError as exc:
                 # Transient infra failure (e.g. no eval GPU capacity) — not the pair's


### PR DESCRIPTION
## The bug

Round ≥ 2 env tasks use `TrainingStartPoint.CONTINUATION`. Each miner is **trained** on `foundation + ΔR_{N-1}` (their previous-round adapter merged into the foundation → `M1`) and learns their new LoRA `R_N` relative to `M1`. But PvP eval set a single shared `base_model = task.augmented_model_id or task.model_id` (the **bare foundation**) and `pvp/__main__._prepare_model` served `foundation + R_N` via `--enable-lora`, **dropping `ΔR_{N-1}`**.

Net: trained on `foundation + ΔR_{N-1} + ΔR_N`, evaluated on `foundation + ΔR_N`. Earlier rounds often establish the tool-call/output format the later adapter assumes, so a model that plays correctly with its full weights can **forfeit every turn** once its earlier delta is dropped — flipping PvP results.

Confirmed against the code, including the key subtlety: `hf_upload.patch_model_metadata` flattens each continuation adapter's `base_model_name_or_path` to the foundation, which also defeats the trainer's own chain walk — so the base the trainer actually uses each round is `foundation + merge(starting_model_repo)`, a **single** adapter, never a deep chain.

## The fix — eval-side reconstruction

Rebuild the exact base the trainer used and serve the miner's adapter on top.

- `core/models/pvp_models.py` — `PvPModelSpec.base_chain: list[str]` (adapters to merge onto `original_model` before applying `repo`).
- `validator/evaluation/scoring.py:_get_continuation_base_chains` — per-miner chain from `starting_model_repo`; threaded through `_eval_pvp_envs` → `_get_or_run_pvp_pairs` → `run_evaluation_pvp_pair` (`base_chain_a`/`base_chain_b`).
- `validator/evaluation/pvp/materialize.py` — download foundation + merge chain, reusing the env-eval merge primitives.
- `validator/evaluation/pvp/__main__.py:_prepare_model` — serve the materialized base + adapter for continuation specs (parser resolved from the merged dir's `config.json`).

`base_chain` is a list only to stay correct if the upload-side flattening is ever removed; scoring populates it with the single `starting_model_repo`.

**Why eval-side, not upload-side full-merge:** keeps uploads as small adapters and reuses the existing per-model PvP serving path; cost is a single per-miner adapter merge at eval time (bounded by the flattening above). Upload-side would multiply upload size every round and require reworking winner-lineage handling.

## Blast radius (`docs/continuation_base_mismatch.md`)

| Path | Affected? | Status |
|---|---|---|
| Env / PvP continuation | Yes | **Fixed** |
| Boss round task 1 — env CONTINUATION | Yes | **Fixed** (same `starting_model_repo` path) |
| Boss round task 2 — FROM_SCRATCH | No | served on foundation |
| Boss round task 3 — PREVIOUS_WINNER | Yes, if winner repo is an adapter | **Not fixed** — lineage via `task.model_id`, not per-miner `starting_model_repo`; fix sketch in doc |
| Text (instruct/DPO/GRPO) | Latent (same root cause) | **Not triggered** — text task creators never set CONTINUATION/`starting_model_repo` today |

## Tests

- `tests/test_continuation_base_mismatch.py` — deterministic, GPU-free reproduction: dropping the round-1 delta flips the argmax token; real-code check that a missing/garbled tool call forfeits.
- `tests/test_continuation_eval_base.py` — regression: per-miner chain derivation, `_prepare_model` serving the reconstructed base (not the bare foundation), and a real-transformer LoRA-merge check that sequential merge reconstructs the trained model while dropping the prior adapter diverges.

All new tests pass; existing PvP/scoring tests pass (`base_chains` plumbed as an optional param).

🤖 Generated with [Claude Code](https://claude.com/claude-code)