### PR TITLE
PvP continuation: chain-walk the adapter lineage at eval

### DIFF
--- a/tests/test_pvp_continuation_eval.py
+++ b/tests/test_pvp_continuation_eval.py
@@ -110,6 +110,7 @@ def test_materialize_uses_distinct_dirs_per_label(monkeypatch):
     dirs must differ — otherwise the second clobbers the first's reconstructed base."""
     import validator.evaluation.pvp.materialize as mat
 
+    monkeypatch.setattr(mat, "_declared_base", lambda repo: None)  # treat each starting repo as foundation-relative
     monkeypatch.setattr(mat, "_download_lora_with_retry", lambda repo, d, **kw: d)
     monkeypatch.setattr(mat, "_download_model_with_retry", lambda repo, **kw: f"/base/{repo}")
     monkeypatch.setattr(mat, "_merge_base_and_lora", lambda base, lora, output_dir, device=None: output_dir)
@@ -119,6 +120,42 @@ def test_materialize_uses_distinct_dirs_per_label(monkeypatch):
 
     assert path_a != path_b, "two models must materialize to distinct dirs (no /tmp clobber)"
     assert (path_a, path_b) == ("/tmp/base_chain_a_merged_0", "/tmp/base_chain_b_merged_0")
+
+
+def test_resolve_chain_walks_unflattened_lineage(monkeypatch):
+    """When an adapter's base pointer wasn't flattened, eval must still walk down to
+    the real foundation and merge every adapter — matching the trainer, not crash
+    trying to load an intermediate adapter as a full model."""
+    import validator.evaluation.pvp.materialize as mat
+
+    # R3 -> R2 -> R1 -> foundation (none flattened).
+    declared = {
+        "org/R3": "org/R2",
+        "org/R2": "org/R1",
+        "org/R1": "org/foundation",
+        "org/foundation": None,
+    }
+    monkeypatch.setattr(mat, "_declared_base", lambda repo: declared[repo])
+
+    foundation, adapters = mat._resolve_chain("org/R3", "org/wrong-fallback")
+
+    assert foundation == "org/foundation"
+    # bottom-to-top merge order, exactly what the trainer merges.
+    assert adapters == ["org/R1", "org/R2", "org/R3"]
+
+
+def test_resolve_chain_flattened_is_single_hop(monkeypatch):
+    """The normal (flattened) case: the starting adapter points straight at the
+    foundation, so only it is merged."""
+    import validator.evaluation.pvp.materialize as mat
+
+    declared = {"org/R2": "org/foundation", "org/foundation": None}
+    monkeypatch.setattr(mat, "_declared_base", lambda repo: declared[repo])
+
+    foundation, adapters = mat._resolve_chain("org/R2", "org/foundation")
+
+    assert foundation == "org/foundation"
+    assert adapters == ["org/R2"]
 
 
 # --------------------------------------------------------------------------- #

--- a/validator/evaluation/pvp/materialize.py
+++ b/validator/evaluation/pvp/materialize.py
@@ -2,12 +2,18 @@
 
 A continuation miner trains on the foundation with their previous-round adapter
 merged in, so their uploaded adapter is relative to that merged base. This rebuilds
-it — the previous adapter(s) merged onto the base each one declares — reusing the
-env-eval merge primitives so both eval paths share one merge implementation.
+that base by mirroring the trainer's merge-on-download: from the top adapter, walk
+`adapter_config.base_model_name_or_path` down to the foundation, then merge every
+adapter bottom-to-top. Walking (rather than assuming a single flattened hop) keeps
+eval identical to the trainer even when an adapter's base pointer was not flattened
+to the foundation at upload — the same parity, including the 10-hop cap, that
+trainer_downloader._detect_and_merge_lora gives the training side.
 """
 
 import json
 import os
+
+from huggingface_hub import hf_hub_download
 
 from validator.evaluation.eval_environment import _download_lora_with_retry
 from validator.evaluation.eval_environment import _download_model_with_retry
@@ -17,16 +23,41 @@ from validator.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
+# Matches trainer_downloader._detect_and_merge_lora's guard, so both sides truncate
+# an over-deep lineage at the same depth and still agree.
+MAX_CHAIN_DEPTH = 10
 
-def _declared_base(lora_dir: str, fallback: str) -> str:
-    """The base an adapter was trained on, per its adapter_config (else fallback)."""
-    config_path = os.path.join(lora_dir, "adapter_config.json")
-    if os.path.exists(config_path):
-        with open(config_path) as f:
-            base = json.load(f).get("base_model_name_or_path")
-        if base:
-            return base
-    return fallback
+
+def _declared_base(repo: str) -> str | None:
+    """The base a repo's adapter_config declares, or None if it isn't an adapter."""
+    try:
+        config_path = hf_hub_download(repo, "adapter_config.json", token=os.getenv("HUGGINGFACE_TOKEN"))
+    except Exception:
+        return None  # no adapter_config -> repo is a foundation model
+    with open(config_path) as f:
+        return json.load(f).get("base_model_name_or_path") or None
+
+
+def _resolve_chain(top_adapter: str, fallback_foundation: str) -> tuple[str, list[str]]:
+    """Walk from top_adapter to the foundation, returning (foundation, adapters).
+
+    `adapters` is ordered bottom-to-top (merge order); `foundation` is the first
+    non-adapter repo reached. Mirrors the trainer's walk exactly.
+    """
+    base = _declared_base(top_adapter)
+    if base is None:
+        return fallback_foundation, [top_adapter]
+
+    intermediate: list[str] = []  # adapters between top_adapter's base and the foundation
+    foundation = base
+    for _ in range(MAX_CHAIN_DEPTH):
+        parent = _declared_base(foundation)
+        if parent is None:
+            break  # foundation is a real model
+        intermediate.append(foundation)
+        foundation = parent
+
+    return foundation, list(reversed(intermediate)) + [top_adapter]
 
 
 def materialize_base_model(
@@ -35,22 +66,22 @@ def materialize_base_model(
     """Return a local path to the base a continuation miner trained on.
 
     Empty chain returns the foundation repo id unchanged (SGLang downloads it).
-    Otherwise each adapter is merged onto the base it declares — matching what the
-    trainer merged onto — so eval and train reconstruct an identical base. `label`
-    keeps per-model scratch dirs distinct (two models are prepared before either
-    SGLang server starts, so a shared path would clobber the first model's base).
+    Otherwise the lineage is resolved from the chain's top adapter and merged
+    bottom-to-top. `label` keeps per-model scratch dirs distinct (two models are
+    prepared before either SGLang server starts, so a shared path would clobber the
+    first model's base).
     """
     if not base_chain:
         return foundation_repo
 
-    base_path: str | None = None
-    for idx, adapter_repo in enumerate(base_chain):
+    foundation, adapters = _resolve_chain(base_chain[0], foundation_repo)
+    logger.info("Reconstructing base for %s: foundation=%s adapters=%s", base_chain[0], foundation, adapters)
+
+    base_path = _download_model_with_retry(foundation)
+    for idx, adapter_repo in enumerate(adapters):
         lora_dir = f"/tmp/base_chain_{label}_lora_{idx}"
         _download_lora_with_retry(adapter_repo, lora_dir)
-        if base_path is None:
-            base_path = _download_model_with_retry(_declared_base(lora_dir, foundation_repo))
         output_dir = f"/tmp/base_chain_{label}_merged_{idx}"
         base_path = _merge_base_and_lora(base_path, lora_dir, output_dir=output_dir, device=device)
         logger.info("Merged base-chain adapter %s -> %s", adapter_repo, base_path)
-    assert base_path is not None  # base_chain is non-empty, so the loop ran
     return base_path


### PR DESCRIPTION
Follow-up to #1234. The continuation-base reconstruction did a single merge of the previous-round adapter onto the foundation, which only matches the trainer while every uploaded adapter's `base_model_name_or_path` is flattened to the foundation. That flattening (`hf_upload.patch_model_metadata` → `_resolve_base_model`) is best-effort — it swallows errors and caps at 10 hops — so a transient upload error or a very deep lineage can leave an adapter pointing at the previous adapter. Eval would then load an adapter as a full model (crash) or reconstruct a shallower base than training, silently, while the trainer's chain-walking merge keeps working.

This mirrors `trainer_downloader._detect_and_merge_lora`: from the top adapter, walk `base_model_name_or_path` down to the first non-adapter repo (same 10-hop cap), then merge every adapter bottom-to-top. In the normal flattened case the walk terminates immediately and behaviour is unchanged; otherwise eval reconstructs the exact base the trainer used.

## Tests
- `test_resolve_chain_walks_unflattened_lineage` — r1→r2→r3 with no flattening resolves to the real foundation and merges all three bottom-to-top.
- `test_resolve_chain_flattened_is_single_hop` — the normal case is a single merge.
- Existing per-label scratch-dir and `_prepare_model` tests updated for the walk.

Found by adversarial review of #1234 (the "worst realistic divergence"). Note: the reviewer's other suggestion — add `@retry_on_5xx()` to `check_for_lora` — is already present (`utils.py:496`).