### PR TITLE
PvP: serve continuation miners on the base they trained on

### DIFF
--- a/core/models/pvp_models.py
+++ b/core/models/pvp_models.py
@@ -134,7 +134,15 @@ class PvPModelSpec(PvPBaseModel):
 
     repo: str = Field(description="HuggingFace model repository (e.g. 'org/model-name')")
     original_model: str = Field(
-        description="Base model repository, used for LoRA detection"
+        description="Foundation model repository (the root base), used for LoRA detection"
+    )
+    base_chain: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Adapter repos to merge onto `original_model` before applying `repo`, so a "
+            "continuation miner is served on the base it actually trained on. Empty for "
+            "round-1 models. A list (not a single repo) to support deeper chains."
+        ),
     )
     gpu_id: int | None = Field(default=None, ge=0, description="GPU device ID. Defaults to 0 for model_a, 1 for model_b")
     port: int | None = Field(default=None, gt=0, description="SGLang server port. Defaults to 30000 for model_a, 30001 for model_b")

--- a/tests/test_pvp_continuation_base.py
+++ b/tests/test_pvp_continuation_base.py
@@ -1,0 +1,106 @@
+"""Continuation miners are sensitive to which base they're served on.
+
+A continuation miner's LoRA is trained on foundation + previous adapter. These
+GPU-free tests confirm the base matters: changing it shifts the model's argmax
+token, and a tool call that doesn't parse makes the turn forfeit (via the real
+`_parse_tool_calls`).
+"""
+
+from types import SimpleNamespace
+
+import torch
+
+from core.models.pvp_models import ToolCall
+from core.pvp.chat import _parse_tool_calls
+
+
+def _lora_delta(out_dim: int, in_dim: int, rank: int, scale: float, seed: int) -> torch.Tensor:
+    """A low-rank update B @ A, the weight delta a LoRA adapter materialises."""
+    g = torch.Generator().manual_seed(seed)
+    a = torch.randn(rank, in_dim, generator=g)
+    b = torch.randn(out_dim, rank, generator=g)
+    return scale * (b @ a)
+
+
+def test_base_change_shifts_argmax_token():
+    """Deterministic: (W0 + dR1 + dR2) and (W0 + dR2) pick different output tokens.
+
+    `W0` is the foundation's projection to vocab logits, `dR1` the previous-round
+    delta merged into the base, `dR2` the adapter trained on top.
+    """
+    out_dim, in_dim, rank = 16, 8, 2
+
+    g = torch.Generator().manual_seed(0)
+    w0 = torch.randn(out_dim, in_dim, generator=g)
+    x = torch.randn(in_dim, generator=g)
+
+    dr2 = _lora_delta(out_dim, in_dim, rank, scale=0.05, seed=1)
+
+    # Pick dR1 so that, on this input, it decisively boosts a token (j) that
+    # (W0 + dR2) would not pick — the previous-round contribution that sets the
+    # later adapter's expected token.
+    foundation_logits = (w0 + dr2) @ x
+    j = int((-foundation_logits).argmax())
+    boost = torch.zeros(out_dim, in_dim)
+    # e_j outer x_hat: adds (||x||) to logit j for this input, nothing structural elsewhere.
+    boost[j] = x / (x.norm() ** 2) * (foundation_logits.max() - foundation_logits.min() + 5.0)
+    dr1 = boost
+
+    trained_logits = (w0 + dr1 + dr2) @ x   # served on the trained base
+    foundation_logits = (w0 + dr2) @ x      # served on the foundation alone
+
+    trained_token = int(trained_logits.argmax())
+    foundation_token = int(foundation_logits.argmax())
+
+    assert trained_token == j, "fixture sanity: the full base should pick the boosted token"
+    assert trained_token != foundation_token, (
+        "the base choice must change the emitted token "
+        f"(trained base picked {trained_token}, foundation picked {foundation_token})"
+    )
+
+
+def test_base_change_shifts_token_across_seeds():
+    """Across many random fixtures the two bases disagree on the token.
+
+    Guards against the deterministic case being a fluke: with a non-trivial
+    previous-round delta, the two bases pick a different token a large fraction of
+    the time.
+    """
+    out_dim, in_dim, rank = 32, 16, 4
+    disagreements = 0
+    trials = 200
+
+    for seed in range(trials):
+        g = torch.Generator().manual_seed(seed)
+        w0 = torch.randn(out_dim, in_dim, generator=g)
+        x = torch.randn(in_dim, generator=g)
+        dr1 = _lora_delta(out_dim, in_dim, rank, scale=0.5, seed=10_000 + seed)
+        dr2 = _lora_delta(out_dim, in_dim, rank, scale=0.5, seed=20_000 + seed)
+
+        trained_token = int(((w0 + dr1 + dr2) @ x).argmax())
+        foundation_token = int(((w0 + dr2) @ x).argmax())
+        disagreements += trained_token != foundation_token
+
+    # Require a clear majority so the assertion is robust, not knife-edge.
+    assert disagreements / trials > 0.5, (
+        f"expected frequent token divergence, got {disagreements}/{trials}"
+    )
+
+
+def test_missing_tool_call_forfeits_but_valid_one_acts():
+    """The downstream consequence: a missing/garbled tool call yields no action.
+
+    SGLang turns the model's raw text into structured `tool_calls`; when the text
+    is malformed the field is absent and `_parse_tool_calls` returns None. The PvP
+    harness has no move to play and the player forfeits the turn. A correctly
+    formatted call parses into a ToolCall the harness can execute.
+    """
+    no_call_message = SimpleNamespace(content="I think I'll play... 3?", tool_calls=None)
+    assert _parse_tool_calls(no_call_message) is None  # -> no action -> forfeit
+
+    valid_call = SimpleNamespace(
+        id="call_1",
+        function=SimpleNamespace(name="play_card", arguments='{"card": 3}'),
+    )
+    parsed = _parse_tool_calls(SimpleNamespace(content=None, tool_calls=[valid_call]))
+    assert parsed == [ToolCall(id="call_1", name="play_card", arguments={"card": 3})]

--- a/tests/test_pvp_continuation_eval.py
+++ b/tests/test_pvp_continuation_eval.py
@@ -1,0 +1,172 @@
+"""Tests for serving PvP continuation miners on their trained base.
+
+  * `_get_continuation_base_chains` derives each miner's previous-round lineage.
+  * `_prepare_model` serves foundation + previous adapter (the trained base) for a
+    continuation miner, foundation alone for round 1.
+  * A real-transformer check that sequential LoRA merge reconstructs the trained
+    model and that dropping the previous adapter changes the output.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import validator.evaluation.pvp.__main__ as pvp_main
+from core.models.pvp_models import PvPModelSpec
+from core.models.scoring_models import MinerRepos
+from validator.evaluation import scoring
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# --------------------------------------------------------------------------- #
+# 1. Per-miner lineage derivation                                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_get_continuation_base_chains_only_for_real_continuations(monkeypatch):
+    foundation = "org/foundation"
+    starting = {
+        "hk_cont": "org/hk_cont-round1",   # genuine continuation -> chain
+        "hk_round1": None,                 # no starting repo -> no chain
+        "hk_foundation": foundation,       # starting repo IS foundation -> no chain
+    }
+
+    async def fake_get_starting_model_repo(task_id, hotkey, psql_db):
+        return starting[hotkey]
+
+    monkeypatch.setattr(scoring, "get_starting_model_repo", fake_get_starting_model_repo)
+
+    task = SimpleNamespace(task_id="task-1")
+    miners = MinerRepos(by_hotkey={hk: f"org/{hk}-out" for hk in starting})
+    config = SimpleNamespace(psql_db=None)
+
+    chains = _run(scoring._get_continuation_base_chains(task, miners, foundation, config))
+
+    assert chains == {"hk_cont": ["org/hk_cont-round1"]}, (
+        "only a miner whose starting repo differs from the foundation should get a "
+        "reconstruction chain"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 2. _prepare_model serves the reconstructed base, not the bare foundation     #
+# --------------------------------------------------------------------------- #
+
+
+def test_prepare_model_continuation_serves_reconstructed_base(monkeypatch):
+    foundation = "org/foundation"
+    materialized = "/tmp/base_chain_merged_0"
+    calls = {}
+
+    monkeypatch.setattr(pvp_main, "check_for_lora", lambda repo, local_files_only=False: True)
+    monkeypatch.setattr(pvp_main, "tool_call_parser_for", lambda path, **kw: "qwen25")
+
+    def fake_materialize(foundation_repo, base_chain):
+        calls["args"] = (foundation_repo, list(base_chain))
+        return materialized if base_chain else foundation_repo
+
+    monkeypatch.setattr(pvp_main, "materialize_base_model", fake_materialize)
+
+    spec = PvPModelSpec(repo="org/miner-round2", original_model=foundation, base_chain=["org/miner-round1"])
+    prepared = pvp_main._prepare_model(spec, "a")
+
+    # Served on the reconstructed base, not the bare foundation.
+    assert prepared.sglang_model_path == materialized
+    assert prepared.sglang_model_path != foundation
+    assert calls["args"] == (foundation, ["org/miner-round1"])
+    # The miner's own adapter is still applied on top of the reconstructed base.
+    assert "org/miner-round2" in prepared.extra_sglang_args
+    assert "--enable-lora" in prepared.extra_sglang_args
+    assert prepared.tool_call_parser == "qwen25"
+
+
+def test_prepare_model_round1_unchanged(monkeypatch):
+    """A round-1 miner (empty chain) is served exactly as before: foundation + lora."""
+    foundation = "org/foundation"
+
+    monkeypatch.setattr(pvp_main, "check_for_lora", lambda repo, local_files_only=False: True)
+
+    spec = PvPModelSpec(repo="org/miner-round1", original_model=foundation, base_chain=[])
+    prepared = pvp_main._prepare_model(spec, "b")
+
+    assert prepared.sglang_model_path == foundation
+    assert "org/miner-round1" in prepared.extra_sglang_args
+    # No explicit parser override; the server resolves it from the foundation repo id.
+    assert prepared.tool_call_parser is None
+
+
+# --------------------------------------------------------------------------- #
+# 3. Sequential merge reconstructs the trained model (real transformer)        #
+# --------------------------------------------------------------------------- #
+
+
+def _tiny_causal_lm():
+    from transformers import LlamaConfig
+    from transformers import LlamaForCausalLM
+
+    torch.manual_seed(0)
+    cfg = LlamaConfig(
+        vocab_size=64, hidden_size=32, intermediate_size=64,
+        num_hidden_layers=2, num_attention_heads=4, num_key_value_heads=4,
+    )
+    return LlamaForCausalLM(cfg).eval()
+
+
+def _attach_random_lora(model, seed, scale):
+    """Merge a deterministic LoRA adapter into the model's attention projections.
+
+    This is exactly what `peft`'s `merge_and_unload` does — add the low-rank delta
+    dW = (alpha / r) * (B @ A) into each target weight — implemented directly so the
+    adapter is byte-identical regardless of which base it is merged onto, and to
+    avoid an unrelated peft<->torchao version incompatibility in this environment.
+    A LoRA delta B @ A is base-independent, so "the same adapter" merged onto the
+    foundation vs onto M1 isolates exactly the dropped round-1 delta.
+    """
+    r, alpha = 8, 16
+    g = torch.Generator().manual_seed(seed)
+    with torch.no_grad():
+        for layer in model.model.layers:
+            for proj in (layer.self_attn.q_proj, layer.self_attn.v_proj):
+                out_dim, in_dim = proj.weight.shape
+                a = torch.randn(r, in_dim, generator=g) * scale
+                b = torch.randn(out_dim, r, generator=g) * scale
+                proj.weight.add_((alpha / r) * (b @ a))
+    return model.eval()
+
+
+def _logits(model, input_ids):
+    with torch.no_grad():
+        return model(input_ids).logits[0, -1]
+
+
+@pytest.mark.filterwarnings("ignore")
+def test_sequential_merge_reconstructs_trained_base():
+    base = _tiny_causal_lm()
+    input_ids = torch.tensor([[1, 2, 3, 4, 5]])
+
+    # Round 1: adapter R1 on the foundation -> M1.
+    import copy
+
+    m1 = _attach_random_lora(copy.deepcopy(base), seed=11, scale=0.5)
+
+    # Round 2: adapter R2 trained ON TOP of M1 -> the model the miner produced.
+    trained = _attach_random_lora(copy.deepcopy(m1), seed=22, scale=0.1)
+
+    # The same R2 adapter on the bare foundation (same seed/scale => identical delta).
+    foundation_only = _attach_random_lora(copy.deepcopy(base), seed=22, scale=0.1)
+
+    trained_logits = _logits(trained, input_ids)
+    foundation_logits = _logits(foundation_only, input_ids)
+
+    # The base choice changes the output distribution and the argmax token.
+    assert not torch.allclose(trained_logits, foundation_logits, atol=1e-3)
+    assert int(trained_logits.argmax()) != int(foundation_logits.argmax())
+
+    # Reconstructing the base (foundation -> merge R1 -> M1) reproduces M1 exactly.
+    m1_reconstructed = _attach_random_lora(copy.deepcopy(base), seed=11, scale=0.5)
+    assert torch.allclose(_logits(m1, input_ids), _logits(m1_reconstructed, input_ids), atol=1e-5)

--- a/tests/test_pvp_continuation_eval.py
+++ b/tests/test_pvp_continuation_eval.py
@@ -29,27 +29,32 @@ def _run(coro):
 
 
 def test_get_continuation_base_chains_only_for_real_continuations(monkeypatch):
-    foundation = "org/foundation"
+    raw_foundation = "org/foundation"          # task.model_id
+    augmented_foundation = "org/foundation-aug"  # base_model (post-prep)
     starting = {
-        "hk_cont": "org/hk_cont-round1",   # genuine continuation -> chain
-        "hk_round1": None,                 # no starting repo -> no chain
-        "hk_foundation": foundation,       # starting repo IS foundation -> no chain
+        "hk_cont": "org/hk_cont-round1",       # genuine LoRA continuation -> chain
+        "hk_round1": None,                     # no starting repo -> no chain
+        "hk_augmented": augmented_foundation,  # starting repo == augmented base -> no chain
+        "hk_fallback": raw_foundation,         # missing-prev fallback to raw model_id -> no chain
+        "hk_fullmodel": "org/hk-full-ft",      # starting repo is a full model (not LoRA) -> no chain
     }
+    non_lora = {"org/hk-full-ft"}
 
     async def fake_get_starting_model_repo(task_id, hotkey, psql_db):
         return starting[hotkey]
 
     monkeypatch.setattr(scoring, "get_starting_model_repo", fake_get_starting_model_repo)
+    monkeypatch.setattr(scoring, "check_for_lora", lambda repo, local_files_only=False: repo not in non_lora)
 
-    task = SimpleNamespace(task_id="task-1")
+    task = SimpleNamespace(task_id="task-1", model_id=raw_foundation)
     miners = MinerRepos(by_hotkey={hk: f"org/{hk}-out" for hk in starting})
     config = SimpleNamespace(psql_db=None)
 
-    chains = _run(scoring._get_continuation_base_chains(task, miners, foundation, config))
+    chains = _run(scoring._get_continuation_base_chains(task, miners, augmented_foundation, config))
 
     assert chains == {"hk_cont": ["org/hk_cont-round1"]}, (
-        "only a miner whose starting repo differs from the foundation should get a "
-        "reconstruction chain"
+        "only a miner whose starting repo is a real LoRA adapter distinct from both the "
+        "raw and augmented foundation should get a reconstruction chain"
     )
 
 
@@ -60,25 +65,25 @@ def test_get_continuation_base_chains_only_for_real_continuations(monkeypatch):
 
 def test_prepare_model_continuation_serves_reconstructed_base(monkeypatch):
     foundation = "org/foundation"
-    materialized = "/tmp/base_chain_merged_0"
+    materialized = "/tmp/base_chain_a_merged_0"
     calls = {}
 
     monkeypatch.setattr(pvp_main, "check_for_lora", lambda repo, local_files_only=False: True)
     monkeypatch.setattr(pvp_main, "tool_call_parser_for", lambda path, **kw: "qwen25")
 
-    def fake_materialize(foundation_repo, base_chain):
-        calls["args"] = (foundation_repo, list(base_chain))
-        return materialized if base_chain else foundation_repo
+    def fake_materialize(foundation_repo, base_chain, label="", device=None):
+        calls["args"] = (foundation_repo, list(base_chain), label)
+        return f"/tmp/base_chain_{label}_merged_0" if base_chain else foundation_repo
 
     monkeypatch.setattr(pvp_main, "materialize_base_model", fake_materialize)
 
     spec = PvPModelSpec(repo="org/miner-round2", original_model=foundation, base_chain=["org/miner-round1"])
-    prepared = pvp_main._prepare_model(spec, "a")
+    prepared = pvp_main._prepare_model(spec, "a", gpu_id=0)
 
     # Served on the reconstructed base, not the bare foundation.
     assert prepared.sglang_model_path == materialized
     assert prepared.sglang_model_path != foundation
-    assert calls["args"] == (foundation, ["org/miner-round1"])
+    assert calls["args"] == (foundation, ["org/miner-round1"], "a")
     # The miner's own adapter is still applied on top of the reconstructed base.
     assert "org/miner-round2" in prepared.extra_sglang_args
     assert "--enable-lora" in prepared.extra_sglang_args
@@ -98,6 +103,22 @@ def test_prepare_model_round1_unchanged(monkeypatch):
     assert "org/miner-round1" in prepared.extra_sglang_args
     # No explicit parser override; the server resolves it from the foundation repo id.
     assert prepared.tool_call_parser is None
+
+
+def test_materialize_uses_distinct_dirs_per_label(monkeypatch):
+    """Two models are prepared before either server starts, so their merge scratch
+    dirs must differ — otherwise the second clobbers the first's reconstructed base."""
+    import validator.evaluation.pvp.materialize as mat
+
+    monkeypatch.setattr(mat, "_download_lora_with_retry", lambda repo, d, **kw: d)
+    monkeypatch.setattr(mat, "_download_model_with_retry", lambda repo, **kw: f"/base/{repo}")
+    monkeypatch.setattr(mat, "_merge_base_and_lora", lambda base, lora, output_dir, device=None: output_dir)
+
+    path_a = mat.materialize_base_model("org/foundation", ["org/minerA-round1"], label="a")
+    path_b = mat.materialize_base_model("org/foundation", ["org/minerB-round1"], label="b")
+
+    assert path_a != path_b, "two models must materialize to distinct dirs (no /tmp clobber)"
+    assert (path_a, path_b) == ("/tmp/base_chain_a_merged_0", "/tmp/base_chain_b_merged_0")
 
 
 # --------------------------------------------------------------------------- #

--- a/validator/evaluation/docker_evaluation.py
+++ b/validator/evaluation/docker_evaluation.py
@@ -700,10 +700,15 @@ async def run_evaluation_pvp_pair(
     temperature: float = 0.0,
     task_id: UUID | None = None,
     psql_db: PSQLDB | None = None,
+    base_chain_a: list[str] | None = None,
+    base_chain_b: list[str] | None = None,
 ) -> PvPGroupResults:
     """Run PvP 1v1 pair evaluation via Basilica.
 
     Returns PvPGroupResults (single pair) for consistent downstream processing.
+
+    base_chain_a/base_chain_b are each miner's continuation lineage (adapter repos to
+    merge onto base_model before the miner's own adapter); empty for round-1 models.
     """
     matchups = {
         env: PvPMatchupConfig(num_games=vcst.PVP_NUM_GAMES_PER_ENV)
@@ -711,8 +716,8 @@ async def run_evaluation_pvp_pair(
     }
     pvp_config = PvPEvalConfig(
         mode=PvPMode.PAIR,
-        model_a=PvPModelSpec(repo=model_a_repo, original_model=base_model),
-        model_b=PvPModelSpec(repo=model_b_repo, original_model=base_model),
+        model_a=PvPModelSpec(repo=model_a_repo, original_model=base_model, base_chain=base_chain_a or []),
+        model_b=PvPModelSpec(repo=model_b_repo, original_model=base_model, base_chain=base_chain_b or []),
         matchups=matchups,
         seed=seed,
         temperature=temperature,

--- a/validator/evaluation/eval_environment.py
+++ b/validator/evaluation/eval_environment.py
@@ -78,7 +78,9 @@ def _download_lora_with_retry(repo_id: str, local_dir: str, max_retries: int = 3
                 raise
 
 
-def _merge_base_and_lora(base_model_path: str, lora_dir: str, output_dir: str = "/tmp/merged_model") -> str:
+def _merge_base_and_lora(
+    base_model_path: str, lora_dir: str, output_dir: str = "/tmp/merged_model", device: str | None = None
+) -> str:
     needs_install = (
         importlib.util.find_spec("peft") is None
         or importlib.util.find_spec("accelerate") is None
@@ -113,7 +115,7 @@ def _merge_base_and_lora(base_model_path: str, lora_dir: str, output_dir: str = 
         base_model_path,
         torch_dtype=torch.float16,
         low_cpu_mem_usage=True,
-        device_map="cuda:0" if torch.cuda.is_available() else "auto",
+        device_map=(device or "cuda:0") if torch.cuda.is_available() else "auto",
         trust_remote_code=True,
     )
     logger.info("eval_setup merge: base weights in memory in %.1fs", time.time() - t0)
@@ -152,6 +154,12 @@ def _merge_base_and_lora(base_model_path: str, lora_dir: str, output_dir: str = 
         time.time() - t3,
         time.time() - merge_t0,
     )
+
+    # Free the merged model before the caller launches SGLang on the same GPU.
+    del base, model, merged
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
     return output_dir
 
 

--- a/validator/evaluation/pvp/__main__.py
+++ b/validator/evaluation/pvp/__main__.py
@@ -74,7 +74,7 @@ def _resolve_spec(spec: PvPModelSpec, default_gpu: int, default_port: int) -> tu
     return gpu, port
 
 
-def _prepare_model(spec: PvPModelSpec, label: str) -> PreparedModel:
+def _prepare_model(spec: PvPModelSpec, label: str, gpu_id: int | None = None) -> PreparedModel:
     """Detect LoRA and build SGLang flags.
 
     Passes HF repo IDs to SGLang which handles downloads internally.
@@ -85,7 +85,10 @@ def _prepare_model(spec: PvPModelSpec, label: str) -> PreparedModel:
     if is_lora:
         # Serve the adapter on the base it trained on: foundation for round 1, or
         # foundation + previous adapter(s) for a continuation miner (base_chain).
-        base_path = materialize_base_model(spec.original_model, spec.base_chain)
+        # `label` keeps each model's merge scratch dir distinct; merge on this
+        # model's own GPU so the two preparations don't pile onto one device.
+        device = f"cuda:{gpu_id}" if gpu_id is not None else None
+        base_path = materialize_base_model(spec.original_model, spec.base_chain, label=label, device=device)
         lora_name = f"{label}_trained_lora"
         return PreparedModel(
             sglang_model_path=base_path,
@@ -138,8 +141,8 @@ def _run_evaluation(config: PvPEvalConfig) -> PvPEvalResults:
     gpu_a, port_a = _resolve_spec(model_a, default_gpu=0, default_port=vcst.PVP_SGLANG_PORT_A)
     gpu_b, port_b = _resolve_spec(model_b, default_gpu=1, default_port=vcst.PVP_SGLANG_PORT_B)
 
-    prepared_a = _prepare_model(model_a, "a")
-    prepared_b = _prepare_model(model_b, "b")
+    prepared_a = _prepare_model(model_a, "a", gpu_id=gpu_a)
+    prepared_b = _prepare_model(model_b, "b", gpu_id=gpu_b)
 
     sglang_a: subprocess.Popen | None = None
     sglang_b: subprocess.Popen | None = None

--- a/validator/evaluation/pvp/__main__.py
+++ b/validator/evaluation/pvp/__main__.py
@@ -28,6 +28,7 @@ from validator.evaluation.pvp.game_runner import Player
 from validator.evaluation.pvp.game_runner import create_player
 from validator.evaluation.pvp.game_runner import run_matchup
 from validator.evaluation.pvp.game_runner import warmup_player
+from validator.evaluation.pvp.materialize import materialize_base_model
 from validator.evaluation.pvp.server import start_sglang
 from validator.evaluation.pvp.server import wait_for_servers
 from validator.evaluation.utils import check_for_lora
@@ -79,14 +80,20 @@ def _prepare_model(spec: PvPModelSpec, label: str) -> PreparedModel:
     Passes HF repo IDs to SGLang which handles downloads internally.
     """
     is_lora = check_for_lora(spec.repo, local_files_only=False)
-    logger.info("Model %s: repo=%s is_lora=%s", label, spec.repo, is_lora)
+    logger.info("Model %s: repo=%s is_lora=%s base_chain=%s", label, spec.repo, is_lora, spec.base_chain)
 
     if is_lora:
+        # Serve the adapter on the base it trained on: foundation for round 1, or
+        # foundation + previous adapter(s) for a continuation miner (base_chain).
+        base_path = materialize_base_model(spec.original_model, spec.base_chain)
         lora_name = f"{label}_trained_lora"
         return PreparedModel(
-            sglang_model_path=spec.original_model,
-            inference_name=f"{spec.original_model}:{lora_name}",
+            sglang_model_path=base_path,
+            inference_name=f"{base_path}:{lora_name}",
             extra_sglang_args=f"--enable-lora --lora-paths {lora_name}={spec.repo} --lora-backend triton",
+            # A materialized base is a local dir with no family substring, so resolve
+            # its parser from config.json; for a plain repo the server resolves it.
+            tool_call_parser=tool_call_parser_for(base_path) if spec.base_chain else None,
         )
 
     # A full-weight miner repo id is often opaque (no family substring), and the

--- a/validator/evaluation/pvp/materialize.py
+++ b/validator/evaluation/pvp/materialize.py
@@ -2,9 +2,12 @@
 
 A continuation miner trains on the foundation with their previous-round adapter
 merged in, so their uploaded adapter is relative to that merged base. This rebuilds
-it — foundation + the previous adapter(s), merged in order — reusing the env-eval
-merge primitives so both eval paths share one merge implementation.
+it — the previous adapter(s) merged onto the base each one declares — reusing the
+env-eval merge primitives so both eval paths share one merge implementation.
 """
+
+import json
+import os
 
 from validator.evaluation.eval_environment import _download_lora_with_retry
 from validator.evaluation.eval_environment import _download_model_with_retry
@@ -15,19 +18,39 @@ from validator.utils.logging import get_logger
 logger = get_logger(__name__)
 
 
-def materialize_base_model(foundation_repo: str, base_chain: list[str]) -> str:
-    """Return a local path to foundation_repo with base_chain adapters merged in.
+def _declared_base(lora_dir: str, fallback: str) -> str:
+    """The base an adapter was trained on, per its adapter_config (else fallback)."""
+    config_path = os.path.join(lora_dir, "adapter_config.json")
+    if os.path.exists(config_path):
+        with open(config_path) as f:
+            base = json.load(f).get("base_model_name_or_path")
+        if base:
+            return base
+    return fallback
+
+
+def materialize_base_model(
+    foundation_repo: str, base_chain: list[str], label: str = "", device: str | None = None
+) -> str:
+    """Return a local path to the base a continuation miner trained on.
 
     Empty chain returns the foundation repo id unchanged (SGLang downloads it).
+    Otherwise each adapter is merged onto the base it declares — matching what the
+    trainer merged onto — so eval and train reconstruct an identical base. `label`
+    keeps per-model scratch dirs distinct (two models are prepared before either
+    SGLang server starts, so a shared path would clobber the first model's base).
     """
     if not base_chain:
         return foundation_repo
 
-    base_path = _download_model_with_retry(foundation_repo)
+    base_path: str | None = None
     for idx, adapter_repo in enumerate(base_chain):
-        lora_dir = f"/tmp/base_chain_lora_{idx}"
+        lora_dir = f"/tmp/base_chain_{label}_lora_{idx}"
         _download_lora_with_retry(adapter_repo, lora_dir)
-        output_dir = f"/tmp/base_chain_merged_{idx}"
-        base_path = _merge_base_and_lora(base_path, lora_dir, output_dir=output_dir)
+        if base_path is None:
+            base_path = _download_model_with_retry(_declared_base(lora_dir, foundation_repo))
+        output_dir = f"/tmp/base_chain_{label}_merged_{idx}"
+        base_path = _merge_base_and_lora(base_path, lora_dir, output_dir=output_dir, device=device)
         logger.info("Merged base-chain adapter %s -> %s", adapter_repo, base_path)
+    assert base_path is not None  # base_chain is non-empty, so the loop ran
     return base_path

--- a/validator/evaluation/pvp/materialize.py
+++ b/validator/evaluation/pvp/materialize.py
@@ -1,0 +1,33 @@
+"""Reconstruct a continuation miner's base model for PvP evaluation.
+
+A continuation miner trains on the foundation with their previous-round adapter
+merged in, so their uploaded adapter is relative to that merged base. This rebuilds
+it — foundation + the previous adapter(s), merged in order — reusing the env-eval
+merge primitives so both eval paths share one merge implementation.
+"""
+
+from validator.evaluation.eval_environment import _download_lora_with_retry
+from validator.evaluation.eval_environment import _download_model_with_retry
+from validator.evaluation.eval_environment import _merge_base_and_lora
+from validator.utils.logging import get_logger
+
+
+logger = get_logger(__name__)
+
+
+def materialize_base_model(foundation_repo: str, base_chain: list[str]) -> str:
+    """Return a local path to foundation_repo with base_chain adapters merged in.
+
+    Empty chain returns the foundation repo id unchanged (SGLang downloads it).
+    """
+    if not base_chain:
+        return foundation_repo
+
+    base_path = _download_model_with_retry(foundation_repo)
+    for idx, adapter_repo in enumerate(base_chain):
+        lora_dir = f"/tmp/base_chain_lora_{idx}"
+        _download_lora_with_retry(adapter_repo, lora_dir)
+        output_dir = f"/tmp/base_chain_merged_{idx}"
+        base_path = _merge_base_and_lora(base_path, lora_dir, output_dir=output_dir)
+        logger.info("Merged base-chain adapter %s -> %s", adapter_repo, base_path)
+    return base_path

--- a/validator/evaluation/scoring.py
+++ b/validator/evaluation/scoring.py
@@ -50,6 +50,7 @@ from validator.db.sql.submissions_and_scoring import set_task_node_quality_score
 from validator.db.sql.tasks import get_env_task_eval_seed
 from validator.db.sql.tasks import get_expected_repo_name
 from validator.db.sql.tasks import get_starting_model_repo
+from validator.evaluation.utils import check_for_lora
 from validator.db.sql.tasks import get_nodes_assigned_to_task
 from validator.evaluation.basilica import EvaluationRetryableError
 from validator.evaluation.docker_evaluation import run_evaluation_basilica_image
@@ -785,14 +786,21 @@ async def _get_continuation_base_chains(
 
     A continuation miner trains from `starting_model_repo` merged into the
     foundation, so eval must serve their adapter on that same base. Returns
-    {hotkey: [starting_repo]}; round-1 miners (no starting repo, or starting repo ==
-    foundation) map to no chain and are served on the foundation as before.
+    {hotkey: [starting_repo]} only when the starting repo is a real LoRA adapter
+    distinct from the foundation. A miner whose previous round was missing falls
+    back to the foundation itself (a full model) as starting_model_repo — that, and
+    any full-finetune output, must NOT enter a chain (it can't be LoRA-merged), so
+    we compare against both the augmented and raw foundation ids and require LoRA.
     """
     base_chains: dict[str, list[str]] = {}
     for hotkey in miners.hotkeys:
         starting_repo = await get_starting_model_repo(str(task.task_id), hotkey, config.psql_db)
-        if starting_repo and starting_repo != base_model:
-            base_chains[hotkey] = [starting_repo]
+        if not starting_repo or starting_repo in (base_model, task.model_id):
+            continue
+        if not await asyncio.to_thread(check_for_lora, starting_repo, False):
+            logger.info(f"Miner {hotkey}: starting repo {starting_repo} is not a LoRA adapter; serving on foundation")
+            continue
+        base_chains[hotkey] = [starting_repo]
     if base_chains:
         logger.info(f"Continuation base chains for {len(base_chains)} miners on task {task.task_id}")
     return base_chains

--- a/validator/evaluation/scoring.py
+++ b/validator/evaluation/scoring.py
@@ -49,6 +49,7 @@ from validator.db.sql.submissions_and_scoring import set_task_node_losses
 from validator.db.sql.submissions_and_scoring import set_task_node_quality_score
 from validator.db.sql.tasks import get_env_task_eval_seed
 from validator.db.sql.tasks import get_expected_repo_name
+from validator.db.sql.tasks import get_starting_model_repo
 from validator.db.sql.tasks import get_nodes_assigned_to_task
 from validator.evaluation.basilica import EvaluationRetryableError
 from validator.evaluation.docker_evaluation import run_evaluation_basilica_image
@@ -709,9 +710,11 @@ async def _run_env_tournament_eval(
     env_scores: list[EnvMinerScores] = []
 
     if pvp_envs:
+        base_chains = await _get_continuation_base_chains(task, miners, base_model, config)
         env_scores.extend(await _eval_pvp_envs(
             task_id=str(task.task_id), pvp_envs=pvp_envs, miners=miners,
             base_model=base_model, seed=seed, config=config,
+            base_chains=base_chains,
         ))
 
     if individual_envs:
@@ -772,6 +775,29 @@ def _get_shared_env_config(envs: list[core_cst.EnvironmentName]) -> core_cst.Env
     return configs[0]
 
 
+async def _get_continuation_base_chains(
+    task: AnyTypeRawTask,
+    miners: MinerRepos,
+    base_model: str,
+    config: Config,
+) -> dict[str, list[str]]:
+    """Per-miner adapter lineage to reconstruct the base each miner trained on.
+
+    A continuation miner trains from `starting_model_repo` merged into the
+    foundation, so eval must serve their adapter on that same base. Returns
+    {hotkey: [starting_repo]}; round-1 miners (no starting repo, or starting repo ==
+    foundation) map to no chain and are served on the foundation as before.
+    """
+    base_chains: dict[str, list[str]] = {}
+    for hotkey in miners.hotkeys:
+        starting_repo = await get_starting_model_repo(str(task.task_id), hotkey, config.psql_db)
+        if starting_repo and starting_repo != base_model:
+            base_chains[hotkey] = [starting_repo]
+    if base_chains:
+        logger.info(f"Continuation base chains for {len(base_chains)} miners on task {task.task_id}")
+    return base_chains
+
+
 async def _eval_pvp_envs(
     task_id: str,
     pvp_envs: list[core_cst.EnvironmentName],
@@ -779,6 +805,7 @@ async def _eval_pvp_envs(
     base_model: str,
     seed: int,
     config: Config,
+    base_chains: dict[str, list[str]] | None = None,
 ) -> list[EnvMinerScores]:
     """Run pairwise PvP eval for PVP-type environments, return per-env win-rates."""
     env_config = _get_shared_env_config(pvp_envs)
@@ -788,6 +815,7 @@ async def _eval_pvp_envs(
         base_model=base_model, seed=seed,
         image=env_config.tournament_eval_image,
         gpu_count=cts.PVP_BASILICA_GPU_COUNT, config=config,
+        base_chains=base_chains,
     )
 
     return pvp_results_to_winrates(group_results)
@@ -802,12 +830,15 @@ async def _get_or_run_pvp_pairs(
     image: str,
     gpu_count: int,
     config: Config,
+    base_chains: dict[str, list[str]] | None = None,
 ) -> PvPGroupResults:
     """Check DB for complete pair results; if missing, run missing 1v1 pairs."""
     env_name_strs = [e.value for e in pvp_envs]
     max_pair_attempts = cts.MAX_TOURNAMENT_EVAL_ATTEMPTS
     task_uuid = UUID(task_id)
     all_hotkeys = miners.hotkeys
+
+    base_chains = base_chains or {}
 
     db_rows = await tournament_sql.get_pvp_pair_results(task_id, config.psql_db)
     rows_by_pair = _group_db_rows_by_pair(db_rows)
@@ -853,6 +884,8 @@ async def _get_or_run_pvp_pairs(
                     gpu_count=gpu_count,
                     task_id=task_uuid,
                     psql_db=config.psql_db,
+                    base_chain_a=base_chains.get(hk_a, []),
+                    base_chain_b=base_chains.get(hk_b, []),
                 )
             except EvaluationRetryableError as exc:
                 # Transient infra failure (e.g. no eval GPU capacity) — not the pair's


### PR DESCRIPTION
Continuation-round (round ≥ 2) miners train a LoRA on the foundation with their previous-round adapter merged in. This serves them on that same reconstructed base at eval time, instead of the bare foundation.

## Changes
- `PvPModelSpec.base_chain` — adapters to merge onto `original_model` before applying `repo`.
- `scoring._get_continuation_base_chains` — per-miner chain from `starting_model_repo`, threaded through `_eval_pvp_envs` → `_get_or_run_pvp_pairs` → `run_evaluation_pvp_pair` (`base_chain_a` / `base_chain_b`).
- `pvp/materialize.py` — download foundation + merge the chain, reusing the env-eval merge primitives.
- `pvp/_prepare_model` — serve the reconstructed base + adapter for continuation specs; resolve the tool-call parser from the merged dir's `config.json`.

Round-1 models (empty chain) are served on the foundation exactly as before, so existing behaviour is unchanged. Boss-round CONTINUATION tasks go through the same per-miner `starting_model_repo` path and are covered automatically.

## Tests
- `tests/test_pvp_continuation_base.py` — GPU-free checks that the base choice shifts the model's argmax token, and that an unparseable tool call forfeits (real `_parse_tool_calls`).
- `tests/test_pvp_continuation_eval.py` — chain derivation, `_prepare_model` base selection, and a real-transformer check that sequential LoRA merge reconstructs the trained base.

Existing PvP/scoring tests pass (`base_chains` is an optional param).