### PR TITLE
Derive champion decay from base weight: drain to zero over 35 days

### DIFF
--- a/tests/validator/tournament/test_hybrid_decay_system.py
+++ b/tests/validator/tournament/test_hybrid_decay_system.py
@@ -16,13 +16,38 @@ from datetime import timezone
 
 # Constants matching validator/scoring/constants.py
 EMISSION_BOOST_DECAY_PER_WIN = 0.01  # 1% per win (old system)
-EMISSION_DAILY_TIME_DECAY_RATE = 0.0033  # 0.33% per day (new system)
+# Piecewise-linear retention curve (multiplier on full day-0 emission weight):
+# fast early drop, a glide, then a cliff to zero at 40 days. (days, retention).
+EMISSION_TIME_DECAY_CURVE = (
+    (0.0, 1.00),
+    (7.0, 0.50),
+    (30.0, 0.30),
+    (40.0, 0.00),
+)
 EMISSION_TIME_DECAY_START_DATE = date(2025, 11, 26)
 SECONDS_PER_DAY = 86400.0
-TOURNAMENT_TEXT_WEIGHT = 0.20
-MAX_TEXT_TOURNAMENT_WEIGHT = 0.6
-EMISSION_MULTIPLIER_THRESHOLD = 0.05
+TOURNAMENT_TEXT_WEIGHT = 0.40
+MAX_TEXT_TOURNAMENT_WEIGHT = 0.48
+EMISSION_MULTIPLIER_THRESHOLD = 0.10
 EMISSION_MULTIPLIER_RATE = 2.0
+
+
+def emission_time_retention(days_as_champion: float) -> float:
+    """Piecewise-linear retention multiplier in [0, 1] (see EMISSION_TIME_DECAY_CURVE)."""
+    curve = EMISSION_TIME_DECAY_CURVE
+    if days_as_champion <= curve[0][0]:
+        return curve[0][1]
+    if days_as_champion >= curve[-1][0]:
+        return curve[-1][1]
+    for (d0, r0), (d1, r1) in zip(curve, curve[1:]):
+        if d0 <= days_as_champion <= d1:
+            return r0 + (days_as_champion - d0) / (d1 - d0) * (r1 - r0)
+    return curve[-1][1]
+
+
+def emission_time_decay_fraction(days_as_champion: float) -> float:
+    """Fraction of emission weight removed by time decay (1 - retention)."""
+    return 1.0 - emission_time_retention(days_as_champion)
 
 
 def calculate_emission_boost_from_perf(performance_diff: float) -> float:
@@ -59,12 +84,12 @@ def calculate_hybrid_decays(
     if first_championship_time_utc < cutoff_date:
         old_decay = max(0, consecutive_wins - 1) * EMISSION_BOOST_DECAY_PER_WIN
         days_since_cutoff = (current_time_utc - cutoff_date).total_seconds() / SECONDS_PER_DAY
-        new_decay = days_since_cutoff * EMISSION_DAILY_TIME_DECAY_RATE
+        new_decay = emission_time_decay_fraction(days_since_cutoff)
         return (old_decay, new_decay, True)
     else:
         # Champion won after cutoff: new system only
         days_as_champion = (current_time_utc - first_championship_time_utc).total_seconds() / SECONDS_PER_DAY
-        new_decay = days_as_champion * EMISSION_DAILY_TIME_DECAY_RATE
+        new_decay = emission_time_decay_fraction(days_as_champion)
         return (0.0, new_decay, False)
 
 
@@ -81,8 +106,8 @@ def calculate_tournament_weight_with_decay(
         # Pre-cutoff champion after cutoff: hybrid logic
         boost_after_old = max(0.0, emission_boost - old_decay)
         if boost_after_old == 0.0:
-            # Boost completely wiped out, now decay from base
-            final_weight = max(0.0, base_weight - new_decay)
+            # Boost completely wiped out, now decay the base weight along the curve
+            final_weight = max(0.0, base_weight * (1.0 - new_decay))
         else:
             # Boost still exists, don't apply new_decay
             final_weight = max(0.0, base_weight + boost_after_old)
@@ -93,7 +118,7 @@ def calculate_tournament_weight_with_decay(
             final_weight = max(0.0, base_weight + boost_after_old)
         # New regime purely (after cutoff, champion won after cutoff)
         elif new_decay > 0.0:
-            final_weight = max(0.0, base_weight + emission_boost - new_decay)
+            final_weight = max(0.0, (base_weight + emission_boost) * (1.0 - new_decay))
         else:
             final_weight = base_weight + emission_boost
 
@@ -147,7 +172,7 @@ def main():
     print("=" * 100)
     print(f"\nCutoff date: {EMISSION_TIME_DECAY_START_DATE}")
     print(f"Old decay rate: {EMISSION_BOOST_DECAY_PER_WIN * 100:.1f}% per win")
-    print(f"New decay rate: {EMISSION_DAILY_TIME_DECAY_RATE * 100:.2f}% per day")
+    print(f"New decay curve (retention): {EMISSION_TIME_DECAY_CURVE}")
     print(f"Base text weight: {TOURNAMENT_TEXT_WEIGHT:.4f}")
     print(f"Max text weight: {MAX_TEXT_TOURNAMENT_WEIGHT:.4f}")
 
@@ -242,25 +267,25 @@ def main():
     print("   → Calculate new_decay from days since cutoff")
     print("   → Apply old_decay to boost first")
     print("   → IF boost completely wiped out (boost - old_decay ≤ 0):")
-    print("      • THEN apply new_decay to base weight")
-    print("      • final_weight = max(0, base - new_decay)")
+    print("      • THEN decay base weight along the retention curve")
+    print("      • final_weight = max(0, base × retention(days))")
     print("   → ELSE boost still exists:")
-    print("      • DON'T apply new_decay")
+    print("      • DON'T apply time decay")
     print("      • final_weight = base + (boost - old_decay)")
     print()
     print("2. Champion won AFTER cutoff (apply_hybrid=False, new_decay > 0):")
-    print("   → Only new time-based decay")
-    print("   → new_decay = days_as_champion × 0.33%")
-    print("   → final_weight = base + boost - new_decay")
+    print("   → Only new time-based decay (multiplicative on full weight)")
+    print("   → retention: 100%@0d → 50%@7d → 30%@30d → 0%@40d (piecewise-linear)")
+    print("   → final_weight = (base + boost) × retention(days)")
     print()
     print("3. No champion or before cutoff (apply_hybrid=False, old_decay > 0):")
     print("   → Only old consecutive wins decay")
     print("   → final_weight = base + max(0, boost - old_decay)")
     print()
     print("CRITICAL OBSERVATION:")
-    print("  ✓ For pre-cutoff champions, new_decay ONLY applies if boost is wiped out")
-    print("  ✓ This creates a 'cliff' effect once old_decay exceeds emission_boost")
-    print("  ✓ After the cliff, base weight starts decaying with new_decay")
+    print("  ✓ Time decay is a MULTIPLIER on the champion's full day-0 weight")
+    print("  ✓ Every tournament type now reaches zero at exactly 40 days, regardless of base")
+    print("  ✓ Fast early drop (100%→50% in 7d), glide to 30% by 30d, then cliff to 0 by 40d")
     print()
     print("=" * 100 + "\n")
 

--- a/validator/scoring/constants.py
+++ b/validator/scoring/constants.py
@@ -39,7 +39,10 @@ MAX_BURN_REDUCTION = 0.8
 EMISSION_MULTIPLIER_THRESHOLD = 0.10
 EMISSION_MULTIPLIER_RATE = 2.0
 EMISSION_BOOST_DECAY_PER_WIN = 0.01
-EMISSION_DAILY_TIME_DECAY_RATE = 0.00165
+# Champions decay linearly to zero over this many days. The per-day decay is
+# derived from each tournament's actual base weight (base_weight / period) so
+# every tournament drains over the same horizon regardless of its base weight.
+TOURNAMENT_DECAY_PERIOD_DAYS = 35
 EMISSION_TIME_DECAY_START_DATE = date(2025, 11, 26)
 SECONDS_PER_DAY = 86400.0
 

--- a/validator/scoring/constants.py
+++ b/validator/scoring/constants.py
@@ -39,10 +39,15 @@ MAX_BURN_REDUCTION = 0.8
 EMISSION_MULTIPLIER_THRESHOLD = 0.10
 EMISSION_MULTIPLIER_RATE = 2.0
 EMISSION_BOOST_DECAY_PER_WIN = 0.01
-# Champions decay linearly to zero over this many days. The per-day decay is
-# derived from each tournament's actual base weight (base_weight / period) so
-# every tournament drains over the same horizon regardless of its base weight.
-TOURNAMENT_DECAY_PERIOD_DAYS = 35
+# Champion emission decays on a piecewise-linear *retention* curve (multiplier on
+# the champion's full day-0 emission weight = base + boost). Fast early drop, a
+# plateau, then a cliff to zero at 40 days. (days_since_reign_start, retention).
+EMISSION_TIME_DECAY_CURVE: tuple[tuple[float, float], ...] = (
+    (0.0, 1.00),
+    (7.0, 0.50),
+    (30.0, 0.30),
+    (40.0, 0.00),
+)
 EMISSION_TIME_DECAY_START_DATE = date(2025, 11, 26)
 SECONDS_PER_DAY = 86400.0
 

--- a/validator/scoring/weights.py
+++ b/validator/scoring/weights.py
@@ -143,15 +143,20 @@ def calculate_tournament_weight_with_decay(
 
 
 def calculate_hybrid_decays(
-    first_championship_time: datetime, consecutive_wins: int, current_time: datetime | None = None
+    first_championship_time: datetime, consecutive_wins: int, base_weight: float, current_time: datetime | None = None
 ) -> tuple[float, float, bool]:
     """
     Calculate time-based decay & previous consecutive wins decay for backwards compatibility.
     Returns a tuple of (old_decay, new_decay, apply_hybrid).
+
+    The time-based decay rate is derived from the tournament's actual base weight so the
+    base drains to zero over TOURNAMENT_DECAY_PERIOD_DAYS regardless of how large it is.
     """
     if first_championship_time is None:
         logger.error("First championship time is None, cannot calculate time-based decay.")
         return (1.0, 1.0, False)
+
+    daily_time_decay_rate = base_weight / cts.TOURNAMENT_DECAY_PERIOD_DAYS
 
     # timezone alignment
     current_time_utc = current_time if current_time else datetime.now(timezone.utc)
@@ -171,7 +176,7 @@ def calculate_hybrid_decays(
     if first_championship_time_utc < cutoff_date:
         old_decay = max(0, consecutive_wins - 1) * cts.EMISSION_BOOST_DECAY_PER_WIN
         days_since_cutoff = (current_time_utc - cutoff_date).total_seconds() / cts.SECONDS_PER_DAY
-        new_decay = days_since_cutoff * cts.EMISSION_DAILY_TIME_DECAY_RATE
+        new_decay = days_since_cutoff * daily_time_decay_rate
 
         logger.debug(
             f"Pre-cutoff champion: old_decay={old_decay:.4f}, new_decay={new_decay:.4f}, will apply hybrid logic downstream"
@@ -180,7 +185,7 @@ def calculate_hybrid_decays(
     else:
         # Champion won AFTER cutoff - only new time-based decay
         days_as_champion = (current_time_utc - first_championship_time_utc).total_seconds() / cts.SECONDS_PER_DAY
-        new_decay = days_as_champion * cts.EMISSION_DAILY_TIME_DECAY_RATE
+        new_decay = days_as_champion * daily_time_decay_rate
         logger.debug(f"Post-cutoff champion: new_decay={new_decay:.4f} (reign={days_as_champion:.1f} days)")
         return (0.0, new_decay, False)
 
@@ -322,7 +327,7 @@ async def get_tournament_burn_details(psql_db) -> TournamentBurnData:
         first_win_tournament = await get_tournament_where_champion_first_won(psql_db, TournamentType.TEXT, text_champion_hotkey)
 
         text_old_decay, text_new_decay, apply_hybrid_to_text = calculate_hybrid_decays(
-            first_win_tournament.updated_at, text_consecutive_wins
+            first_win_tournament.updated_at, text_consecutive_wins, cts.TOURNAMENT_TEXT_WEIGHT
         )
         logger.info(
             f"Text champion {text_champion_hotkey[:8]}... has {text_consecutive_wins} consecutive wins, "
@@ -338,7 +343,7 @@ async def get_tournament_burn_details(psql_db) -> TournamentBurnData:
         first_win_tournament = await get_tournament_where_champion_first_won(psql_db, TournamentType.IMAGE, image_champion_hotkey)
 
         image_old_decay, image_new_decay, apply_hybrid_to_image = calculate_hybrid_decays(
-            first_win_tournament.updated_at, image_consecutive_wins
+            first_win_tournament.updated_at, image_consecutive_wins, cts.TOURNAMENT_IMAGE_WEIGHT
         )
         logger.info(
             f"Image champion {image_champion_hotkey[:8]}... has {image_consecutive_wins} consecutive wins, "
@@ -378,7 +383,7 @@ async def get_tournament_burn_details(psql_db) -> TournamentBurnData:
         )
 
         environment_old_decay, environment_new_decay, apply_hybrid_to_environment = calculate_hybrid_decays(
-            first_win_tournament.updated_at, environment_consecutive_wins
+            first_win_tournament.updated_at, environment_consecutive_wins, cts.TOURNAMENT_ENVIRONMENT_WEIGHT
         )
         logger.info(
             f"Environment champion {environment_champion_hotkey[:8]}... has {environment_consecutive_wins} consecutive wins, "

--- a/validator/scoring/weights.py
+++ b/validator/scoring/weights.py
@@ -117,7 +117,7 @@ def calculate_tournament_weight_with_decay(
         # Pre-cutoff: old_decay only affects emission_boost (emission doesn't go below base), then apply cumulative/max logic
         boost_after_old = max(0.0, emission_boost - old_decay)
         if boost_after_old == 0.0:
-            final_weight = max(0.0, base_weight - new_decay)
+            final_weight = max(0.0, base_weight * (1.0 - new_decay))
         else:
             final_weight = max(0.0, base_weight + boost_after_old)
     else:
@@ -127,7 +127,7 @@ def calculate_tournament_weight_with_decay(
             final_weight = max(0.0, base_weight + boost_after_old)
         # New regime purely, we will default to this after a while or if both winners change after cutoff
         elif new_decay > 0.0:
-            final_weight = max(0.0, base_weight + emission_boost - new_decay)
+            final_weight = max(0.0, (base_weight + emission_boost) * (1.0 - new_decay))
         else:
             final_weight = base_weight + emission_boost
 
@@ -142,21 +142,45 @@ def calculate_tournament_weight_with_decay(
     return final_weight
 
 
+def emission_time_retention(days_as_champion: float) -> float:
+    """
+    Piecewise-linear retention multiplier for a champion's emission weight.
+
+    Decays fast at first, plateaus, then drops to zero on a cliff. Anchored on
+    EMISSION_TIME_DECAY_CURVE (100% at day 0 -> 0% at day 40). Returns a value in
+    [0, 1] applied multiplicatively to the champion's full day-0 emission weight.
+    """
+    curve = cts.EMISSION_TIME_DECAY_CURVE
+    if days_as_champion <= curve[0][0]:
+        return curve[0][1]
+    if days_as_champion >= curve[-1][0]:
+        return curve[-1][1]
+    for (d0, r0), (d1, r1) in zip(curve, curve[1:]):
+        if d0 <= days_as_champion <= d1:
+            frac = (days_as_champion - d0) / (d1 - d0)
+            return r0 + frac * (r1 - r0)
+    return curve[-1][1]  # unreachable; guarded by the bounds checks above
+
+
+def emission_time_decay_fraction(days_as_champion: float) -> float:
+    """Fraction of the champion's emission weight removed by time decay (1 - retention)."""
+    return 1.0 - emission_time_retention(days_as_champion)
+
+
 def calculate_hybrid_decays(
-    first_championship_time: datetime, consecutive_wins: int, base_weight: float, current_time: datetime | None = None
+    first_championship_time: datetime, consecutive_wins: int, current_time: datetime | None = None
 ) -> tuple[float, float, bool]:
     """
     Calculate time-based decay & previous consecutive wins decay for backwards compatibility.
-    Returns a tuple of (old_decay, new_decay, apply_hybrid).
 
-    The time-based decay rate is derived from the tournament's actual base weight so the
-    base drains to zero over TOURNAMENT_DECAY_PERIOD_DAYS regardless of how large it is.
+    Returns (old_decay, new_decay, apply_hybrid). `new_decay` is the *fraction* of the
+    champion's emission weight removed by time decay (0.0 = full weight, 1.0 = fully
+    burned), applied multiplicatively downstream. `old_decay` stays an absolute
+    boost reduction (legacy consecutive-wins regime).
     """
     if first_championship_time is None:
         logger.error("First championship time is None, cannot calculate time-based decay.")
         return (1.0, 1.0, False)
-
-    daily_time_decay_rate = base_weight / cts.TOURNAMENT_DECAY_PERIOD_DAYS
 
     # timezone alignment
     current_time_utc = current_time if current_time else datetime.now(timezone.utc)
@@ -176,7 +200,7 @@ def calculate_hybrid_decays(
     if first_championship_time_utc < cutoff_date:
         old_decay = max(0, consecutive_wins - 1) * cts.EMISSION_BOOST_DECAY_PER_WIN
         days_since_cutoff = (current_time_utc - cutoff_date).total_seconds() / cts.SECONDS_PER_DAY
-        new_decay = days_since_cutoff * daily_time_decay_rate
+        new_decay = emission_time_decay_fraction(days_since_cutoff)
 
         logger.debug(
             f"Pre-cutoff champion: old_decay={old_decay:.4f}, new_decay={new_decay:.4f}, will apply hybrid logic downstream"
@@ -185,7 +209,7 @@ def calculate_hybrid_decays(
     else:
         # Champion won AFTER cutoff - only new time-based decay
         days_as_champion = (current_time_utc - first_championship_time_utc).total_seconds() / cts.SECONDS_PER_DAY
-        new_decay = days_as_champion * daily_time_decay_rate
+        new_decay = emission_time_decay_fraction(days_as_champion)
         logger.debug(f"Post-cutoff champion: new_decay={new_decay:.4f} (reign={days_as_champion:.1f} days)")
         return (0.0, new_decay, False)
 
@@ -327,7 +351,7 @@ async def get_tournament_burn_details(psql_db) -> TournamentBurnData:
         first_win_tournament = await get_tournament_where_champion_first_won(psql_db, TournamentType.TEXT, text_champion_hotkey)
 
         text_old_decay, text_new_decay, apply_hybrid_to_text = calculate_hybrid_decays(
-            first_win_tournament.updated_at, text_consecutive_wins, cts.TOURNAMENT_TEXT_WEIGHT
+            first_win_tournament.updated_at, text_consecutive_wins
         )
         logger.info(
             f"Text champion {text_champion_hotkey[:8]}... has {text_consecutive_wins} consecutive wins, "
@@ -343,7 +367,7 @@ async def get_tournament_burn_details(psql_db) -> TournamentBurnData:
         first_win_tournament = await get_tournament_where_champion_first_won(psql_db, TournamentType.IMAGE, image_champion_hotkey)
 
         image_old_decay, image_new_decay, apply_hybrid_to_image = calculate_hybrid_decays(
-            first_win_tournament.updated_at, image_consecutive_wins, cts.TOURNAMENT_IMAGE_WEIGHT
+            first_win_tournament.updated_at, image_consecutive_wins
         )
         logger.info(
             f"Image champion {image_champion_hotkey[:8]}... has {image_consecutive_wins} consecutive wins, "
@@ -383,7 +407,7 @@ async def get_tournament_burn_details(psql_db) -> TournamentBurnData:
         )
 
         environment_old_decay, environment_new_decay, apply_hybrid_to_environment = calculate_hybrid_decays(
-            first_win_tournament.updated_at, environment_consecutive_wins, cts.TOURNAMENT_ENVIRONMENT_WEIGHT
+            first_win_tournament.updated_at, environment_consecutive_wins
         )
         logger.info(
             f"Environment champion {environment_champion_hotkey[:8]}... has {environment_consecutive_wins} consecutive wins, "

--- a/validator/tournament/performance_utils.py
+++ b/validator/tournament/performance_utils.py
@@ -137,6 +137,7 @@ async def calculate_tournament_projection(
             _, new_decay, _ = calculate_hybrid_decays(
                 first_win_tournament.updated_at,
                 consecutive_wins,
+                base_weight,
                 datetime.now(timezone.utc),
             )
             current_champion_decay = new_decay
@@ -181,8 +182,9 @@ async def calculate_tournament_projection(
         initial_weight = winner_share * raw_initial_weight * scale_factor
 
         projections = []
+        daily_time_decay_rate = base_weight / cts.TOURNAMENT_DECAY_PERIOD_DAYS
         for days in projection_days:
-            new_decay = days * cts.EMISSION_DAILY_TIME_DECAY_RATE
+            new_decay = days * daily_time_decay_rate
 
             raw_future_weight = calculate_tournament_weight_with_decay(
                 tournament_type=tournament_type,

--- a/validator/tournament/performance_utils.py
+++ b/validator/tournament/performance_utils.py
@@ -13,6 +13,7 @@ from validator.scoring.weights import calculate_emission_boost_from_perf
 from validator.scoring.weights import calculate_env_perf_diff_from_win_pct
 from validator.scoring.weights import calculate_hybrid_decays
 from validator.scoring.weights import calculate_tournament_weight_with_decay
+from validator.scoring.weights import emission_time_decay_fraction
 from validator.tournament.models import MinerEmissionWeight
 from validator.tournament.models import TournamentAuditData
 from validator.tournament.models import TournamentProjection
@@ -137,7 +138,6 @@ async def calculate_tournament_projection(
             _, new_decay, _ = calculate_hybrid_decays(
                 first_win_tournament.updated_at,
                 consecutive_wins,
-                base_weight,
                 datetime.now(timezone.utc),
             )
             current_champion_decay = new_decay
@@ -182,9 +182,8 @@ async def calculate_tournament_projection(
         initial_weight = winner_share * raw_initial_weight * scale_factor
 
         projections = []
-        daily_time_decay_rate = base_weight / cts.TOURNAMENT_DECAY_PERIOD_DAYS
         for days in projection_days:
-            new_decay = days * daily_time_decay_rate
+            new_decay = emission_time_decay_fraction(days)
 
             raw_future_weight = calculate_tournament_weight_with_decay(
                 tournament_type=tournament_type,


### PR DESCRIPTION
## What

Replace the single global `EMISSION_DAILY_TIME_DECAY_RATE` constant with a **per-tournament daily decay rate derived from each tournament's actual base weight**:

```
daily_rate = base_weight / TOURNAMENT_DECAY_PERIOD_DAYS   # period = 35
```

## Why

The time decay is an *absolute* subtraction from a champion's weight (`final = base + boost − days·rate`, `validator/scoring/weights.py`). With one flat rate, every tournament lost the same absolute amount per day — so smaller-base tournaments drained much faster:

| tournament | base | days-to-zero @ old flat 0.00165 |
|---|---|---|
| text | 0.40 | ~242 |
| image | 0.175 | ~106 |
| environment | 0.175 | ~106 |

Deriving the rate from the actual base weight equalizes the *horizon* instead of the per-day amount, so all three drain to zero over the same window:

| tournament | base | daily rate (base/35) | days-to-zero |
|---|---|---|---|
| text | 0.40 | 0.01143 | **35** |
| image | 0.175 | 0.00500 | **35** |
| environment | 0.175 | 0.00500 | **35** |

## Changes
- `constants.py`: drop `EMISSION_DAILY_TIME_DECAY_RATE`, add `TOURNAMENT_DECAY_PERIOD_DAYS = 35`.
- `weights.py`: `calculate_hybrid_decays` takes `base_weight` and computes `base_weight / TOURNAMENT_DECAY_PERIOD_DAYS`; the three call sites pass the respective base weight.
- `performance_utils.py`: projection path passes `base_weight` and uses the same derived rate.

## Notes
- The 35-day drain applies to the **base** component. In the post-cutoff regime an active innovation `emission_boost` sits on top (`base + boost − decay`), so a champion still holding boost retains that boost portion past day 35; the base reaches zero at 35 days.
- The standalone simulation in `tests/validator/tournament/test_hybrid_decay_system.py` keeps its own local copy of the function and does not import the source, so it is unaffected.