### PR TITLE
pvp: resolve tool-call parser from chat template

### DIFF
--- a/core/pvp/sglang_parsers.py
+++ b/core/pvp/sglang_parsers.py
@@ -1,9 +1,18 @@
-"""Map a served model to its SGLang --tool-call-parser (by family).
+"""Map a served model to its SGLang --tool-call-parser.
 
 No parser (or 'auto', which forfeits for Qwen2.5) -> SGLang returns tool calls as
 plain text and every PvP turn forfeits. Override with SGLANG_TOOL_CALL_PARSER.
+
+Resolution prefers the model's chat template (the actual contract for how tool
+calls are rendered) over name/architecture proxies, because both the repo name
+and config.json model_type lie once a model is anonymized/augmented: an opaque
+'augmented-<hash>' id carries no family substring, and a Hermes finetune reports
+model_type 'llama'/'mistral' while speaking hermes tool-call format. The chat
+template survives anonymization (the scrubber only strips _name_or_path) and
+names the format directly.
 """
 
+import functools
 import json
 import logging
 import os
@@ -30,6 +39,25 @@ _FAMILY_PARSERS: list[tuple[str, str]] = [
     ("mistral", "mistral"),
 ]
 
+# Ordered (chat-template marker -> SGLang parser); first match wins. These are
+# the distinctive tokens each format emits for tool calls, so the match is the
+# format itself rather than a proxy for it. Qwen2.5/3 adopted the Hermes
+# <tool_call> JSON wrapper, and SGLang's hermes parser handles that wrapper, so
+# both map to 'hermes' here. qwen3-coder uses a distinct <function= ...> body
+# inside <tool_call> and must be checked first.
+_TEMPLATE_MARKERS: list[tuple[str, str]] = [
+    ("[TOOL_CALLS]", "mistral"),
+    ("<|python_tag|>", "llama3"),
+    ("<function=", "qwen3_coder"),
+    ("<tool_call>", "hermes"),
+]
+
+# Files that may carry the chat template, in priority order. Newer HF layouts
+# split the template into a standalone chat_template.jinja; older ones inline it
+# under tokenizer_config.json's "chat_template" key.
+_CHAT_TEMPLATE_FILE = "chat_template.jinja"
+_TOKENIZER_CONFIG_FILE = "tokenizer_config.json"
+
 
 def _parser_for_family(needle: str) -> str | None:
     for substring, parser in _FAMILY_PARSERS:
@@ -41,14 +69,9 @@ def _parser_for_family(needle: str) -> str | None:
 def _parser_from_local_config(model_dir: str) -> str | None:
     """Resolve the parser from config.json's model_type for a local weights dir.
 
-    Opaque model ids (anonymized cache dirs, miner repos, augmented-<hash>) carry
-    no family substring, but model_type survives anonymization (the scrubber only
-    strips _name_or_path) and names the architecture family directly.
-
-    Caveat: model_type is the architecture, not the finetune's tool-call format —
-    a Hermes finetune reports model_type llama/mistral but speaks hermes format.
-    Id-substring/override resolution must catch those first; this is a last
-    resort where the alternative is forfeiting every turn.
+    Last resort: model_type is the architecture, not the finetune's tool-call
+    format, so a Hermes finetune reports llama/mistral here. The chat-template
+    and id-substring resolvers must run first.
     """
     config_path = os.path.join(model_dir, "config.json")
     if not os.path.isfile(config_path):
@@ -65,21 +88,119 @@ def _parser_from_local_config(model_dir: str) -> str | None:
     return parser
 
 
+def _parser_for_template(template: str) -> str | None:
+    for marker, parser in _TEMPLATE_MARKERS:
+        if marker in template:
+            return parser
+    return None
+
+
+def _chat_template_from_config(raw: str) -> str | None:
+    """Pull the chat template out of a tokenizer_config.json blob.
+
+    The "chat_template" value is usually a Jinja string, but some repos ship a
+    list of {name, template} dicts (e.g. a separate 'tool_use' template); join
+    them so a tool template anywhere in the list is still matched.
+    """
+    try:
+        chat_template = json.loads(raw).get("chat_template")
+    except Exception as exc:
+        logger.warning("Could not parse tokenizer config for chat_template: %s", exc)
+        return None
+    if isinstance(chat_template, str):
+        return chat_template
+    if isinstance(chat_template, list):
+        return "\n".join(t["template"] for t in chat_template if isinstance(t, dict) and "template" in t)
+    return None
+
+
+def _read_local_chat_template(model_dir: str) -> str | None:
+    jinja_path = os.path.join(model_dir, _CHAT_TEMPLATE_FILE)
+    if os.path.isfile(jinja_path):
+        try:
+            with open(jinja_path) as f:
+                return f.read()
+        except Exception as exc:
+            logger.warning("Could not read %s: %s", jinja_path, exc)
+    config_path = os.path.join(model_dir, _TOKENIZER_CONFIG_FILE)
+    if os.path.isfile(config_path):
+        try:
+            with open(config_path) as f:
+                return _chat_template_from_config(f.read())
+        except Exception as exc:
+            logger.warning("Could not read %s: %s", config_path, exc)
+    return None
+
+
+def _read_hub_chat_template(repo_id: str) -> str | None:
+    """Download just the chat template for a remote HF repo (tiny file).
+
+    Returns None on any failure (missing file, private repo, network) — the
+    caller falls through to cheaper resolvers, and an unmapped model still logs
+    loudly. Imported lazily so non-eval call sites don't pay the import.
+    """
+    from huggingface_hub import hf_hub_download
+    from huggingface_hub.errors import EntryNotFoundError
+
+    token = os.getenv("HF_TOKEN")
+    try:
+        path = hf_hub_download(repo_id, _CHAT_TEMPLATE_FILE, token=token)
+        with open(path) as f:
+            return f.read()
+    except EntryNotFoundError:
+        pass
+    except Exception as exc:
+        logger.warning("Could not fetch %s from %s: %s", _CHAT_TEMPLATE_FILE, repo_id, exc)
+        return None
+    try:
+        path = hf_hub_download(repo_id, _TOKENIZER_CONFIG_FILE, token=token)
+        with open(path) as f:
+            return _chat_template_from_config(f.read())
+    except Exception as exc:
+        logger.warning("Could not fetch %s from %s: %s", _TOKENIZER_CONFIG_FILE, repo_id, exc)
+        return None
+
+
+@functools.lru_cache(maxsize=128)
+def _parser_from_chat_template(model_id: str) -> str | None:
+    """Resolve the parser from model_id's chat template (local dir or HF repo).
+
+    Cached because the same served model is resolved more than once per eval and
+    the remote case hits the network.
+    """
+    if os.path.isdir(model_id):
+        template = _read_local_chat_template(model_id)
+    else:
+        template = _read_hub_chat_template(model_id)
+    if not template:
+        return None
+    parser = _parser_for_template(template)
+    if parser:
+        logger.info("Resolved tool-call parser %r from chat template of %r", parser, model_id)
+    return parser
+
+
 def tool_call_parser_for(model_id: str, *, log_unmapped: bool = True) -> str | None:
     """Return the SGLang tool-call-parser for model_id, or None if unmapped.
 
     Resolution order: SGLANG_TOOL_CALL_PARSER override, family substring in
-    model_id, then config.json model_type when model_id is a local weights dir.
+    model_id (cheap, correct for clearly-named repos), the model's chat template
+    (the real tool-call-format contract, and the only signal that survives
+    anonymization/augmentation), then config.json model_type for a local dir.
     An unmapped model logs a loud error (its tool calls won't be parsed and it
     will forfeit every turn) rather than silently picking a wrong parser; pass
-    log_unmapped=False where None is expected and another resolver (the
-    container's config.json fallback) gets the final word.
+    log_unmapped=False where None is expected and another resolver gets the
+    final word.
     """
     override = os.getenv(TOOL_CALL_PARSER_ENV)
     if override:
         return override.strip()
 
     parser = _parser_for_family(model_id.lower())
+    if parser:
+        return parser
+
+    parser = _parser_from_chat_template(model_id)
     if parser:
         return parser
 

--- a/tests/test_sglang_parsers.py
+++ b/tests/test_sglang_parsers.py
@@ -1,7 +1,18 @@
 import json
 
+import pytest
+
 from core.pvp.sglang_parsers import TOOL_CALL_PARSER_ENV
+from core.pvp.sglang_parsers import _parser_for_template
+from core.pvp.sglang_parsers import _parser_from_chat_template
 from core.pvp.sglang_parsers import tool_call_parser_for
+
+
+@pytest.fixture(autouse=True)
+def _clear_template_cache():
+    _parser_from_chat_template.cache_clear()
+    yield
+    _parser_from_chat_template.cache_clear()
 
 
 def test_family_substring_in_model_id():
@@ -33,4 +44,71 @@ def test_local_dir_with_unknown_model_type_is_unmapped(tmp_path):
 
 def test_local_dir_with_malformed_config_is_unmapped(tmp_path):
     (tmp_path / "config.json").write_text("not json")
+    assert tool_call_parser_for(str(tmp_path)) is None
+
+
+# --- chat-template resolution ---------------------------------------------
+
+
+def test_parser_for_template_markers():
+    assert _parser_for_template("...[TOOL_CALLS]...") == "mistral"
+    assert _parser_for_template("...<|python_tag|>...") == "llama3"
+    assert _parser_for_template("...<tool_call>{json}</tool_call>...") == "hermes"
+    # qwen3-coder's <function= body wins over the shared <tool_call> wrapper.
+    assert _parser_for_template("...<tool_call>\n<function=foo>...") == "qwen3_coder"
+    assert _parser_for_template("no tool markers here") is None
+
+
+def test_chat_template_in_tokenizer_config(tmp_path):
+    (tmp_path / "tokenizer_config.json").write_text(
+        json.dumps({"chat_template": "render <tool_call>{...}</tool_call> please"})
+    )
+    assert tool_call_parser_for(str(tmp_path)) == "hermes"
+
+
+def test_standalone_chat_template_jinja_preferred(tmp_path):
+    (tmp_path / "tokenizer_config.json").write_text(json.dumps({"chat_template": "[TOOL_CALLS]"}))
+    (tmp_path / "chat_template.jinja").write_text("emits <|python_tag|>")
+    # The standalone .jinja is the source of truth when both are present.
+    assert tool_call_parser_for(str(tmp_path)) == "llama3"
+
+
+def test_chat_template_as_named_list(tmp_path):
+    (tmp_path / "tokenizer_config.json").write_text(
+        json.dumps(
+            {
+                "chat_template": [
+                    {"name": "default", "template": "plain chat, no tools"},
+                    {"name": "tool_use", "template": "uses <tool_call> wrapper"},
+                ]
+            }
+        )
+    )
+    assert tool_call_parser_for(str(tmp_path)) == "hermes"
+
+
+def test_chat_template_beats_misleading_model_type(tmp_path):
+    """The hermes-on-llama regression: model_type reports the architecture
+    (llama), but the chat template speaks hermes tool-call format. Template
+    must win, otherwise the model forfeits every turn behind a llama3 parser."""
+    (tmp_path / "config.json").write_text(json.dumps({"model_type": "llama"}))
+    (tmp_path / "tokenizer_config.json").write_text(
+        json.dumps({"chat_template": "hermes finetune uses <tool_call>...</tool_call>"})
+    )
+    assert tool_call_parser_for(str(tmp_path)) == "hermes"
+
+
+def test_named_repo_skips_template_io(monkeypatch):
+    """A clearly-named repo resolves by substring without touching the chat
+    template (keeps the cheap path cheap and avoids network for the common case)."""
+    import core.pvp.sglang_parsers as mod
+
+    def _boom(_model_id):
+        raise AssertionError("chat-template resolver should not run for a named repo")
+
+    monkeypatch.setattr(mod, "_parser_from_chat_template", _boom)
+    assert tool_call_parser_for("NousResearch/Hermes-3-Llama-3.1-8B") == "hermes"
+
+
+def test_local_dir_without_template_or_config_is_unmapped(tmp_path):
     assert tool_call_parser_for(str(tmp_path)) is None


### PR DESCRIPTION
## Problem
The SGLang \`--tool-call-parser\` was resolved from the model repo name, with \`config.json\` \`model_type\` as fallback. Both lie once a model is anonymized/augmented:

- An opaque \`augmented-<hash>\` id (and an opaque miner push) carries no family substring.
- A Hermes finetune reports \`model_type: llama\`/\`mistral\` — the *architecture*, not the tool-call format — so it resolves \`llama3\` and forfeits every tool turn.

## Fix
Resolve the parser from the model's **chat template** — the actual contract for how tool calls are rendered, and the one signal that survives anonymization (the scrubber only strips \`_name_or_path\`). New order:

\`\`\`
SGLANG_TOOL_CALL_PARSER override
  → family substring in model_id   (cheap; clearly-named repos)
  → chat-template signature         (new; local dir or remote HF repo)
  → config.json model_type          (last resort)
\`\`\`

Reads \`chat_template.jinja\` (preferred) or \`tokenizer_config.json\` (incl. the named-list \`tool_use\` form). Markers: \`[TOOL_CALLS]\`→mistral, \`<|python_tag|>\`→llama3, \`<function=\`→qwen3_coder, \`<tool_call>\`→hermes. Remote fetch is lazy-imported, cached, and fails closed (falls through, never throws).

## SGLang coupling
Verified we resolve against the same artifact SGLang serves: neither launcher overrides \`--tokenizer-path\`/\`--chat-template\`, so the tokenizer comes from \`--model-path\` — which is exactly what the resolver reads (\`sglang_model_path\` in PvP; the served model in intercode).

## Tests
13 unit tests incl. the hermes-on-llama regression, named-list template, \`.jinja\` precedence, and named-repo-skips-IO. Live-checked against \`NousResearch/Hermes-3-Llama-3.1-8B\` (→hermes from template) and \`Mistral-7B-Instruct-v0.3\` (→mistral).