### PR TITLE
scheduler: use core env-model whitelist as single source of truth

### DIFF
--- a/validator/tasks/synthetics/scheduler.py
+++ b/validator/tasks/synthetics/scheduler.py
@@ -24,6 +24,7 @@ from core.models.payload_models import InstructTextDatasetColumnsResponse
 from core.models.reward_models import RewardFunction
 from core.models.task_models import TaskStatus
 from core.models.task_models import TaskType
+from core.whitelisted_env_models import SUPPORTED_ENV_MODELS
 from validator.app.config import Config
 from validator.db.database import PSQLDB
 from validator.db.sql import grpo as grpo_sql
@@ -48,17 +49,6 @@ from validator.tournament.gpu_requirements import get_tournament_gpu_requirement
 
 
 logger = get_logger(__name__)
-
-SUPPORTED_ENV_MODELS = [
-    "Qwen/Qwen2-7B-Instruct",
-    "unsloth/Llama-3.2-3B-Instruct",
-    "Qwen/Qwen3-4B-Instruct-2507",
-    "Qwen/Qwen2.5-3B-Instruct",
-    "Qwen/Qwen2.5-7B-Instruct",
-    "codellama/CodeLlama-7b-Instruct-hf",
-    "NousResearch/Hermes-3-Llama-3.2-3B",
-]
-
 
 def maybe_get_yarn_factor() -> int | None:
     """


### PR DESCRIPTION
The synthetic env task scheduler carried its own inline `SUPPORTED_ENV_MODELS` list that had diverged from `core/whitelisted_env_models.json` (the documented whitelist — its module comment even claims the scheduler's seeded `random.choice` reads it, which it didn't). Drop the inline copy and import the canonical list, so env tasks only ever pick base models from the JSON whitelist.

Effective changes to the random pick pool:
- **removed:** `Qwen/Qwen2-7B-Instruct`, `codellama/CodeLlama-7b-Instruct-hf`, `NousResearch/Hermes-3-Llama-3.2-3B`
- **added:** `unsloth/Meta-Llama-3.1-8B-Instruct`, `Qwen/Qwen2.5-1.5B-Instruct`

Both added models resolve to SGLang tool-call parsers (`llama3` / `qwen25` via the family map in `core/pvp/sglang_parsers.py`), so neither forfeits turns.

Note: `model_id_override` paths in `validator/tournament/task_creator.py` (R2+ base-model reuse, boss-round previous-winner continuation) intentionally bypass the random pick and are unchanged.