### PR TITLE
model-prep-env: install fiber + docker; guard docker import in core/l…

### DIFF
--- a/core/logging.py
+++ b/core/logging.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import logging
 import os
@@ -6,10 +8,14 @@ import time
 from contextvars import ContextVar
 from logging import Logger
 from logging import LogRecord
+from typing import TYPE_CHECKING
 
 import requests
-from docker.models.containers import Container
 from fiber.logging_utils import get_logger as fiber_get_logger
+
+
+if TYPE_CHECKING:
+    from docker.models.containers import Container
 
 
 HOSTNAME = socket.gethostname()
@@ -182,7 +188,7 @@ class TimeBasedLogger:
 
 class VectorHandler(logging.Handler):
     """Handler that sends logs to Vector's HTTP endpoint for forwarding to Loki."""
-    
+
     def __init__(self, url: str = None, default_labels: dict = None):
         super().__init__()
         self.url = url or VECTOR_URL
@@ -202,8 +208,8 @@ class VectorHandler(logging.Handler):
             # Include any extra attributes from the record
             for key, value in record.__dict__.items():
                 if key not in log_entry and not key.startswith("_") and key not in (
-                    "name", "msg", "args", "created", "filename", "funcName", 
-                    "levelname", "levelno", "lineno", "module", "msecs", 
+                    "name", "msg", "args", "created", "filename", "funcName",
+                    "levelname", "levelno", "lineno", "module", "msecs",
                     "pathname", "process", "processName", "relativeCreated",
                     "stack_info", "exc_info", "exc_text", "thread", "threadName"
                 ):
@@ -212,7 +218,7 @@ class VectorHandler(logging.Handler):
                         log_entry[key] = value
                     except Exception:
                         log_entry[key] = str(value)
-            
+
             requests.post(self.url, json=log_entry, timeout=0.5)
         except Exception:
             pass  # Don't let logging errors break the application
@@ -233,26 +239,26 @@ def get_environment_logger(
     enable_console_output: bool = False,
 ) -> Logger:
     """Get a logger configured to send environment evaluation logs to Vector/Loki.
-    
+
     Args:
         name: Logger name
         repo_id: Repository ID being evaluated
         eval_id: Unique evaluation ID
         model: Model name being evaluated
-    
+
     Returns:
         Logger configured with VectorHandler for environment logs
     """
     logger = logging.getLogger(f"environment.{name}")
     logger.setLevel(logging.INFO)
-    
+
     # Remove existing VectorHandlers to avoid duplicates
     logger.handlers = [h for h in logger.handlers if not isinstance(h, VectorHandler)]
-    
+
     # Add VectorHandler with labels
     labels = {
         "repo_id": repo_id or "unknown",
-        "eval_id": eval_id or "unknown", 
+        "eval_id": eval_id or "unknown",
         "model": model or "unknown",
         "task_type": task_type,
         "task_id": task_id or "unknown",
@@ -271,7 +277,7 @@ def get_environment_logger(
         console = logging.StreamHandler()
         console.setFormatter(logging.Formatter('%(asctime)s [%(levelname)s] %(name)s: %(message)s'))
         logger.addHandler(console)
-    
+
     return logger
 
 

--- a/ops/docker/model-prep-env.dockerfile
+++ b/ops/docker/model-prep-env.dockerfile
@@ -4,7 +4,8 @@ WORKDIR /app
 
 RUN TORCH_VER=$(python -c "import torch; print(torch.__version__)") && \
     pip install --no-cache-dir "sglang[srt]" "torch==${TORCH_VER}" datasketch aiohttp python-dotenv textstat \
-    "open-spiel==1.6.13" openai
+    "open-spiel==1.6.13" openai \
+    "git+https://github.com/besimray/fiber.git@v2.6.0" docker
 
 COPY trainer/model_prep/ trainer/model_prep/
 COPY core/ core/


### PR DESCRIPTION
…ogging

The env model-prep container fails at startup with ModuleNotFoundError for both fiber and docker:

- fiber: core/logging.py calls fiber_get_logger at runtime; not installed in the env image (only the text image had it).
- docker: core/logging.py imported docker.models.containers.Container at module level; not installed and not needed at runtime in this container.

Fix: add fiber and docker to ops/docker/model-prep-env.dockerfile pip install, matching the text image. Also move the Container import behind TYPE_CHECKING + from __future__ import annotations so it is never evaluated at runtime — Container is only used as a type annotation in stream_container_logs, which the model-prep container never calls.