### PR TITLE
Cut off runner-up projection at next tournament

### DIFF
--- a/tests/validator/tournament/test_projection_alpha.py
+++ b/tests/validator/tournament/test_projection_alpha.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import pytest
 
 import validator.scoring.constants as cts
+import validator.tournament.constants as t_cst
 from validator.scoring.weights import emission_time_retention
 from validator.tournament.models import TournamentType
 from validator.tournament.performance_utils import calculate_tournament_projection
@@ -56,6 +57,21 @@ async def test_total_alpha_matches_curve_integral():
     expected = initial_weight * area * cts.DAILY_ALPHA_TO_MINERS
 
     assert by_days[180].total_alpha == pytest.approx(expected, rel=1e-6)
+
+
+@pytest.mark.asyncio
+async def test_runner_up_earns_only_until_next_tournament():
+    # 0.5% improvement is below the 1% dethrone margin: boss defends, challenger is runner-up.
+    projection = await project(percentage_improvement=0.5)
+    assert projection.placement == "runner_up"
+    by_days = {p.days: p for p in projection.projections}
+
+    cutoff_alpha = t_cst.RUNNER_UP_EMISSION_DAYS * cts.DAILY_ALPHA_TO_MINERS * projection.initial_weight
+    assert by_days[7].weight == pytest.approx(projection.initial_weight)
+    assert by_days[7].total_alpha == pytest.approx(cutoff_alpha)
+    for days in (30, 90, 180):
+        assert by_days[days].weight == 0.0
+        assert by_days[days].total_alpha == pytest.approx(cutoff_alpha)
 
 
 @pytest.mark.asyncio

--- a/validator/tournament/constants.py
+++ b/validator/tournament/constants.py
@@ -7,6 +7,10 @@ from core.models.task_models import TaskType
 
 TOURNAMENT_INTERVAL_HOURS = 120
 
+# A runner-up holds their base-pool share only until the next tournament's
+# results replace the standings: one interval plus roughly the run itself.
+RUNNER_UP_EMISSION_DAYS = 7
+
 # Tournament scheduling settings
 TOURNAMENT_SCHEDULE_ENVIRONMENT_DAY_OF_WEEK = 0
 TOURNAMENT_SCHEDULE_ENVIRONMENT_HOUR = 11

--- a/validator/tournament/performance_utils.py
+++ b/validator/tournament/performance_utils.py
@@ -124,7 +124,8 @@ async def calculate_tournament_projection(
 
     A challenger only becomes champion if they exceed the dethrone threshold;
     below it the boss defends and the challenger projects as the 2nd-place
-    runner-up (base-pool share, no champion boost, no time decay).
+    runner-up (base-pool share, no champion boost, earning only until the next
+    tournament's results replace the standings).
     """
     latest_tournament = await get_latest_completed_tournament(psql_db, tournament_type)
     current_champion = get_real_tournament_winner(latest_tournament) if latest_tournament else None
@@ -213,7 +214,8 @@ async def calculate_tournament_projection(
         placement = "champion"
     else:
         # Below the dethrone threshold the boss defends; the challenger places 2nd
-        # and earns the runner-up share of the base pool (no champion boost, no decay).
+        # and earns the runner-up share of the base pool (no champion boost) only
+        # until the next tournament's results replace the standings.
         emission_boost = 0.0
         runner_up_share = exponential_decline_mapping(max(num_participants, 1), 2)
         runner_up_weight = runner_up_share * base_weight * scale_factor
@@ -222,8 +224,8 @@ async def calculate_tournament_projection(
         projections = [
             WeightProjection(
                 days=days,
-                weight=runner_up_weight,
-                total_alpha=days * cts.DAILY_ALPHA_TO_MINERS * runner_up_weight,
+                weight=runner_up_weight if days <= t_cst.RUNNER_UP_EMISSION_DAYS else 0.0,
+                total_alpha=min(days, t_cst.RUNNER_UP_EMISSION_DAYS) * cts.DAILY_ALPHA_TO_MINERS * runner_up_weight,
             )
             for days in projection_days
         ]


### PR DESCRIPTION
The runner-up branch of the weight projection paid the flat 2nd-place weight out to every horizon (180-day total = 26x the realistic figure). In reality a runner-up only earns their base-pool share until the next tournament's results replace the standings — roughly one interval (120h) plus the run itself.

Cap runner-up alpha accrual at `RUNNER_UP_EMISSION_DAYS` (7) and report zero weight beyond it, so all horizons past the first week show the same week-one total. Champion-path projections are untouched.