### PR TITLE
Restore t_cst import in performance_utils (weight-projection 500s)

### DIFF
--- a/validator/tournament/performance_utils.py
+++ b/validator/tournament/performance_utils.py
@@ -14,6 +14,7 @@ from validator.scoring.weights import calculate_env_perf_diff_from_win_pct
 from validator.scoring.weights import calculate_hybrid_decays
 from validator.scoring.weights import calculate_tournament_weight_with_decay
 from validator.scoring.weights import emission_time_decay_fraction
+from validator.tournament import constants as t_cst
 from validator.tournament.models import MinerEmissionWeight
 from validator.tournament.models import TournamentAuditData
 from validator.tournament.models import TournamentProjection


### PR DESCRIPTION
#1268 replaced the `from validator.tournament import constants as t_cst` import line instead of keeping it, but `t_cst.BOSS_ROUND_WIN_MARGIN` is still used in `calculate_tournament_projection` (performance_utils.py:153). Result: NameError at runtime → `/v1/performance/weight-projection` and `/v1/performance/weight-projection-static` return 500 on prod, which is why the miner emission calculator disappeared from the dashboard.

One-line fix: re-add the import. Verified locally — module imports cleanly and the 26 decay/perf tests pass.