### PR TITLE
PvP eval: graceful chat-failure handling + 15s read timeout

### DIFF
--- a/core/pvp/bot.py
+++ b/core/pvp/bot.py
@@ -34,6 +34,7 @@ from core.models.pvp_models import ToolCall
 from core.models.pvp_models import ToolSchema
 from core.pvp import constants as cst
 from core.pvp import tools as tool_lib
+from core.pvp.chat import ChatUnavailableError
 from core.pvp.agents import BaseGameAgent
 from core.pvp.memory import SlotMemory
 from core.pvp.memory import WhitespaceTokenCounter
@@ -83,6 +84,31 @@ class InvalidActionForfeitError(Exception):
     def __init__(self, player_id: int):
         self.player_id = player_id
         super().__init__(f"Player {player_id} did not commit a legal action this turn and forfeits")
+
+
+class ChatTimeoutForfeitError(Exception):
+    """Raised when a player's model was too slow to respond (timed out after retries).
+
+    Treated as a forfeit: an unresponsive model is the miner's fault, mirroring
+    TurnTimeoutError. The opponent wins the game.
+    """
+
+    def __init__(self, player_id: int):
+        self.player_id = player_id
+        super().__init__(f"Player {player_id} inference timed out after retries and forfeits")
+
+
+class ModelUnreachableError(Exception):
+    """Raised when a player's inference server was unreachable (connection refused).
+
+    This is an infra failure, NOT the miner's fault, so it must not forfeit the
+    player. It propagates past the game-eval forfeit handlers up to the matchup
+    runner, which waits for the server to recover and replays the game.
+    """
+
+    def __init__(self, player_id: int):
+        self.player_id = player_id
+        super().__init__(f"Player {player_id} inference server unreachable (infra failure)")
 
 
 def default_memories() -> dict[MemoryArea, SlotMemory]:
@@ -222,6 +248,22 @@ class LLMBot(pyspiel.Bot):
             if "context length" in str(exc).lower():
                 raise ContextOverflowError(self._player_id) from exc
             raise
+        except ChatUnavailableError as exc:
+            # Check timeout first: openai.APITimeoutError subclasses APIConnectionError.
+            # Slow model = the miner's fault (forfeit); unreachable server = infra
+            # (wait-and-replay upstream).
+            if isinstance(exc.cause, (openai.APITimeoutError, TimeoutError)):
+                logger.warning(
+                    "Player %d chat timed out after retries (%s) — forfeiting turn",
+                    self._player_id, type(exc.cause).__name__,
+                )
+                raise ChatTimeoutForfeitError(self._player_id) from exc
+            logger.error(
+                "Player %d inference server unreachable after retries (%s) — infra failure, "
+                "will wait for recovery and replay",
+                self._player_id, type(exc.cause).__name__,
+            )
+            raise ModelUnreachableError(self._player_id) from exc
 
     @staticmethod
     def _validate_action(call: ToolCall, legal_set: set[int]) -> int | None:

--- a/core/pvp/chat.py
+++ b/core/pvp/chat.py
@@ -22,6 +22,21 @@ from core.pvp import constants as cst
 
 logger = logging.getLogger(__name__)
 
+
+class ChatUnavailableError(Exception):
+    """Inference endpoint failed after exhausting retries.
+
+    Carries the underlying cause so callers can distinguish a slow model
+    (openai.APITimeoutError) from an unreachable server (openai.APIConnectionError).
+    A bare RuntimeError here used to crash the whole matchup; this typed error
+    lets the bot layer convert it into a player-attributed forfeit instead.
+    """
+
+    def __init__(self, cause: BaseException | None, attempts: int):
+        self.cause = cause
+        super().__init__(f"Chat failed after {attempts} attempts: {cause}")
+
+
 _THINK_COMPLETE = re.compile(r"<think(?:ing)?>.*?</think(?:ing)?>", re.DOTALL | re.IGNORECASE)
 _THINK_UNCLOSED = re.compile(r"<think(?:ing)?>.*", re.DOTALL | re.IGNORECASE)
 
@@ -87,7 +102,7 @@ def _with_retries(
                 continue
             raise
 
-    raise RuntimeError(f"Chat failed after {attempts} attempts: {last_exc}")
+    raise ChatUnavailableError(last_exc, attempts)
 
 
 def _call(

--- a/core/pvp/constants.py
+++ b/core/pvp/constants.py
@@ -17,10 +17,14 @@ PVP_TURN_TIMEOUT_SECONDS = 15
 PVP_REFLECTION_TIMEOUT_SECONDS = 12
 PVP_RETRY_BACKOFF_CAP_SECONDS = 32
 
-# HTTP read timeout + retries for in-turn/reflection calls. Kept under the turn
-# budget so a hung connection is caught (and at most one retry attempted) before
-# the wall-clock alarm forfeits — the old 30s/10-retry defaults could never fit.
-PVP_HTTP_READ_TIMEOUT_SECONDS = 12
+# HTTP read timeout + retries for in-turn/reflection calls. Matches the turn
+# wall-clock budget: a full PVP_TURN_MAX_TOKENS turn can legitimately take into
+# the low-teens of seconds, so a tighter read timeout spuriously timed out
+# healthy models. When a call still exhausts retries it raises ChatUnavailableError,
+# which the bot layer turns into a graceful, attributed outcome (slow model
+# forfeits; unreachable server triggers wait-and-replay) instead of crashing
+# the whole matchup.
+PVP_HTTP_READ_TIMEOUT_SECONDS = 15
 PVP_HTTP_MAX_RETRIES = 1
 
 # Tool-calling memory harness.

--- a/core/pvp/game_eval.py
+++ b/core/pvp/game_eval.py
@@ -25,6 +25,7 @@ from core.pvp.agents import GoofspielAgent
 from core.pvp.agents import LeducPokerAgent
 from core.pvp.agents import LiarsDiceAgent
 from core.pvp.agents import OthelloAgent
+from core.pvp.bot import ChatTimeoutForfeitError
 from core.pvp.bot import ContextOverflowError
 from core.pvp.bot import EmptyLegalActionsError
 from core.pvp.bot import InvalidActionForfeitError
@@ -93,15 +94,24 @@ def _evaluate_game_with_timeout(
 ) -> GameEvaluation:
     """Run evaluate_bots, catching bot-level forfeits.
 
-    Per-turn timeouts are enforced inside LLMBot.step() via SIGALRM. Timeout,
-    context overflow, and invalid-action strikeouts propagate up through
-    evaluate_bots and are caught here as forfeits.
+    Per-turn timeouts are enforced inside LLMBot.step() via SIGALRM. Wall-clock
+    timeout, chat timeout (slow model), context overflow, and invalid-action
+    strikeouts propagate up through evaluate_bots and are caught here as forfeits.
+
+    A ModelUnreachableError (the player's inference *server* is down — infra, not
+    the model's fault) is deliberately NOT caught: it propagates to the matchup
+    runner, which waits for the server to recover and replays the game.
     """
     try:
         returns = evaluate_bots.evaluate_bots(state, bots, np.random.RandomState(seed))
         return GameEvaluation(returns=list(returns))
     except TurnTimeoutError as exc:
         logger.warning("Player %d timed out on turn — opponent wins by forfeit", exc.player_id)
+        return GameEvaluation(returns=_forfeit_returns(state, exc.player_id), forfeiting_player_id=exc.player_id)
+    except ChatTimeoutForfeitError as exc:
+        logger.warning(
+            "Player %d inference timed out after retries — opponent wins by forfeit", exc.player_id
+        )
         return GameEvaluation(returns=_forfeit_returns(state, exc.player_id), forfeiting_player_id=exc.player_id)
     except ContextOverflowError as exc:
         logger.warning("Player %d exceeded context length — opponent wins by forfeit", exc.player_id)

--- a/validator/evaluation/constants.py
+++ b/validator/evaluation/constants.py
@@ -92,6 +92,13 @@ PVP_SGLANG_PORT_A = 30000
 PVP_SGLANG_PORT_B = 30001
 PVP_SGLANG_HEALTH_TIMEOUT = 1800
 PVP_SGLANG_HEALTH_PATH = "/v1/models"
+# Mid-eval recovery: if a model's SGLang server becomes unreachable DURING a
+# matchup (infra blip / crash), wait for it to come back and replay the game
+# rather than penalizing the miner. Shorter than the 30-min setup timeout —
+# a server that doesn't recover in this window is treated as a hard failure
+# and the eval is re-run by the orchestrator. Retries bound a flapping server.
+PVP_SERVER_RECOVERY_HEALTH_TIMEOUT = 300
+PVP_SERVER_RECOVERY_MAX_RETRIES = 2
 PVP_SGLANG_API_PATH = "/v1"
 PVP_RESULTS_PATH = "/app/pvp_results.json"
 PVP_CONFIG_PATH = "/config/pvp_eval.json"

--- a/validator/evaluation/pvp/__main__.py
+++ b/validator/evaluation/pvp/__main__.py
@@ -161,6 +161,18 @@ def _run_evaluation(config: PvPEvalConfig) -> PvPEvalResults:
         warmup_player(player_b)
         logger.info("Warmup complete")
 
+        def _recover_servers() -> None:
+            """Wait for both SGLang servers to become healthy again after a mid-eval
+            outage, so the matchup runner can replay the failed game."""
+            logger.warning(
+                "Recovering: waiting up to %ds for SGLang servers on ports %d/%d to come back",
+                vcst.PVP_SERVER_RECOVERY_HEALTH_TIMEOUT,
+                port_a,
+                port_b,
+            )
+            asyncio.run(wait_for_servers(port_a, port_b, timeout=vcst.PVP_SERVER_RECOVERY_HEALTH_TIMEOUT))
+            logger.info("Recovery complete: SGLang servers on ports %d/%d are healthy", port_a, port_b)
+
         env_results: dict[EnvironmentName, PvPEnvironmentResult] = {}
         for env_name, matchup_config in config.matchups.items():
             logger.info("Starting matchup: %s (%.0fs budget)", env_name.value, matchup_config.time_budget_seconds)
@@ -170,6 +182,7 @@ def _run_evaluation(config: PvPEvalConfig) -> PvPEvalResults:
                 player_a=player_a,
                 player_b=player_b,
                 base_seed=config.seed,
+                recover_fn=_recover_servers,
             )
 
         return PvPEvalResults(

--- a/validator/evaluation/pvp/game_runner.py
+++ b/validator/evaluation/pvp/game_runner.py
@@ -10,6 +10,7 @@ import functools
 import logging
 import random
 import time
+from collections.abc import Callable
 from collections.abc import Iterator
 from typing import NamedTuple
 
@@ -31,6 +32,7 @@ from core.models.pvp_models import PvPEnvironmentResult
 from core.models.pvp_models import PvPMatchupConfig
 from core.pvp.agents import BaseGameAgent
 from core.pvp.bot import LLMBot
+from core.pvp.bot import ModelUnreachableError
 from core.pvp.chat import chat_completion
 from core.pvp.chat import create_client
 from core.pvp.game_eval import _AGENT_REGISTRY
@@ -82,18 +84,22 @@ def run_matchup(
     player_a: Player,
     player_b: Player,
     base_seed: int,
+    recover_fn: Callable[[], None] | None = None,
 ) -> PvPEnvironmentResult:
     """Run a time-budgeted PvP matchup for one environment.
 
     Plays seed pairs, each seed twice with positions swapped, until the wall-clock
     budget expires or an early forfeit fires. The deadline is checked between
     complete pairs so every recorded game has a position-balanced counterpart.
+
+    recover_fn, when supplied, is called to wait for the inference servers to come
+    back if one goes unreachable mid-game; the failed game is then replayed.
     """
     agent = _AGENT_REGISTRY[env_name]()
     seed_stream = _seed_stream(env_name, agent, base_seed)
     start = time.monotonic()
     deadline = start + matchup_config.time_budget_seconds
-    return _execute_matchup(env_name, seed_stream, start, deadline, player_a, player_b, agent)
+    return _execute_matchup(env_name, seed_stream, start, deadline, player_a, player_b, agent, recover_fn)
 
 
 def _seed_stream(
@@ -230,6 +236,7 @@ def _execute_matchup(
     player_a: Player,
     player_b: Player,
     agent: BaseGameAgent,
+    recover_fn: Callable[[], None] | None = None,
 ) -> PvPEnvironmentResult:
     """Play seed pairs until the deadline or an early forfeit fires."""
     counter_a = load_token_counter(player_a.config.tokenizer_repo or player_a.config.inference_model)
@@ -265,8 +272,19 @@ def _execute_matchup(
                 instance.seed,
                 instance.model_a_player_id,
             )
-            played = play(instance)
-            game_elapsed = time.monotonic() - game_start
+            played, recovery_wait = _play_with_recovery(
+                play, instance, env_name, games_played + 1, recover_fn
+            )
+            if recovery_wait:
+                # An infra wait isn't game time — credit it back so a server blip
+                # doesn't eat into the matchup budget.
+                deadline += recovery_wait
+                logger.info(
+                    "%s: credited %.0fs of server-recovery wait back to the matchup deadline",
+                    env_name.value,
+                    recovery_wait,
+                )
+            game_elapsed = time.monotonic() - game_start - recovery_wait
             _tally(result, played.outcome)
             games_played += 1
 
@@ -332,6 +350,66 @@ def _execute_matchup(
         result.model_a_wins, result.model_b_wins, result.draws,
     )
     return result
+
+
+def _play_with_recovery(
+    play: Callable[[GameInstance], PlayedGame],
+    instance: GameInstance,
+    env_name: EnvironmentName,
+    game_number: int,
+    recover_fn: Callable[[], None] | None,
+) -> tuple[PlayedGame, float]:
+    """Play one game, recovering from inference-server (infra) failures.
+
+    A slow or broken model already forfeits inside the game. This handles the
+    distinct case where a model's SGLang *server* goes unreachable mid-game
+    (crash/restart/blip): wait for both servers to come back and replay the game
+    from scratch so an infra hiccup never penalizes a miner. Returns the played
+    game plus the seconds spent waiting (credited back to the matchup deadline).
+
+    Replaying is safe — long-term memory is only mutated by reflect() after a
+    completed game, so a game that died mid-play left it untouched.
+
+    With no recover_fn, or once recovery is exhausted, the error propagates and
+    the eval fails loudly so the orchestrator re-runs it.
+    """
+    total_wait = 0.0
+    for attempt in range(vcst.PVP_SERVER_RECOVERY_MAX_RETRIES + 1):
+        try:
+            return play(instance), total_wait
+        except ModelUnreachableError as exc:
+            attempts_left = vcst.PVP_SERVER_RECOVERY_MAX_RETRIES - attempt
+            if recover_fn is None or attempts_left <= 0:
+                logger.error(
+                    "%s: game %d — player %d inference server still unreachable after %d "
+                    "recovery attempt(s); failing the eval for re-run",
+                    env_name.value,
+                    game_number,
+                    exc.player_id,
+                    vcst.PVP_SERVER_RECOVERY_MAX_RETRIES,
+                )
+                raise
+            logger.error(
+                "%s: game %d — player %d inference server unreachable (infra). Waiting up to "
+                "%ds for both servers to recover, then replaying (%d attempt(s) left)",
+                env_name.value,
+                game_number,
+                exc.player_id,
+                vcst.PVP_SERVER_RECOVERY_HEALTH_TIMEOUT,
+                attempts_left,
+            )
+            wait_start = time.monotonic()
+            recover_fn()  # blocks until both servers healthy; raises TimeoutError if not
+            waited = time.monotonic() - wait_start
+            total_wait += waited
+            logger.info(
+                "%s: game %d — servers healthy again after %.0fs wait; replaying game",
+                env_name.value,
+                game_number,
+                waited,
+            )
+    # Unreachable: the loop either returns a PlayedGame or raises above.
+    raise AssertionError("unreachable: recovery loop exited without returning or raising")
 
 
 def _play_game(

--- a/validator/evaluation/pvp/server.py
+++ b/validator/evaluation/pvp/server.py
@@ -68,19 +68,24 @@ def _drain_stdout(proc: subprocess.Popen, name: str) -> None:
     thread.start()
 
 
-async def wait_for_servers(port_a: int, port_b: int) -> None:
-    """Wait for both SGLang instances to become healthy."""
+async def wait_for_servers(port_a: int, port_b: int, timeout: int = vcst.PVP_SGLANG_HEALTH_TIMEOUT) -> None:
+    """Wait for both SGLang instances to become healthy.
+
+    Used both for initial startup (long timeout) and for mid-eval recovery after
+    a server goes unreachable (shorter timeout). Raises TimeoutError if either
+    server is not healthy within `timeout`.
+    """
     await asyncio.gather(
         _wait_for_health(
             f"http://{vcst.PVP_SGLANG_HOST}:{port_a}",
             vcst.PVP_SGLANG_HEALTH_PATH,
-            vcst.PVP_SGLANG_HEALTH_TIMEOUT,
+            timeout,
             service_name="sglang-a",
         ),
         _wait_for_health(
             f"http://{vcst.PVP_SGLANG_HOST}:{port_b}",
             vcst.PVP_SGLANG_HEALTH_PATH,
-            vcst.PVP_SGLANG_HEALTH_TIMEOUT,
+            timeout,
             service_name="sglang-b",
         ),
     )


### PR DESCRIPTION
Slow model forfeits; unreachable server waits-and-replays instead of crashing the matchup.