### PR TITLE
fix(miner-ping): drop redundant log + validate non-empty repo fields

### DIFF
--- a/validator/infrastructure/content_service.py
+++ b/validator/infrastructure/content_service.py
@@ -53,7 +53,7 @@ async def process_non_stream_fiber_get(endpoint: str, config: Config, node: Node
             timeout=10,
         )
     except Exception as e:
-        logger.error(f"Failed to communicate with node {node.node_id} ({server_address}{endpoint}): {type(e).__name__}: {e}")
+        logger.error(f"Failed to communicate with node {node.node_id} ({server_address}{endpoint}): {repr(e)}")
         return None
 
     if response.status_code != 200:
@@ -85,7 +85,7 @@ async def process_non_stream_fiber(
             timeout=timeout,
         )
     except Exception as e:
-        logger.debug(f"Failed to communicate with node {node.node_id} ({server_address}{endpoint}): {type(e).__name__}: {e}")
+        logger.debug(f"Failed to communicate with node {node.node_id} ({server_address}{endpoint}): {repr(e)}")
         return None
 
     if response.status_code != 200:

--- a/validator/tournament/tournament_manager.py
+++ b/validator/tournament/tournament_manager.py
@@ -977,11 +977,23 @@ async def _get_miner_training_repo(node: Node, config: Config, tournament_type: 
         url = f"{TRAINING_REPO_ENDPOINT}/{tournament_type.value}"
         response = await process_non_stream_fiber_get(url, config, node)
 
-        if response and isinstance(response, dict):
-            return TrainingRepoResponse(**response)
-        else:
+        if not response:
+            return None
+
+        if not isinstance(response, dict):
             logger.warning(f"Invalid response format from {node.hotkey}: {response}")
             return None
+
+        training_repo = TrainingRepoResponse(**response)
+
+        if not training_repo.github_repo or not training_repo.commit_hash:
+            logger.warning(
+                f"Miner {node.hotkey} returned empty repo or commit hash: "
+                f"repo={training_repo.github_repo!r} commit={training_repo.commit_hash!r}"
+            )
+            return None
+
+        return training_repo
 
     except Exception as e:
         logger.error(f"Failed to get training repo from {node.hotkey}: {e}")


### PR DESCRIPTION
## Summary

- **Double logging removed**: when `process_non_stream_fiber_get` returns `None` (already logged the failure), `_get_miner_training_repo` no longer re-logs "Invalid response format: None" — that warning is now reserved for genuinely malformed non-None responses
- **Empty repo/commit validation**: miners that return a valid JSON response but with blank `github_repo` or `commit_hash` (seen in prod logs as "Node responded with training repo @") are now rejected with a warning naming the offending hotkey and the actual empty values

🤖 Generated with [Claude Code](https://claude.com/claude-code)