### PR TITLE
Integrate decay curve for projection cumulative alpha

### DIFF
--- a/tests/validator/tournament/test_projection_alpha.py
+++ b/tests/validator/tournament/test_projection_alpha.py
@@ -1,0 +1,66 @@
+"""Cumulative-alpha projections must integrate the piecewise decay curve.
+
+The old trapezoid between day 0 and the horizon kept accruing alpha long after
+the champion's weight hit the curve's zero-cliff (day 40), overstating 90/180
+day totals several-fold.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+import validator.scoring.constants as cts
+from validator.scoring.weights import emission_time_retention
+from validator.tournament.models import TournamentType
+from validator.tournament.performance_utils import calculate_tournament_projection
+
+
+DECAY_ZERO_DAY = cts.EMISSION_TIME_DECAY_CURVE[-1][0]
+
+
+async def project(percentage_improvement: float = 10.0):
+    with (
+        patch("validator.tournament.performance_utils.get_latest_completed_tournament", return_value=None),
+        patch("validator.tournament.performance_utils.get_active_tournament_participants", return_value=[]),
+    ):
+        return await calculate_tournament_projection(
+            psql_db=None,
+            tournament_type=TournamentType.TEXT,
+            percentage_improvement=percentage_improvement,
+            base_weight=cts.TOURNAMENT_TEXT_WEIGHT,
+            max_weight=cts.MAX_TEXT_TOURNAMENT_WEIGHT,
+        )
+
+
+@pytest.mark.asyncio
+async def test_no_alpha_accrues_after_decay_cliff():
+    projection = await project()
+    by_days = {p.days: p for p in projection.projections}
+
+    assert by_days[90].weight == 0.0
+    assert by_days[180].weight == 0.0
+    # Weight is zero from day 40 on, so the 90 and 180 day totals must be equal.
+    assert by_days[90].total_alpha == pytest.approx(by_days[180].total_alpha)
+    assert by_days[90].total_alpha > by_days[30].total_alpha
+
+
+@pytest.mark.asyncio
+async def test_total_alpha_matches_curve_integral():
+    projection = await project()
+    by_days = {p.days: p for p in projection.projections}
+
+    initial_weight = projection.initial_weight
+    # Analytic area under the retention curve up to the zero-cliff, in weight-days.
+    curve = cts.EMISSION_TIME_DECAY_CURVE
+    area = sum((d1 - d0) * (r0 + r1) / 2.0 for (d0, r0), (d1, r1) in zip(curve, curve[1:]))
+    expected = initial_weight * area * cts.DAILY_ALPHA_TO_MINERS
+
+    assert by_days[180].total_alpha == pytest.approx(expected, rel=1e-6)
+
+
+@pytest.mark.asyncio
+async def test_day7_weight_still_matches_retention_curve():
+    projection = await project()
+    by_days = {p.days: p for p in projection.projections}
+
+    assert by_days[7].weight == pytest.approx(projection.initial_weight * emission_time_retention(7.0))

--- a/validator/tournament/performance_utils.py
+++ b/validator/tournament/performance_utils.py
@@ -182,22 +182,31 @@ async def calculate_tournament_projection(
         # Winner's actual emission weight = winner_share * tournament_weight * scale_factor
         initial_weight = winner_share * raw_initial_weight * scale_factor
 
-        projections = []
-        for days in projection_days:
-            new_decay = emission_time_decay_fraction(days)
-
-            raw_future_weight = calculate_tournament_weight_with_decay(
+        def weight_on_day(day: int) -> float:
+            raw_weight = calculate_tournament_weight_with_decay(
                 tournament_type=tournament_type,
                 base_weight=base_weight,
                 emission_boost=emission_boost,
                 old_decay=0.0,
-                new_decay=new_decay,
+                new_decay=emission_time_decay_fraction(day),
                 apply_hybrid=False,
                 max_weight=max_weight,
             )
+            return winner_share * raw_weight * scale_factor
 
-            weight = winner_share * raw_future_weight * scale_factor
-            cumulative_alpha = days * cts.DAILY_ALPHA_TO_MINERS * (initial_weight + weight) / 2.0
+        # Cumulative alpha must integrate the piecewise decay curve, not interpolate
+        # linearly between day 0 and the horizon: the weight hits zero at the curve's
+        # cliff, after which no further alpha accrues.
+        max_days = max(projection_days)
+        daily_weights = [weight_on_day(day) for day in range(max_days + 1)]
+        cumulative_weight_days = [0.0]
+        for day in range(1, max_days + 1):
+            cumulative_weight_days.append(cumulative_weight_days[-1] + (daily_weights[day - 1] + daily_weights[day]) / 2.0)
+
+        projections = []
+        for days in projection_days:
+            weight = daily_weights[days]
+            cumulative_alpha = cts.DAILY_ALPHA_TO_MINERS * cumulative_weight_days[days]
 
             projections.append(WeightProjection(days=days, weight=weight, total_alpha=cumulative_alpha))
 


### PR DESCRIPTION
The weight-projection endpoint estimated total_alpha with a trapezoid between day 0 and the horizon, which assumes linear decline. With the piecewise retention curve (zero at day 40) this kept accruing alpha long after the champion's weight hit zero, overstating 90-day totals ~3x and 180-day totals ~5.6x. Integrate day-by-day under the actual decayed weight instead, so totals plateau once the curve reaches zero.