### PR TITLE
fix(content_service): log status code and error type when miner ping fails

### DIFF
--- a/validator/infrastructure/content_service.py
+++ b/validator/infrastructure/content_service.py
@@ -53,11 +53,13 @@ async def process_non_stream_fiber_get(endpoint: str, config: Config, node: Node
             timeout=10,
         )
     except Exception as e:
-        logger.error(f"Failed to communicate with node {node.node_id}: {e}")
+        logger.error(f"Failed to communicate with node {node.node_id} ({server_address}{endpoint}): {type(e).__name__}: {e}")
         return None
 
     if response.status_code != 200:
-        logger.warning(f"Failed to communicate with node {node.node_id}")
+        logger.warning(
+            f"Node {node.node_id} ({server_address}{endpoint}) returned HTTP {response.status_code}: {response.text[:200]}"
+        )
         return None
 
     return response.json()
@@ -83,11 +85,13 @@ async def process_non_stream_fiber(
             timeout=timeout,
         )
     except Exception as e:
-        logger.debug(f"Failed to communicate with node {node.node_id}: {e}")
+        logger.debug(f"Failed to communicate with node {node.node_id} ({server_address}{endpoint}): {type(e).__name__}: {e}")
         return None
 
     if response.status_code != 200:
-        logger.debug(f"Failed to communicate with node {node.node_id}")
+        logger.debug(
+            f"Node {node.node_id} ({server_address}{endpoint}) returned HTTP {response.status_code}: {response.text[:200]}"
+        )
         return None
 
     return response.json()


### PR DESCRIPTION
## Summary

- Connection errors now include the full address+endpoint and exception type (e.g. `ConnectTimeout`, `ConnectionRefused`) instead of just the exception message
- Non-200 responses now log the HTTP status code and the first 200 chars of the response body instead of a generic "Failed to communicate"
- Applies to both `process_non_stream_fiber_get` (error level) and `process_non_stream_fiber` (debug level)

🤖 Generated with [Claude Code](https://claude.com/claude-code)