### PR TITLE
model-prep: normalize extra_special_tokens list → dict before publish

### DIFF
--- a/trainer/model_prep/entrypoint.py
+++ b/trainer/model_prep/entrypoint.py
@@ -222,28 +222,43 @@ def load_training_data(path: str) -> list[dict]:
 
 
 def sanitize_tokenizer_config(out_dir: str) -> None:
-    """Rewrite the tokenizer_class that transformers 5 leaks into tokenizer_config.json.
+    """Undo transformers-5 serialization quirks in tokenizer_config.json before publish.
 
     save_pretrained under transformers>=5 writes tokenizer_class="TokenizersBackend" — an internal
     backend marker, not a registered class — so any consumer's AutoTokenizer.from_pretrained crashes
     with "Tokenizer class TokenizersBackend does not exist". Rewrite it to PreTrainedTokenizerFast
     when the serialized tokenizer.json is present (loadable on transformers 4 and 5 alike), else drop
     the key so AutoTokenizer falls back to autodetection.
+
+    It also writes extra_special_tokens as a list of token strings (e.g. Qwen2's im_start/im_end),
+    where transformers 4 requires a dict of {name: token} and calls .keys() on it — downstream
+    training on the augmented model crashes (or dies trying to rewrite the read-only model cache).
+    Normalize list → dict.
     """
     config_path = os.path.join(out_dir, "tokenizer_config.json")
     if not os.path.exists(config_path):
         return
     with open(config_path) as f:
         config = json.load(f)
-    if config.get("tokenizer_class") != "TokenizersBackend":
-        return
-    if os.path.exists(os.path.join(out_dir, "tokenizer.json")):
-        config["tokenizer_class"] = "PreTrainedTokenizerFast"
-    else:
-        del config["tokenizer_class"]
-    with open(config_path, "w") as f:
-        json.dump(config, f, indent=2)
-    print(f"[model_prep] Sanitized TokenizersBackend tokenizer_class in {config_path}", flush=True)
+    changed = False
+
+    if config.get("tokenizer_class") == "TokenizersBackend":
+        if os.path.exists(os.path.join(out_dir, "tokenizer.json")):
+            config["tokenizer_class"] = "PreTrainedTokenizerFast"
+        else:
+            del config["tokenizer_class"]
+        changed = True
+        print(f"[model_prep] Sanitized TokenizersBackend tokenizer_class in {config_path}", flush=True)
+
+    extra_special_tokens = config.get("extra_special_tokens")
+    if isinstance(extra_special_tokens, list):
+        config["extra_special_tokens"] = {token: token for token in extra_special_tokens if isinstance(token, str)}
+        changed = True
+        print(f"[model_prep] Normalized extra_special_tokens list → dict in {config_path}", flush=True)
+
+    if changed:
+        with open(config_path, "w") as f:
+            json.dump(config, f, indent=2)
 
 
 def upload_augmented_model(model, tokenizer, repo_id: str, hf_token: str) -> None:


### PR DESCRIPTION
## Bug

Augmented models published by model-prep (e.g. `augmented-6bb78db2915f5c9e` from Qwen/Qwen2-1.5B) carry a malformed `tokenizer_config.json`: `extra_special_tokens` serialized as a **list** of token strings instead of a dict of `{name: token}`.

transformers 5 `save_pretrained` (axolotl base in `ops/docker/model-prep-text.dockerfile`) writes the list form; transformers 4 consumers call `.keys()` on it and crash. The miner-side `fix_tokenizer_config()` detects the list and tries to rewrite the file in place, but the model cache is a read-only mount in the training container:

```
OSError: [Errno 30] Read-only file system
```

→ training aborts → no checkpoint → HF upload fails → task failure. Affects Qwen tokenizers (Qwen2-1.5B, Qwen2.5-0.5B); tokenizers without `extra_special_tokens` are unaffected.

## Fix

Fold list→dict normalization into `sanitize_tokenizer_config()` (#1276), which already runs on every published tokenizer folder (augmented upload + local LoRA merge_dir) — previously it early-returned unless `tokenizer_class == "TokenizersBackend"`, so the extra_special_tokens fix now runs unconditionally.

## Verification (run, not just typechecked)

- Saved Qwen/Qwen2-1.5B and Qwen/Qwen2.5-0.5B tokenizers under **transformers 5.12.1** — reproduces `extra_special_tokens` as a list on both.
- Ran `sanitize_tokenizer_config()` on the saved dirs — asserted `extra_special_tokens` is a dict.
- Reloaded via `AutoTokenizer.from_pretrained` on transformers **5.12.1** and **4.57.6**: loads clean on both.
- Ran the miner's `fix_tokenizer_config()` (sn56-text `scripts/model_utility.py`) against the sanitized dirs: returns False — no read-only-filesystem rewrite triggered.