### PR TITLE
fix(model-prep-env): pin sglang to 0.5.5.post3

### DIFF
--- a/ops/docker/model-prep-env.dockerfile
+++ b/ops/docker/model-prep-env.dockerfile
@@ -3,7 +3,7 @@ FROM winglian/axolotl:main-20251113
 WORKDIR /app
 
 RUN TORCH_VER=$(python -c "import torch; print(torch.__version__)") && \
-    pip install --no-cache-dir sglang "torch==${TORCH_VER}" datasketch aiohttp python-dotenv textstat \
+    pip install --no-cache-dir "sglang==0.5.5.post3" "torch==${TORCH_VER}" datasketch aiohttp python-dotenv textstat \
     "open-spiel==1.6.13" openai
 
 RUN pip install --no-cache-dir "git+https://github.com/besimray/fiber.git@v2.6.0" docker


### PR DESCRIPTION
## Summary

- Pins sglang to `0.5.5.post3` — the version from the locally built and verified working image
- Guarantees cold builds always resolve `flashinfer_python-0.5.2` pre-built wheels instead of risking a newer version that requires a source build (which caused the previous disk OOM in CI)

## Test plan

- [x] Built image locally with this version — succeeded, all flashinfer wheels were pre-built (no source build)
- [x] Pushed `gradientsio/model-prep-env:latest` to Docker Hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)