### PR TITLE
Switch model prep baselines to time-budgeted runs

### DIFF
--- a/core/constants/environments.py
+++ b/core/constants/environments.py
@@ -35,6 +35,8 @@ class EnvironmentConfig:
     task_id_min: int
     task_id_max: int
     num_seeds: int
+    # Retained for payload compatibility. Model-prep environment baselines run
+    # until the per-environment time budget expires.
     num_baseline_episodes: int
     eval_type: EvalType
     env_image: str = ""
@@ -54,7 +56,7 @@ ENVIRONMENT_CONFIGS: dict[EnvironmentName, EnvironmentConfig] = {
         task_id_min=200_000_000,
         task_id_max=299_999_999,
         num_seeds=2000,
-        num_baseline_episodes=50,
+        num_baseline_episodes=0,
         eval_type=EvalType.PVP,
         env_image=MCTS_API_DOCKER_IMAGE,
         tournament_eval_image=VALIDATOR_DOCKER_IMAGE_PVP,
@@ -70,7 +72,7 @@ ENVIRONMENT_CONFIGS: dict[EnvironmentName, EnvironmentConfig] = {
         task_id_min=100_000_000,
         task_id_max=199_999_999,
         num_seeds=10_000,
-        num_baseline_episodes=50,
+        num_baseline_episodes=0,
         eval_type=EvalType.PVP,
         env_image=MCTS_API_DOCKER_IMAGE,
         tournament_eval_image=VALIDATOR_DOCKER_IMAGE_PVP,
@@ -86,7 +88,7 @@ ENVIRONMENT_CONFIGS: dict[EnvironmentName, EnvironmentConfig] = {
         task_id_min=300_000_000,
         task_id_max=399_999_999,
         num_seeds=1000,
-        num_baseline_episodes=25,
+        num_baseline_episodes=0,
         eval_type=EvalType.PVP,
         env_image=MCTS_API_DOCKER_IMAGE,
         tournament_eval_image=VALIDATOR_DOCKER_IMAGE_PVP,
@@ -102,7 +104,7 @@ ENVIRONMENT_CONFIGS: dict[EnvironmentName, EnvironmentConfig] = {
         task_id_min=400_000_000,
         task_id_max=499_999_999,
         num_seeds=10_000,
-        num_baseline_episodes=25,
+        num_baseline_episodes=0,
         eval_type=EvalType.PVP,
         env_image=MCTS_API_DOCKER_IMAGE,
         tournament_eval_image=VALIDATOR_DOCKER_IMAGE_PVP,
@@ -118,7 +120,7 @@ ENVIRONMENT_CONFIGS: dict[EnvironmentName, EnvironmentConfig] = {
         task_id_min=700_000_000,
         task_id_max=799_999_999,
         num_seeds=10_000,
-        num_baseline_episodes=25,
+        num_baseline_episodes=0,
         eval_type=EvalType.PVP,
         env_image=MCTS_API_DOCKER_IMAGE,
         tournament_eval_image=VALIDATOR_DOCKER_IMAGE_PVP,
@@ -134,7 +136,7 @@ ENVIRONMENT_CONFIGS: dict[EnvironmentName, EnvironmentConfig] = {
         task_id_min=0,
         task_id_max=99_999_999,
         num_seeds=10_000,
-        num_baseline_episodes=25,
+        num_baseline_episodes=0,
         eval_type=EvalType.PVP,
         env_image=MCTS_API_DOCKER_IMAGE,
         tournament_eval_image=VALIDATOR_DOCKER_IMAGE_PVP,
@@ -150,7 +152,7 @@ ENVIRONMENT_CONFIGS: dict[EnvironmentName, EnvironmentConfig] = {
         task_id_min=1,
         task_id_max=200,
         num_seeds=20,
-        num_baseline_episodes=7,
+        num_baseline_episodes=0,
         eval_type=EvalType.INDIVIDUAL,
         env_image=VALIDATOR_DOCKER_IMAGE_INTERCODE,
         env_server_command=[

--- a/core/models/model_prep_models.py
+++ b/core/models/model_prep_models.py
@@ -180,6 +180,8 @@ class EnvBaselineConfig(BaseModel):
     """Per-environment baseline config passed into the model prep container.
 
     url is the env server sidecar; None for envs baselined in-harness.
+    num_episodes is retained for compatibility; environment baselines use a
+    model-prep time budget.
     """
 
     url: str | None = None

--- a/core/models/payload_models.py
+++ b/core/models/payload_models.py
@@ -140,7 +140,11 @@ class TrainingRepoResponse(BaseModel):
 
 
 class EnvConfig(BaseModel):
-    """Per-environment config for model prep evaluation."""
+    """Per-environment config for model prep evaluation.
+
+    num_episodes is retained for compatibility; environment baselines are time-budgeted.
+    """
+
     env_image: str
     env_server_command: list[str] | None = None
     task_id_min: int

--- a/core/pvp/baseline.py
+++ b/core/pvp/baseline.py
@@ -81,23 +81,27 @@ def run_mcts_baseline(
     env_name: EnvironmentName,
     chat_fn: ChatFn,
     config: ChatCompletionConfig,
-    num_games: int,
+    num_games: int | None,
     mcts_simulations: int | None = None,
     base_seed: int = 0,
     time_budget_seconds: float | None = None,
 ) -> MctsBaselineResult:
-    """Play num_games of env_name as the model (LLMBot) vs MCTS; return outcome counts.
+    """Play env_name as the model (LLMBot) vs MCTS; return outcome counts.
 
     The model alternates seats for fairness and carries one long-term memory across
     the games (it builds a read on the MCTS opponent, exactly as in a real matchup).
     A model-side forfeit (timeout, repeated illegal moves, context overflow) scores
     as a loss, mirroring eval.
 
+    num_games can be None when the caller wants a purely time-budgeted run.
     time_budget_seconds bounds wall-clock: no new game starts past the deadline
     and the partial tally is returned — a baseline over fewer games beats blowing
     the caller's dispatch timeout. The turn alarm bounds a single turn, not a
     game, so slow models need this outer guard.
     """
+    if num_games is None and time_budget_seconds is None:
+        raise ValueError("run_mcts_baseline requires num_games or time_budget_seconds")
+
     agent = _AGENT_REGISTRY[env_name]()
     env_config = ENVIRONMENT_CONFIGS[env_name]
     simulations = mcts_simulations if mcts_simulations is not None else _mcts_simulations_for(env_name)
@@ -108,11 +112,13 @@ def run_mcts_baseline(
     result = MctsBaselineResult()
     started = time.monotonic()
 
-    for i in range(num_games):
+    i = 0
+    while num_games is None or i < num_games:
         if time_budget_seconds is not None and time.monotonic() - started >= time_budget_seconds:
+            target_games = "time-budgeted" if num_games is None else str(num_games)
             logger.warning(
-                "%s baseline time budget (%.0fs) exhausted after %d/%d games; returning partial tally",
-                env_name.value, time_budget_seconds, result.num_games, num_games,
+                "%s baseline time budget (%.0fs) exhausted after %d/%s games; returning partial tally",
+                env_name.value, time_budget_seconds, result.num_games, target_games,
             )
             break
         seed = seed_rng.randint(1, cst.PVP_SEED_RANGE_MAX)
@@ -159,6 +165,8 @@ def run_mcts_baseline(
         # would just hit the same wall — skip it.
         if evaluation.forfeiting_player_id != model_seat:
             model_bot.reflect(state, outcome)
+
+        i += 1
 
     logger.info(
         "%s MCTS baseline: %d games, %d-%d-%d (W-D-L), score=%.3f",

--- a/ops/tools/trainer/model_prep_env_smoke.py
+++ b/ops/tools/trainer/model_prep_env_smoke.py
@@ -85,7 +85,8 @@ def print_env_plan(env_configs: dict[EnvironmentName, EnvConfig]) -> None:
     for env_name, cfg in env_configs.items():
         print(
             f"- {env_name.value}: image={cfg.env_image}, "
-            f"task_ids={cfg.task_id_min}-{cfg.task_id_max}, episodes={cfg.num_episodes}"
+            f"task_ids={cfg.task_id_min}-{cfg.task_id_max}, "
+            "baseline=time-budgeted (MODEL_PREP_ENV_TIME_BUDGET_SECONDS, default 420s)"
         )
         if cfg.env_server_command:
             print(f"  command={' '.join(cfg.env_server_command)}")
@@ -122,12 +123,12 @@ def parse_args() -> argparse.Namespace:
         "--episodes",
         type=positive_int,
         default=1,
-        help="Override baseline episodes per environment. Default: 1.",
+        help="Compatibility override for legacy baseline episode payloads. Time-budgeted baselines ignore this. Default: 1.",
     )
     parser.add_argument(
         "--use-default-episodes",
         action="store_true",
-        help="Use the canonical episode counts instead of --episodes.",
+        help="Use canonical compatibility episode counts instead of --episodes.",
     )
     parser.add_argument("--gpu-ids", type=parse_gpu_ids, default=parse_gpu_ids("0"), help="Comma-separated GPU IDs.")
     parser.add_argument("--task-id", default=None, help="Optional task id for cache paths/container names.")

--- a/tests/trainer/model_prep/test_env_stats.py
+++ b/tests/trainer/model_prep/test_env_stats.py
@@ -2,10 +2,15 @@ import asyncio
 
 import pytest
 
+
+pytest.importorskip("pyspiel")
+pytest.importorskip("open_spiel")
+
 from core.constants.environments import EnvironmentName
 from core.models.model_prep_models import EnvBaselineConfig
 from core.models.model_prep_models import EnvStats
 from core.models.model_prep_models import WeightStats
+from core.pvp.baseline import MctsBaselineResult
 from trainer.model_prep import env_stats
 
 
@@ -60,14 +65,18 @@ class _FakeSession:
 
 
 @pytest.mark.asyncio
-async def test_play_episodes_reports_sidecar_result_errors(capsys):
+async def test_play_episodes_reports_sidecar_result_errors(monkeypatch, capsys):
+    ticks = iter([0.0, 0.0, 2.0])
+
+    monkeypatch.setattr(env_stats.time, "monotonic", lambda: next(ticks))
+    monkeypatch.setattr(env_stats, "ENV_BASELINE_TIME_BUDGET_SECONDS", 1.0)
+
     stats = await env_stats._play_episodes(
         session=_FakeSession(),
         env_name=EnvironmentName.INTERCODE,
         env_server_url="http://env-server",
         sglang_base_url="http://sglang/v1",
         model_name="model",
-        num_episodes=1,
         task_id_min=1,
         task_id_max=1,
         eval_payload_extra=None,
@@ -81,18 +90,46 @@ async def test_play_episodes_reports_sidecar_result_errors(capsys):
     assert "TimeoutError" in captured.out
 
 
+def test_mcts_baseline_stats_uses_time_budget_instead_of_episode_count(monkeypatch):
+    captured = {}
+
+    def fake_run_mcts_baseline(**kwargs):
+        captured.update(kwargs)
+        return MctsBaselineResult(wins=2, draws=1, losses=1, num_games=4)
+
+    monkeypatch.setattr(env_stats, "create_client", lambda config: object())
+    monkeypatch.setattr(env_stats, "run_mcts_baseline", fake_run_mcts_baseline)
+    monkeypatch.setattr(env_stats, "ENV_BASELINE_TIME_BUDGET_SECONDS", 420.0)
+
+    stats = env_stats._mcts_baseline_stats(
+        env_name=EnvironmentName.LIARS_DICE,
+        sglang_base_url="http://sglang/v1",
+        model_name="model",
+        model_path="/cache/models/model",
+        eval_payload_extra={"mcts_max_simulations": 225},
+    )
+
+    assert captured["num_games"] is None
+    assert captured["time_budget_seconds"] == 420.0
+    assert captured["mcts_simulations"] == 225
+    assert stats.num_episodes == 4
+    assert stats.mean_score == 0.625
+
+
 def test_compute_env_stats_routes_games_in_harness_and_others_to_sidecar(monkeypatch):
     """Pyspiel games use in-harness MCTS; intercode uses its env sidecar."""
     calls: dict[str, list[EnvironmentName]] = {"mcts": [], "http": []}
 
     def fake_mcts_baseline_stats(*, env_name, **kwargs):
+        assert "num_episodes" not in kwargs
         calls["mcts"].append(env_name)
-        return EnvStats(num_episodes=kwargs["num_episodes"], mean_score=1.0)
+        return EnvStats(num_episodes=11, mean_score=1.0)
 
     async def fake_play_episodes(*, env_name, env_server_url, **kwargs):
         assert env_server_url == "http://10.0.0.42:8000"
+        assert "num_episodes" not in kwargs
         calls["http"].append(env_name)
-        return EnvStats(num_episodes=kwargs["num_episodes"], mean_score=0.5)
+        return EnvStats(num_episodes=13, mean_score=0.5)
 
     async def fake_wait_for_health(*args, **kwargs):
         return None
@@ -116,8 +153,8 @@ def test_compute_env_stats_routes_games_in_harness_and_others_to_sidecar(monkeyp
 
     assert calls["mcts"] == [EnvironmentName.OTHELLO]
     assert calls["http"] == [EnvironmentName.INTERCODE]
-    assert result.env_stats[EnvironmentName.OTHELLO].num_episodes == 3
-    assert result.env_stats[EnvironmentName.INTERCODE].num_episodes == 7
+    assert result.env_stats[EnvironmentName.OTHELLO].num_episodes == 11
+    assert result.env_stats[EnvironmentName.INTERCODE].num_episodes == 13
 
 
 def test_compute_env_stats_one_env_failing_degrades_to_empty_stats(monkeypatch):
@@ -127,7 +164,8 @@ def test_compute_env_stats_one_env_failing_degrades_to_empty_stats(monkeypatch):
         raise RuntimeError("sglang returned 400")
 
     async def fake_play_episodes(*, env_name, **kwargs):
-        return EnvStats(num_episodes=kwargs["num_episodes"], mean_score=0.5)
+        assert "num_episodes" not in kwargs
+        return EnvStats(num_episodes=13, mean_score=0.5)
 
     async def fake_wait_for_health(*args, **kwargs):
         return None
@@ -150,4 +188,4 @@ def test_compute_env_stats_one_env_failing_degrades_to_empty_stats(monkeypatch):
     result = asyncio.run(env_stats.compute_env_stats("/cache/models/m", model=object(), env_configs=env_configs))
 
     assert result.env_stats[EnvironmentName.OTHELLO].num_episodes == 0
-    assert result.env_stats[EnvironmentName.INTERCODE].num_episodes == 7
+    assert result.env_stats[EnvironmentName.INTERCODE].num_episodes == 13

--- a/tests/trainer/model_prep/test_intercode_sidecar.py
+++ b/tests/trainer/model_prep/test_intercode_sidecar.py
@@ -40,6 +40,14 @@ def test_model_prep_configs_include_intercode_sidecar():
     ]
 
 
+def test_model_prep_configs_are_time_budgeted_not_fixed_counts():
+    configs = _build_env_configs()
+
+    assert configs[EnvironmentName.LIARS_DICE].num_episodes == 0
+    assert configs[EnvironmentName.GIN_RUMMY].num_episodes == 0
+    assert configs[EnvironmentName.INTERCODE].num_episodes == 0
+
+
 def test_intercode_sidecar_formats_empty_exceptions(monkeypatch):
     fake_eval_intercode = types.ModuleType("validator.evaluation.evaluators.intercode")
     fake_eval_intercode.DEFAULT_MAX_TOKENS_PER_CALL = 512
@@ -154,6 +162,9 @@ def test_start_env_sidecars_failure_degrades_instead_of_raising(monkeypatch):
 
 
 def test_in_harness_envs_match_agent_registry():
+    pytest.importorskip("pyspiel")
+    pytest.importorskip("open_spiel")
+
     from core.constants.environments import ENVIRONMENT_CONFIGS
     from core.constants.environments import EvalType
     from core.pvp.game_eval import _AGENT_REGISTRY

--- a/trainer/model_prep/README.md
+++ b/trainer/model_prep/README.md
@@ -9,3 +9,7 @@ Model preparation and baseline-stat routines used before selected training jobs.
 - `env_stats.py`: environment-task baseline and sidecar stats collection.
 - `stats.py`: general model and dataset statistics collection.
 - `__init__.py`: package marker.
+
+Environment baselines run until `MODEL_PREP_ENV_TIME_BUDGET_SECONDS` expires, defaulting
+to 420 seconds per environment. PvP game baselines run in-harness; individual environments
+run through their sidecar.

--- a/trainer/model_prep/entrypoint.py
+++ b/trainer/model_prep/entrypoint.py
@@ -154,7 +154,8 @@ def parse_args():
         default=None,
         help=(
             "JSON dict of {env_name: {url, task_id_min, task_id_max, "
-            "num_episodes, eval_payload_extra}}"
+            "num_episodes, eval_payload_extra}}. num_episodes is retained for compatibility; "
+            "environment baselines are time-budgeted."
         ),
     )
     return parser.parse_args()

--- a/trainer/model_prep/env_stats.py
+++ b/trainer/model_prep/env_stats.py
@@ -44,10 +44,10 @@ SGLANG_HEALTH_TIMEOUT = 600
 ENV_EVAL_TEMPERATURE = 0.0
 ENV_EVAL_TASK_TIMEOUT = 150
 CONSECUTIVE_FAILURE_LIMIT = 5
-# Per-env wall-clock budget for the in-harness baseline (soft cap: checked
-# between games, so an in-flight game can overshoot). Overrun returns a partial
-# tally instead of blowing the validator's dispatch timeout.
-ENV_BASELINE_TIME_BUDGET_SECONDS = float(os.getenv("MODEL_PREP_ENV_TIME_BUDGET_SECONDS", "540"))
+# Per-env wall-clock budget for environment baselines (soft cap: checked
+# between games/episodes, so an in-flight run can overshoot). Overrun returns
+# a partial tally instead of blowing the validator's dispatch timeout.
+ENV_BASELINE_TIME_BUDGET_SECONDS = float(os.getenv("MODEL_PREP_ENV_TIME_BUDGET_SECONDS", "420"))
 
 
 # --- SGLang process management (from eval_environment.py) ---
@@ -176,12 +176,11 @@ async def _play_episodes(
     env_server_url: str,
     sglang_base_url: str,
     model_name: str,
-    num_episodes: int,
     task_id_min: int,
     task_id_max: int,
     eval_payload_extra: dict | None,
 ) -> EnvStats:
-    """Play episodes against an env server sidecar and return summary stats.
+    """Play episodes against an env server sidecar until the time budget expires.
 
     Stops early if CONSECUTIVE_FAILURE_LIMIT episodes fail in a row — the
     remaining episodes would almost certainly fail too (model hallucinating,
@@ -190,10 +189,16 @@ async def _play_episodes(
     seed_rng = random.Random(42)
     scores: list[float] = []
     consecutive_failures = 0
+    started = time.monotonic()
 
-    print(f"  {env_name.value}: playing {num_episodes} episodes...", flush=True)
+    print(
+        f"  {env_name.value}: playing episodes for up to "
+        f"{ENV_BASELINE_TIME_BUDGET_SECONDS / 60:.1f} minutes...",
+        flush=True,
+    )
 
-    for i in range(num_episodes):
+    i = 0
+    while time.monotonic() - started < ENV_BASELINE_TIME_BUDGET_SECONDS:
         seed = seed_rng.randint(1, 1_000_000)
         task_id = _sample_task_id(seed, task_id_min, task_id_max)
 
@@ -245,12 +250,14 @@ async def _play_episodes(
             if consecutive_failures >= CONSECUTIVE_FAILURE_LIMIT:
                 print(
                     f"  {env_name.value}: {CONSECUTIVE_FAILURE_LIMIT} consecutive failures, "
-                    f"stopping early at episode {i+1}/{num_episodes}",
+                    f"stopping early after {i+1} episodes",
                     flush=True,
                 )
                 break
         else:
             consecutive_failures = 0
+
+        i += 1
 
     stats = _build_env_stats(scores)
     print(f"  {env_name.value}: {stats.num_episodes} episodes, mean={stats.mean_score:.3f}", flush=True)
@@ -262,10 +269,9 @@ def _mcts_baseline_stats(
     sglang_base_url: str,
     model_name: str,
     model_path: str,
-    num_episodes: int,
     eval_payload_extra: dict | None,
 ) -> EnvStats:
-    """Play num_episodes baseline games of the model vs in-harness MCTS."""
+    """Play baseline games of the model vs in-harness MCTS until the time budget expires."""
     extra = eval_payload_extra or {}
     mcts_simulations = extra.get("mcts_max_simulations")
 
@@ -280,12 +286,16 @@ def _mcts_baseline_stats(
     client = create_client(config)
     chat_fn = functools.partial(chat_completion, client)
 
-    print(f"  {env_name.value}: playing {num_episodes} games vs MCTS...", flush=True)
+    print(
+        f"  {env_name.value}: playing games vs MCTS for up to "
+        f"{ENV_BASELINE_TIME_BUDGET_SECONDS / 60:.1f} minutes...",
+        flush=True,
+    )
     result = run_mcts_baseline(
         env_name=env_name,
         chat_fn=chat_fn,
         config=config,
-        num_games=num_episodes,
+        num_games=None,
         mcts_simulations=mcts_simulations,
         time_budget_seconds=ENV_BASELINE_TIME_BUDGET_SECONDS,
     )
@@ -340,7 +350,6 @@ async def compute_env_stats(
                             sglang_base_url=sglang_base_url,
                             model_name=model_name,
                             model_path=model_path,
-                            num_episodes=cfg.num_episodes,
                             eval_payload_extra=cfg.eval_payload_extra,
                         )
                     elif cfg.url:
@@ -350,7 +359,6 @@ async def compute_env_stats(
                             env_server_url=cfg.url,
                             sglang_base_url=sglang_base_url,
                             model_name=model_name,
-                            num_episodes=cfg.num_episodes,
                             task_id_min=cfg.task_id_min,
                             task_id_max=cfg.task_id_max,
                             eval_payload_extra=cfg.eval_payload_extra,


### PR DESCRIPTION
Change environment model-prep baseline stats from fixed episode/game counts to a per-environment wall-clock budget.

Default baseline budget is now 7 minutes via MODEL_PREP_ENV_TIME_BUDGET_SECONDS=420.

Apply the budget to both in-harness PvP game baselines and individual sidecar envs like InterCode.

Retain num_episodes fields only for payload compatibility, with canonical env baseline counts set to 0.

Update model-prep docs, CLI help, smoke-test output, and focused tests for the new time-budgeted behavior.