### PR TITLE
model-prep: fix CPU thread oversubscription stalling baseline stats

### DIFF
--- a/trainer/model_prep/entrypoint.py
+++ b/trainer/model_prep/entrypoint.py
@@ -238,6 +238,16 @@ def _load_config_with_yarn_fix(model_path: str, hf_token: str):
 
 def main():
     t_total = time.time()
+
+    # Cap CPU threads. Several model-prep containers can share one node, and
+    # torch/OpenMP otherwise each spawn one thread per physical core (hundreds
+    # on big boxes). That oversubscription makes the CPU-bound stats (BPB,
+    # near-duplicate, tokenisation) spend their time in OMP barrier spin rather
+    # than real work. A modest cap keeps each container fast and well-behaved.
+    cpu_threads = int(os.environ.get("MODEL_PREP_CPU_THREADS", "8"))
+    torch.set_num_threads(cpu_threads)
+    print(f"[model_prep] CPU threads capped at {cpu_threads}", flush=True)
+
     args = parse_args()
     aug_config = build_augmentation_config(args)
     hf_token = os.environ.get("HUGGINGFACE_TOKEN", "")

--- a/trainer/model_prep/stats.py
+++ b/trainer/model_prep/stats.py
@@ -45,7 +45,9 @@ LENGTH_SAMPLE_SIZE = 2_000
 # prep; a few hundred to ~1k samples give a stable mean. Decoupled from
 # LENGTH_SAMPLE_SIZE so the token-length distribution stays accurate.
 FORWARD_SAMPLE_SIZE = 1_000
-BPB_SAMPLE_SIZE = 200
+# Bits-per-byte runs a GPT-2 forward pass per text; 64 is plenty for a stable
+# byte-normalised cross-entropy estimate and keeps the probe cheap.
+BPB_SAMPLE_SIZE = 64
 LENGTH_SAMPLE_SEED = 42
 # Cap per-text length for the CPU-bound content stats so a handful of
 # pathologically long records (e.g. long-document datasets) can't blow up
@@ -298,17 +300,18 @@ def _compute_near_duplicate_rate(texts: list[str], num_perm: int = 128, threshol
         return float("nan")
 
 
-def _compute_bits_per_byte(texts: list[str]) -> float:
+def _compute_bits_per_byte(texts: list[str], device: str = "cpu") -> float:
     """Compute bits-per-byte using GPT-2 reference model.
 
-    Always runs on CPU to avoid competing for GPU VRAM with the main model.
-    GPT-2 is small enough that CPU inference is fine here.
+    Runs on the main model's device (GPU when available). GPT-2 is tiny (~124M),
+    so the VRAM cost is negligible and GPU inference avoids the CPU-bound forward
+    loop that dominates model-prep time when several containers share a node.
     """
     t0 = time.time()
     texts = [t for t in texts if t.strip()]
     if not texts:
         return 0.0
-    ref_model = AutoModelForCausalLM.from_pretrained(BPB_REFERENCE_MODEL)
+    ref_model = AutoModelForCausalLM.from_pretrained(BPB_REFERENCE_MODEL).to(device)
     ref_tokenizer = AutoTokenizer.from_pretrained(BPB_REFERENCE_MODEL)
     ref_tokenizer.pad_token = ref_tokenizer.eos_token
     ref_model.eval()
@@ -317,11 +320,13 @@ def _compute_bits_per_byte(texts: list[str]) -> float:
     with torch.no_grad():
         for text in texts:
             total_bytes += len(text.encode("utf-8"))
-            enc = ref_tokenizer(text, truncation=True, max_length=512, return_tensors="pt")
+            enc = ref_tokenizer(text, truncation=True, max_length=512, return_tensors="pt").to(device)
             outputs = ref_model(**enc, labels=enc["input_ids"])
             n_predicted_tokens = enc["input_ids"].shape[1] - 1
             total_loss_nats += outputs.loss.item() * max(n_predicted_tokens, 1)
     del ref_model
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
     result = (total_loss_nats / math.log(2)) / max(total_bytes, 1)
     print(f"[stats] BPB done in {time.time() - t0:.1f}s ({len(texts)} texts, {total_bytes} bytes, bpb={result:.4f})", flush=True)
     return result
@@ -534,7 +539,7 @@ def _compute_instruct_stats(
         num_records=len(records),
         seq_length_distribution=_make_seq_dist([p + c for p, c in zip(prompt_lengths, completion_lengths)]),
         near_duplicate_rate=_compute_near_duplicate_rate(all_texts),
-        bits_per_byte=_compute_bits_per_byte(list(completions)[:BPB_SAMPLE_SIZE]),
+        bits_per_byte=_compute_bits_per_byte(list(completions)[:BPB_SAMPLE_SIZE], device),
         vocab_size=vocab_size,
         unique_tokens_in_data=unique_tokens,
         vocab_coverage_ratio=unique_tokens / max(vocab_size, 1),
@@ -589,7 +594,7 @@ def _compute_dpo_stats(
         num_records=len(records),
         seq_length_distribution=_make_seq_dist([p + c for p, c in zip(prompt_lengths, chosen_lengths)]),
         near_duplicate_rate=_compute_near_duplicate_rate(list(prompts)),
-        bits_per_byte=_compute_bits_per_byte(list(prompts)[:BPB_SAMPLE_SIZE]),
+        bits_per_byte=_compute_bits_per_byte(list(prompts)[:BPB_SAMPLE_SIZE], device),
         vocab_size=vocab_size,
         unique_tokens_in_data=unique_tokens,
         vocab_coverage_ratio=unique_tokens / max(vocab_size, 1),
@@ -642,7 +647,7 @@ def _compute_grpo_stats(
         num_records=len(records),
         seq_length_distribution=_make_seq_dist(prompt_lengths),
         near_duplicate_rate=_compute_near_duplicate_rate(prompts),
-        bits_per_byte=_compute_bits_per_byte(prompts[:BPB_SAMPLE_SIZE]),
+        bits_per_byte=_compute_bits_per_byte(prompts[:BPB_SAMPLE_SIZE], device),
         vocab_size=vocab_size,
         unique_tokens_in_data=unique_tokens,
         vocab_coverage_ratio=unique_tokens / max(vocab_size, 1),

--- a/trainer/model_prep/stats.py
+++ b/trainer/model_prep/stats.py
@@ -37,10 +37,21 @@ from core.models.task_models import TaskType
 BPB_REFERENCE_MODEL = "gpt2"
 
 # Token-length stats are computed on a random sample and scaled to the full
-# record count; model forward passes use the same sample.
+# record count; model forward passes use a smaller subset of the SAME sample.
 LENGTH_SAMPLE_SIZE = 2_000
+# Model forward passes (init loss, entropy, masked loss) and the content stats
+# (unique tokens, near-duplicate rate, BPB) run on this many samples. The
+# forward-pass loops are batch_size=1, so this is the dominant cost of model
+# prep; a few hundred to ~1k samples give a stable mean. Decoupled from
+# LENGTH_SAMPLE_SIZE so the token-length distribution stays accurate.
+FORWARD_SAMPLE_SIZE = 1_000
 BPB_SAMPLE_SIZE = 200
 LENGTH_SAMPLE_SEED = 42
+# Cap per-text length for the CPU-bound content stats so a handful of
+# pathologically long records (e.g. long-document datasets) can't blow up
+# model-prep time. Forward passes are separately capped at max_length=512.
+CONTENT_MAX_TOKENS = 2_048
+NEAR_DUP_MAX_WORDS = 512
 
 # Throughput probe settings.
 THROUGHPUT_TARGET_BATCH_TOKENS = 8_192
@@ -216,7 +227,7 @@ def measure_training_throughput(model, device, seq_len: int, vocab_size: int) ->
 def _count_unique_tokens(texts: list[str], tokenizer) -> int:
     unique: set[int] = set()
     for t in texts:
-        unique.update(tokenizer(t, truncation=False)["input_ids"])
+        unique.update(tokenizer(t, truncation=True, max_length=CONTENT_MAX_TOKENS)["input_ids"])
     return len(unique)
 
 
@@ -273,7 +284,7 @@ def _compute_near_duplicate_rate(texts: list[str], num_perm: int = 128, threshol
         minhashes = []
         for i, text in enumerate(texts):
             m = MinHash(num_perm=num_perm)
-            for word in text.lower().split():
+            for word in text.lower().split()[:NEAR_DUP_MAX_WORDS]:
                 m.update(word.encode("utf-8"))
             minhashes.append(m)
             try:
@@ -358,14 +369,18 @@ def _compute_base_training_dynamics(
 
     # Forward hooks for activation RMS — registered before eval loop so we
     # collect across all batches in eval mode (no dropout/batchnorm noise).
-    activation_rms_accum: dict[str, list[float]] = defaultdict(list)
+    # Keep per-batch RMS as on-device scalars and sync once at the end. Calling
+    # .item() inside the hook would force a GPU->CPU sync for every module on
+    # every batch (hundreds of modules x thousands of batches), serialising the
+    # whole eval loop.
+    activation_rms_accum: dict[str, list[torch.Tensor]] = defaultdict(list)
     hooks = []
 
     def make_hook(name):
         def hook(module, _input, output):
             out = output[0] if isinstance(output, tuple) else output
             if isinstance(out, torch.Tensor):
-                activation_rms_accum[name].append(torch.sqrt(torch.mean(out.float() ** 2)).item())
+                activation_rms_accum[name].append(torch.sqrt(torch.mean(out.float() ** 2)).detach())
         return hook
 
     for name, module in model.named_modules():
@@ -400,7 +415,7 @@ def _compute_base_training_dynamics(
 
     for h in hooks:
         h.remove()
-    activation_rms = {n: float(np.mean(v)) for n, v in activation_rms_accum.items()}
+    activation_rms = {n: float(torch.stack(v).mean().item()) for n, v in activation_rms_accum.items() if v}
     print(
         f"[stats] Eval loop done in {time.time() - t_start:.1f}s "
         f"(loss={init_loss:.4f}, {len(batch_losses)} batches)",
@@ -696,7 +711,7 @@ def compute_text_stats(
     tokenizer,
     data_records: list[dict],
     task_type: TaskType = TaskType.INSTRUCTTEXTTASK,
-    max_samples: int = LENGTH_SAMPLE_SIZE,
+    max_samples: int = FORWARD_SAMPLE_SIZE,
     reward_functions=None,
 ) -> BaselineStats:
     """Compute stats for text-based tasks (instruct, DPO, GRPO, chat)."""


### PR DESCRIPTION
## Problem (diagnosed live)

With several model-prep containers sharing one node, all were wedged in `_compute_bits_per_byte` — the GPT-2 bits-per-byte stat, which deliberately ran **on CPU**. py-spy showed every process pinned in GPT-2 `forward`, each having spawned **~430 threads** (one per physical core on a 252-core box). Three containers → ~1,300 threads, and load was only 160/252 — i.e. the cores weren't even saturated; the time was going into **OpenMP barrier spin**, not work. A ~200-pass GPT-2 CPU loop stretched to 40+ min, leaving tasks stuck in `awaiting_model_prep`.

## Fixes (`trainer/model_prep/`)

1. **Cap CPU threads** — `torch.set_num_threads(MODEL_PREP_CPU_THREADS, default 8)` at entrypoint start, so concurrent containers stop oversubscribing the box.
2. **Run BPB's GPT-2 on the main model's device (GPU when available)** instead of always-CPU. It's ~124M params, so VRAM cost is trivial, and it sidesteps the CPU forward loop that was the actual hang.
3. **`BPB_SAMPLE_SIZE` 200 → 64** — a stable byte-normalised cross-entropy estimate needs far fewer texts.

## Relation to #1261

#1261 (merged) cut the forward-pass sample budget, capped near-dup/unique length, and removed the per-module sync in the activation hook. That helped the forward loops but did **not** touch BPB — which is where the live containers were actually stuck. This PR closes that gap.

## Note

Takes effect once `gradientsio/model-prep:latest` is rebuilt (CI builds on `trainer/model_prep/**` changes). Also worth a separate look: the scheduler placed 3 model-preps on one node at once — the thread cap makes that survivable, but the concurrency itself may be worth bounding.