### PR TITLE
Consolidate chat-template carry into one helper; move mergers to v5 stack

### DIFF
--- a/core/tokenizer_utils.py
+++ b/core/tokenizer_utils.py
@@ -1,0 +1,108 @@
+"""Shared chat-template + tokenizer helpers for the LoRA-merge sites.
+
+A merge rebuilds the merged tokenizer from either the adapter or the base, and whichever is picked
+can lack the adapter's chat template (adapters often ship it only as a standalone chat_template.jinja),
+so it gets silently dropped. read_chat_template + ensure_chat_template carry it; sanitize_tokenizer_config
+normalizes a v5-saved tokenizer dir so v4 consumers can still load it.
+"""
+
+import json
+import os
+
+from huggingface_hub import hf_hub_download
+
+from core.constants.paths import CHAT_TEMPLATE_FILE
+
+
+TOKENIZER_CONFIG_FILE = "tokenizer_config.json"
+
+
+def read_chat_template(source: str, hf_token: str | None = None) -> str | None:
+    """Chat template from a local dir or HF repo id (standalone jinja first, then inline config)."""
+    if os.path.isdir(source):
+        return _read_from_dir(source)
+    return _read_from_hub(source, hf_token)
+
+
+def _read_from_dir(source_dir: str) -> str | None:
+    jinja_path = os.path.join(source_dir, CHAT_TEMPLATE_FILE)
+    if os.path.exists(jinja_path):
+        with open(jinja_path) as f:
+            template = f.read().strip()
+        if template:
+            return template
+    config_path = os.path.join(source_dir, TOKENIZER_CONFIG_FILE)
+    if os.path.exists(config_path):
+        with open(config_path) as f:
+            template = json.load(f).get("chat_template")
+        if isinstance(template, str) and template.strip():
+            return template
+    return None
+
+
+def _read_from_hub(repo_id: str, hf_token: str | None) -> str | None:
+    try:
+        jinja_path = hf_hub_download(repo_id, CHAT_TEMPLATE_FILE, token=hf_token)
+        with open(jinja_path) as f:
+            template = f.read().strip()
+        if template:
+            return template
+    except Exception:
+        pass
+    try:
+        config_path = hf_hub_download(repo_id, TOKENIZER_CONFIG_FILE, token=hf_token)
+        with open(config_path) as f:
+            template = json.load(f).get("chat_template")
+        if isinstance(template, str) and template.strip():
+            return template
+    except Exception:
+        pass
+    return None
+
+
+def ensure_chat_template(tokenizer, *candidates: str | None) -> None:
+    """Graft the first non-empty candidate onto tokenizer if it has no chat template of its own."""
+    if tokenizer.chat_template:
+        return
+    for candidate in candidates:
+        if candidate:
+            tokenizer.chat_template = candidate
+            return
+
+
+def sanitize_tokenizer_config(out_dir: str) -> None:
+    """Undo v5 tokenizer-serialization quirks in place so v4 consumers can load the dir.
+
+    - tokenizer_class="TokenizersBackend" (v5 backend marker, not a loadable class) -> the concrete
+      fast class if tokenizer.json is present, else dropped for autodetection.
+    - extra_special_tokens list -> dict (v4 calls .keys() on it).
+    - chat template folded from the standalone jinja back inline (kept in both), for pre-4.47 readers.
+    """
+    config_path = os.path.join(out_dir, TOKENIZER_CONFIG_FILE)
+    if not os.path.exists(config_path):
+        return
+    with open(config_path) as f:
+        config = json.load(f)
+    changed = False
+
+    if config.get("tokenizer_class") == "TokenizersBackend":
+        if os.path.exists(os.path.join(out_dir, "tokenizer.json")):
+            config["tokenizer_class"] = "PreTrainedTokenizerFast"
+        else:
+            del config["tokenizer_class"]
+        changed = True
+
+    extra_special_tokens = config.get("extra_special_tokens")
+    if isinstance(extra_special_tokens, list):
+        config["extra_special_tokens"] = {token: token for token in extra_special_tokens if isinstance(token, str)}
+        changed = True
+
+    if not config.get("chat_template"):
+        folded = _read_from_dir(out_dir)
+        if folded:
+            config["chat_template"] = folded
+            changed = True
+
+    if changed:
+        with open(config_path, "w") as f:
+            json.dump(config, f, indent=2)

--- a/core/tokenizer_utils.py
+++ b/core/tokenizer_utils.py
@@ -33,8 +33,11 @@ def _read_from_dir(source_dir: str) -> str | None:
             return template
     config_path = os.path.join(source_dir, TOKENIZER_CONFIG_FILE)
     if os.path.exists(config_path):
-        with open(config_path) as f:
-            template = json.load(f).get("chat_template")
+        try:
+            with open(config_path) as f:
+                template = json.load(f).get("chat_template")
+        except (ValueError, OSError):
+            return None
         if isinstance(template, str) and template.strip():
             return template
     return None

--- a/core/tokenizer_utils.py
+++ b/core/tokenizer_utils.py
@@ -63,8 +63,12 @@ def _read_from_hub(repo_id: str, hf_token: str | None) -> str | None:
     return None
 
 
-def ensure_chat_template(tokenizer, *candidates: str | None) -> None:
-    """Graft the first non-empty candidate onto tokenizer if it has no chat template of its own."""
+def ensure_chat_template(tokenizer, *candidates: str | dict | None) -> None:
+    """Graft the first non-empty candidate onto tokenizer if it has no chat template of its own.
+
+    A candidate may be a template string or a dict of named templates (multi-template tokenizers);
+    both are passed through unchanged.
+    """
     if tokenizer.chat_template:
         return
     for candidate in candidates:
@@ -80,6 +84,9 @@ def sanitize_tokenizer_config(out_dir: str) -> None:
       fast class if tokenizer.json is present, else dropped for autodetection.
     - extra_special_tokens list -> dict (v4 calls .keys() on it).
     - chat template folded from the standalone jinja back inline (kept in both), for pre-4.47 readers.
+
+    Rewrites tokenizer_config.json in place, so call it only on a dir you just wrote — never a
+    pin_trusted_remote_code work dir, whose tokenizer files are symlinks into the immutable seed.
     """
     config_path = os.path.join(out_dir, TOKENIZER_CONFIG_FILE)
     if not os.path.exists(config_path):

--- a/ops/docker/model-prep-text.dockerfile
+++ b/ops/docker/model-prep-text.dockerfile
@@ -1,7 +1,7 @@
 # Text-task model-prep: instruct / dpo / grpo / chat, including continuous-SFT custom-arch (quasar).
 # On the transformers-v5 axolotl base so the quasar v5 arch loads. Deliberately NO sglang: it is an
 # unused, heavy dependency for text tasks (sglang is only invoked by ENVIRONMENT-task baseline stats,
-# which run in the separate model-prep image, ops/docker/model-prep.dockerfile). Recent sglang
+# which run in the separate model-prep image, ops/docker/model-prep-env.dockerfile). Recent sglang
 # (>= v0.5.10) pins transformers v5 too, so the historical v4-conflict reason no longer applies.
 FROM axolotlai/axolotl:main-20260701-py3.11-cu128-2.9.1
 

--- a/ops/docker/model-prep-text.dockerfile
+++ b/ops/docker/model-prep-text.dockerfile
@@ -1,8 +1,8 @@
 # Text-task model-prep: instruct / dpo / grpo / chat, including continuous-SFT custom-arch (quasar).
-# On the transformers-v5 axolotl base so the quasar v5 arch loads. Deliberately NO sglang: sglang
-# hard-pins transformers v4 and would drag the whole image back to v4 (breaking v5 arch loading).
-# sglang is only used by ENVIRONMENT-task baseline stats, which run in the separate v4 model-prep
-# image (ops/docker/model-prep.dockerfile) — text tasks never invoke it.
+# On the transformers-v5 axolotl base so the quasar v5 arch loads. Deliberately NO sglang: it is an
+# unused, heavy dependency for text tasks (sglang is only invoked by ENVIRONMENT-task baseline stats,
+# which run in the separate model-prep image, ops/docker/model-prep.dockerfile). Recent sglang
+# (>= v0.5.10) pins transformers v5 too, so the historical v4-conflict reason no longer applies.
 FROM axolotlai/axolotl:main-20260701-py3.11-cu128-2.9.1
 
 WORKDIR /app

--- a/ops/docker/pvp-eval.dockerfile
+++ b/ops/docker/pvp-eval.dockerfile
@@ -1,4 +1,4 @@
-FROM lmsysorg/sglang:latest
+FROM lmsysorg/sglang:v0.5.14
 
 WORKDIR /app
 

--- a/ops/docker/trainer-downloader.dockerfile
+++ b/ops/docker/trainer-downloader.dockerfile
@@ -5,7 +5,8 @@ WORKDIR /app
 RUN pip install --no-cache-dir \
     huggingface_hub aiohttp pydantic python-dotenv safetensors \
     torch --extra-index-url https://download.pytorch.org/whl/cpu && \
-    pip install --no-cache-dir transformers==4.57.1 peft==0.17.1
+    pip install --no-cache-dir transformers==5.12.1 peft==0.19.1
+# v5 stack (matches the axolotl images); downloader.py sanitizes the merged output for v4 miner consumers.
 
 COPY trainer/ trainer/
 COPY core/ core/

--- a/ops/docker/validator-env.dockerfile
+++ b/ops/docker/validator-env.dockerfile
@@ -1,6 +1,6 @@
 FROM phoenixbeaudry/game:mcts-api AS mcts_runtime
 
-FROM lmsysorg/sglang:latest
+FROM lmsysorg/sglang:v0.5.14
 
 WORKDIR /app
 

--- a/ops/docker/validator-intercode.dockerfile
+++ b/ops/docker/validator-intercode.dockerfile
@@ -22,7 +22,7 @@ RUN chmod +x /opt/intercode-build/build_fs.sh && /opt/intercode-build/build_fs.s
 
 
 # ── Stage 2: runtime image (SGLang + python deps + baked-in snapshots/data).
-FROM lmsysorg/sglang:latest
+FROM lmsysorg/sglang:v0.5.14
 
 WORKDIR /app
 

--- a/tests/core/test_tokenizer_utils.py
+++ b/tests/core/test_tokenizer_utils.py
@@ -66,6 +66,13 @@ def test_read_returns_none_on_empty_dir(tmp_path):
     assert read_chat_template(str(tmp_path)) is None
 
 
+def test_read_survives_malformed_config(tmp_path):
+    # A miner adapter with invalid tokenizer_config.json must not crash the merge (AutoTokenizer
+    # load is already guarded upstream and falls back to base); recovering no template is fine.
+    _write(tmp_path, TOKENIZER_CONFIG_FILE, "{not valid json")
+    assert read_chat_template(str(tmp_path)) is None
+
+
 def test_read_ignores_non_string_inline_template(tmp_path):
     _write_config(tmp_path, {"chat_template": {"default": OTHER_TEMPLATE}})
     assert read_chat_template(str(tmp_path)) is None

--- a/tests/core/test_tokenizer_utils.py
+++ b/tests/core/test_tokenizer_utils.py
@@ -1,0 +1,168 @@
+"""Unit tests for core.tokenizer_utils — the single home for chat-template carry + tokenizer
+normalization shared across the four LoRA-merge sites (trainer downloader, model-prep entrypoint,
+env evaluator, intercode evaluator).
+
+Pure filesystem/dict logic — no torch/transformers/network — so these run on any box.
+"""
+
+import json
+import os
+
+from core.constants.paths import CHAT_TEMPLATE_FILE
+from core.tokenizer_utils import TOKENIZER_CONFIG_FILE
+from core.tokenizer_utils import ensure_chat_template
+from core.tokenizer_utils import read_chat_template
+from core.tokenizer_utils import sanitize_tokenizer_config
+
+
+TEMPLATE = "{% for m in messages %}<|{{ m['role'] }}|>{{ m['content'] }}{% endfor %}"
+OTHER_TEMPLATE = "{{ messages[0]['content'] }}"
+
+
+def _write(dir_path, name, content):
+    with open(os.path.join(dir_path, name), "w") as f:
+        f.write(content)
+
+
+def _write_config(dir_path, config):
+    with open(os.path.join(dir_path, TOKENIZER_CONFIG_FILE), "w") as f:
+        json.dump(config, f)
+
+
+class _FakeTokenizer:
+    """Minimal stand-in: .chat_template is a plain settable attribute, like PreTrainedTokenizerBase."""
+
+    def __init__(self, chat_template=None):
+        self.chat_template = chat_template
+
+
+# ── read_chat_template ────────────────────────────────────────────────────────
+
+
+def test_read_prefers_standalone_jinja(tmp_path):
+    _write(tmp_path, CHAT_TEMPLATE_FILE, TEMPLATE)
+    _write_config(tmp_path, {"chat_template": OTHER_TEMPLATE})
+    assert read_chat_template(str(tmp_path)) == TEMPLATE
+
+
+def test_read_falls_back_to_inline_config(tmp_path):
+    _write_config(tmp_path, {"chat_template": OTHER_TEMPLATE})
+    assert read_chat_template(str(tmp_path)) == OTHER_TEMPLATE
+
+
+def test_read_empty_jinja_falls_through_to_inline(tmp_path):
+    # A jinja file that exists but is blank must not shadow a real inline template.
+    _write(tmp_path, CHAT_TEMPLATE_FILE, "   \n")
+    _write_config(tmp_path, {"chat_template": OTHER_TEMPLATE})
+    assert read_chat_template(str(tmp_path)) == OTHER_TEMPLATE
+
+
+def test_read_returns_none_when_absent(tmp_path):
+    _write_config(tmp_path, {"model_max_length": 2048})
+    assert read_chat_template(str(tmp_path)) is None
+
+
+def test_read_returns_none_on_empty_dir(tmp_path):
+    assert read_chat_template(str(tmp_path)) is None
+
+
+def test_read_ignores_non_string_inline_template(tmp_path):
+    _write_config(tmp_path, {"chat_template": {"default": OTHER_TEMPLATE}})
+    assert read_chat_template(str(tmp_path)) is None
+
+
+# ── ensure_chat_template ──────────────────────────────────────────────────────
+
+
+def test_ensure_noop_when_target_has_template():
+    tok = _FakeTokenizer(chat_template=OTHER_TEMPLATE)
+    ensure_chat_template(tok, TEMPLATE, "base_template")
+    assert tok.chat_template == OTHER_TEMPLATE  # target's own template wins
+
+
+def test_ensure_grafts_first_candidate_when_missing():
+    tok = _FakeTokenizer(chat_template=None)
+    ensure_chat_template(tok, TEMPLATE, "base_template")
+    assert tok.chat_template == TEMPLATE
+
+
+def test_ensure_skips_empty_candidates():
+    tok = _FakeTokenizer(chat_template=None)
+    ensure_chat_template(tok, None, "", TEMPLATE)
+    assert tok.chat_template == TEMPLATE
+
+
+def test_ensure_falls_back_to_base_when_adapter_none():
+    tok = _FakeTokenizer(chat_template=None)
+    ensure_chat_template(tok, None, "base_template")
+    assert tok.chat_template == "base_template"
+
+
+def test_ensure_leaves_none_when_no_candidates():
+    tok = _FakeTokenizer(chat_template=None)
+    ensure_chat_template(tok, None, None)
+    assert tok.chat_template is None
+
+
+# ── sanitize_tokenizer_config ─────────────────────────────────────────────────
+
+
+def test_sanitize_noop_without_config(tmp_path):
+    sanitize_tokenizer_config(str(tmp_path))  # must not raise
+    assert not os.path.exists(os.path.join(tmp_path, TOKENIZER_CONFIG_FILE))
+
+
+def test_sanitize_rewrites_tokenizers_backend_with_tokenizer_json(tmp_path):
+    _write_config(tmp_path, {"tokenizer_class": "TokenizersBackend"})
+    _write(tmp_path, "tokenizer.json", "{}")
+    sanitize_tokenizer_config(str(tmp_path))
+    config = json.load(open(os.path.join(tmp_path, TOKENIZER_CONFIG_FILE)))
+    assert config["tokenizer_class"] == "PreTrainedTokenizerFast"
+
+
+def test_sanitize_drops_tokenizers_backend_without_tokenizer_json(tmp_path):
+    _write_config(tmp_path, {"tokenizer_class": "TokenizersBackend"})
+    sanitize_tokenizer_config(str(tmp_path))
+    config = json.load(open(os.path.join(tmp_path, TOKENIZER_CONFIG_FILE)))
+    assert "tokenizer_class" not in config
+
+
+def test_sanitize_normalizes_extra_special_tokens_list(tmp_path):
+    _write_config(tmp_path, {"extra_special_tokens": ["<|im_start|>", "<|im_end|>"]})
+    sanitize_tokenizer_config(str(tmp_path))
+    config = json.load(open(os.path.join(tmp_path, TOKENIZER_CONFIG_FILE)))
+    assert config["extra_special_tokens"] == {"<|im_start|>": "<|im_start|>", "<|im_end|>": "<|im_end|>"}
+
+
+def test_sanitize_folds_jinja_into_inline(tmp_path):
+    # v5 writes the template only as a standalone file and pops the inline key; fold it back so a
+    # pre-4.47 consumer reading only tokenizer_config.json still finds it.
+    _write(tmp_path, CHAT_TEMPLATE_FILE, TEMPLATE)
+    _write_config(tmp_path, {"model_max_length": 2048})
+    sanitize_tokenizer_config(str(tmp_path))
+    config = json.load(open(os.path.join(tmp_path, TOKENIZER_CONFIG_FILE)))
+    assert config["chat_template"] == TEMPLATE
+    # the standalone file is kept too, so jinja-preferring loaders still see the same template
+    assert os.path.exists(os.path.join(tmp_path, CHAT_TEMPLATE_FILE))
+
+
+def test_sanitize_does_not_clobber_existing_inline_template(tmp_path):
+    _write(tmp_path, CHAT_TEMPLATE_FILE, TEMPLATE)
+    _write_config(tmp_path, {"chat_template": OTHER_TEMPLATE})
+    sanitize_tokenizer_config(str(tmp_path))
+    config = json.load(open(os.path.join(tmp_path, TOKENIZER_CONFIG_FILE)))
+    assert config["chat_template"] == OTHER_TEMPLATE
+
+
+def test_sanitize_handles_all_quirks_together(tmp_path):
+    _write(tmp_path, "tokenizer.json", "{}")
+    _write(tmp_path, CHAT_TEMPLATE_FILE, TEMPLATE)
+    _write_config(
+        tmp_path,
+        {"tokenizer_class": "TokenizersBackend", "extra_special_tokens": ["<|im_start|>"]},
+    )
+    sanitize_tokenizer_config(str(tmp_path))
+    config = json.load(open(os.path.join(tmp_path, TOKENIZER_CONFIG_FILE)))
+    assert config["tokenizer_class"] == "PreTrainedTokenizerFast"
+    assert config["extra_special_tokens"] == {"<|im_start|>": "<|im_start|>"}
+    assert config["chat_template"] == TEMPLATE

--- a/tests/core/test_tokenizer_utils_roundtrip.py
+++ b/tests/core/test_tokenizer_utils_roundtrip.py
@@ -1,0 +1,128 @@
+"""Real-tokenizer round-trip tests for core.tokenizer_utils.
+
+The pure-dict tests in test_tokenizer_utils.py prove the config transformations; these prove the
+SEMANTIC guarantees against a real transformers loader — the ones the continuous-SFT / quasar
+lineage depends on:
+
+  1. sanitize_tokenizer_config makes a v5-serialized tokenizer loadable by a v4 consumer WITHOUT
+     changing its vocab, special tokens, or chat template (a v4 loader crashes without it).
+  2. the merge carry preserves the seed/base chat template and custom eos through save + sanitize.
+
+Built from a tiny in-memory fast tokenizer so they need no network. Skipped where tokenizers/
+transformers aren't installed (e.g. a validator-only box).
+"""
+
+import json
+import os
+
+import pytest
+
+
+pytest.importorskip("tokenizers")
+pytest.importorskip("transformers")
+
+from tokenizers import Tokenizer  # noqa: E402
+from tokenizers import models  # noqa: E402
+from tokenizers import pre_tokenizers  # noqa: E402
+from transformers import AutoTokenizer  # noqa: E402
+from transformers import PreTrainedTokenizerFast  # noqa: E402
+
+from core.constants.paths import CHAT_TEMPLATE_FILE  # noqa: E402
+from core.tokenizer_utils import TOKENIZER_CONFIG_FILE  # noqa: E402
+from core.tokenizer_utils import ensure_chat_template  # noqa: E402
+from core.tokenizer_utils import read_chat_template  # noqa: E402
+from core.tokenizer_utils import sanitize_tokenizer_config  # noqa: E402
+
+
+# A quasar-style HUMAN/ASSISTANT-ish template with custom special tokens (not chatml default).
+QUASAR_TEMPLATE = "{% for m in messages %}<|im_start|>{{ m['role'] }}\n{{ m['content'] }}<|im_end|>\n{% endfor %}"
+
+
+def _tiny_tokenizer(chat_template=None):
+    vocab = {"<unk>": 0, "<pad>": 1, "<|endoftext|>": 2, "<|im_start|>": 3, "<|im_end|>": 4, "hi": 5, "there": 6}
+    tk = Tokenizer(models.WordLevel(vocab=vocab, unk_token="<unk>"))
+    tk.pre_tokenizer = pre_tokenizers.Whitespace()
+    ptf = PreTrainedTokenizerFast(tokenizer_object=tk, unk_token="<unk>", pad_token="<pad>", eos_token="<|endoftext|>")
+    if chat_template:
+        ptf.chat_template = chat_template
+    return ptf
+
+
+def _inject_v5_quirks(dir_path):
+    """Rewrite a saved tokenizer dir to look like a transformers-v5 save a v4 consumer chokes on."""
+    cfg_path = os.path.join(dir_path, TOKENIZER_CONFIG_FILE)
+    with open(cfg_path) as f:
+        cfg = json.load(f)
+    cfg["tokenizer_class"] = "TokenizersBackend"
+    cfg["extra_special_tokens"] = ["<|im_start|>", "<|im_end|>"]
+    cfg.pop("chat_template", None)  # v5 pops the inline key, leaving only chat_template.jinja
+    with open(cfg_path, "w") as f:
+        json.dump(cfg, f)
+
+
+def test_sanitize_makes_v5_tokenizer_loadable_on_v4_without_changing_it(tmp_path):
+    tok = _tiny_tokenizer(chat_template=QUASAR_TEMPLATE)
+    d = str(tmp_path / "merged")
+    tok.save_pretrained(d)
+    orig_vocab = tok.get_vocab()
+    _inject_v5_quirks(d)
+
+    # negative control: a v4 loader crashes on the v5 serialization (this is the failure sanitize fixes)
+    with pytest.raises(Exception):
+        AutoTokenizer.from_pretrained(d)
+
+    sanitize_tokenizer_config(d)
+
+    reloaded = AutoTokenizer.from_pretrained(d)  # now loads
+    # vocab + special tokens are untouched — sanitize only rewrites tokenizer_config.json, never tokenizer.json
+    assert reloaded.get_vocab() == orig_vocab
+    assert reloaded.eos_token == "<|endoftext|>"
+    assert "<|im_start|>" in reloaded.get_vocab() and "<|im_end|>" in reloaded.get_vocab()
+    # chat template preserved and renders identically
+    assert reloaded.chat_template == QUASAR_TEMPLATE
+    rendered = reloaded.apply_chat_template([{"role": "user", "content": "hi there"}], tokenize=False)
+    assert "<|im_start|>user" in rendered and "<|im_end|>" in rendered
+    # config is now v4-shaped
+    with open(os.path.join(d, TOKENIZER_CONFIG_FILE)) as f:
+        cfg = json.load(f)
+    assert cfg["tokenizer_class"] == "PreTrainedTokenizerFast"
+    assert isinstance(cfg["extra_special_tokens"], dict)
+    assert cfg["chat_template"] == QUASAR_TEMPLATE  # folded inline for pre-4.47 consumers
+
+
+def test_continuous_sft_seed_template_and_eos_survive_merge_save(tmp_path):
+    # Quasar lineage: the base/seed tokenizer owns the template + custom eos; the merge selects it as
+    # target. The template and eos must survive save + sanitize so the carried base stays consistent.
+    base_tok = _tiny_tokenizer(chat_template=QUASAR_TEMPLATE)
+    adapter_dir = str(tmp_path / "adapter")
+    os.makedirs(adapter_dir)  # bare adapter, no chat template of its own
+    assert read_chat_template(adapter_dir) is None
+
+    target = base_tok  # merge fell back to base
+    ensure_chat_template(target, read_chat_template(adapter_dir), base_tok.chat_template)
+    out = str(tmp_path / "merged")
+    target.save_pretrained(out)
+    sanitize_tokenizer_config(out)
+
+    reloaded = AutoTokenizer.from_pretrained(out)
+    assert reloaded.chat_template == QUASAR_TEMPLATE
+    assert reloaded.eos_token == "<|endoftext|>"
+
+
+def test_adapter_jinja_only_template_grafted_onto_templateless_target(tmp_path):
+    # The primary feature: adapter ships its template only as chat_template.jinja; a base-derived
+    # target that has no template of its own must end up serving the adapter's template.
+    adapter_dir = str(tmp_path / "adapter")
+    os.makedirs(adapter_dir)
+    with open(os.path.join(adapter_dir, CHAT_TEMPLATE_FILE), "w") as f:
+        f.write(QUASAR_TEMPLATE)
+
+    target = _tiny_tokenizer()  # no template
+    assert target.chat_template is None
+    ensure_chat_template(target, read_chat_template(adapter_dir), None)
+    out = str(tmp_path / "merged")
+    target.save_pretrained(out)
+    sanitize_tokenizer_config(out)
+
+    reloaded = AutoTokenizer.from_pretrained(out)
+    assert reloaded.chat_template == QUASAR_TEMPLATE

--- a/trainer/containers/downloader.py
+++ b/trainer/containers/downloader.py
@@ -16,11 +16,13 @@ from transformers import AutoTokenizer
 from transformers import CLIPTokenizer
 
 import trainer.training_paths as train_paths
-from core.constants.paths import CHAT_TEMPLATE_FILE
 from core.downloads import download_s3_file
 from core.models.dataset_models import FileFormat
 from core.models.image_models import ImageModelType
 from core.models.task_models import TaskType
+from core.tokenizer_utils import ensure_chat_template
+from core.tokenizer_utils import read_chat_template
+from core.tokenizer_utils import sanitize_tokenizer_config
 from trainer import constants as cst
 from trainer.model_artifacts import get_anonymous_model_dir
 from trainer.model_artifacts import scrub_model_identity
@@ -137,28 +139,6 @@ async def download_base_model(repo_id: str, save_root: str, model_type: ImageMod
         return result
 
 
-def _read_chat_template(source_dir: str) -> str | None:
-    """Return a chat template string from a local model/adapter dir, or None.
-
-    A LoRA adapter frequently carries its chat template only as a standalone
-    chat_template.jinja file rather than inline in tokenizer_config.json, so a
-    plain merge that rebuilds the tokenizer from the base model silently loses it.
-    """
-    jinja_path = os.path.join(source_dir, CHAT_TEMPLATE_FILE)
-    if os.path.exists(jinja_path):
-        with open(jinja_path) as f:
-            template = f.read().strip()
-        if template:
-            return template
-    config_path = os.path.join(source_dir, "tokenizer_config.json")
-    if os.path.exists(config_path):
-        with open(config_path) as f:
-            template = json.load(f).get("chat_template")
-        if isinstance(template, str) and template.strip():
-            return template
-    return None
-
-
 def _detect_and_merge_lora(model_dir: str) -> None:
     """If model_dir contains a LoRA adapter, merge it into the base model in-place.
 
@@ -219,11 +199,6 @@ def _detect_and_merge_lora(model_dir: str) -> None:
     if top_tokenizer is not base_tokenizer:
         lora_tokenizer = top_tokenizer
 
-    # Capture the adapter's chat template before the adapter dir is dropped. Miners often ship it only
-    # as a standalone chat_template.jinja; rebuilding the tokenizer from the base loses it, which later
-    # breaks chat-template-dependent serving/eval on the merged full model.
-    chat_template = _read_chat_template(model_dir) or getattr(base_tokenizer, "chat_template", None)
-
     # Disable peft hooks that break save_pretrained in newer transformers
     if hasattr(merged, "_hf_peft_config_loaded"):
         merged._hf_peft_config_loaded = False
@@ -233,12 +208,11 @@ def _detect_and_merge_lora(model_dir: str) -> None:
     os.makedirs(merge_tmp, exist_ok=True)
     merged.save_pretrained(merge_tmp, safe_serialization=True)
     target_tokenizer = lora_tokenizer if len(lora_tokenizer) >= len(base_tokenizer) else base_tokenizer
-    if chat_template and not getattr(target_tokenizer, "chat_template", None):
-        target_tokenizer.chat_template = chat_template
+    # Carry the adapter's chat template onto the saved tokenizer (base selection would drop it).
+    ensure_chat_template(target_tokenizer, read_chat_template(model_dir), base_tokenizer.chat_template)
     target_tokenizer.save_pretrained(merge_tmp)
-    if chat_template:
-        with open(os.path.join(merge_tmp, CHAT_TEMPLATE_FILE), "w") as f:
-            f.write(chat_template)
+    # Keep the merged dir loadable by the read-only, any-version miner training container.
+    sanitize_tokenizer_config(merge_tmp)
 
     del base_model, merged
     if torch.cuda.is_available():

--- a/trainer/model_prep/entrypoint.py
+++ b/trainer/model_prep/entrypoint.py
@@ -22,7 +22,6 @@ from transformers import AutoModelForCausalLM
 from transformers import AutoTokenizer
 
 from core.constants.environments import EnvironmentName
-from core.constants.paths import CHAT_TEMPLATE_FILE
 from core.constants.paths import LORA_ADAPTER_CONFIG_FILE
 from core.downloads import download_s3_file
 from core.models.model_prep_models import AugmentationConfig
@@ -33,6 +32,9 @@ from core.models.model_prep_models import ModelPrepResult
 from core.models.task_models import TaskType
 from core.remote_code import continuous_sft_trust_remote_code
 from core.remote_code import pin_trusted_remote_code
+from core.tokenizer_utils import ensure_chat_template
+from core.tokenizer_utils import read_chat_template
+from core.tokenizer_utils import sanitize_tokenizer_config
 from trainer.model_prep.augmentation import augment_model
 from trainer.model_prep.stats import compute_text_stats
 
@@ -48,46 +50,6 @@ def _pin_and_trust(model_ref: str) -> tuple[str, bool]:
     custom arch. No-op (ref unchanged, trust=False) when no audited-mirror env is set."""
     trust = continuous_sft_trust_remote_code()
     return (pin_trusted_remote_code(model_ref) if trust else model_ref), trust
-
-
-def _resolve_chat_template(model_id: str, hf_token: str, is_local: bool) -> str | None:
-    """Return the adapter's chat template, or None.
-
-    A LoRA adapter frequently carries its chat template only as a standalone
-    chat_template.jinja file rather than inline in tokenizer_config.json, so a
-    plain merge that rebuilds the tokenizer from the base model silently loses it.
-    Handles both a local adapter dir and a remote HF repo.
-    """
-    if is_local:
-        jinja_path = os.path.join(model_id, CHAT_TEMPLATE_FILE)
-        if os.path.exists(jinja_path):
-            with open(jinja_path) as f:
-                template = f.read().strip()
-            return template or None
-        config_path = os.path.join(model_id, "tokenizer_config.json")
-        if os.path.exists(config_path):
-            with open(config_path) as f:
-                template = json.load(f).get("chat_template")
-            return template if isinstance(template, str) and template.strip() else None
-        return None
-
-    try:
-        jinja_path = hf_hub_download(model_id, CHAT_TEMPLATE_FILE, token=hf_token)
-        with open(jinja_path) as f:
-            template = f.read().strip()
-        if template:
-            return template
-    except Exception:
-        pass
-    try:
-        config_path = hf_hub_download(model_id, "tokenizer_config.json", token=hf_token)
-        with open(config_path) as f:
-            template = json.load(f).get("chat_template")
-        if isinstance(template, str) and template.strip():
-            return template
-    except Exception:
-        pass
-    return None
 
 
 def detect_and_merge_lora(model_id: str, hf_token: str) -> ModelPrepResult:
@@ -171,22 +133,13 @@ def detect_and_merge_lora(model_id: str, hf_token: str) -> ModelPrepResult:
         if top_tokenizer is not base_tokenizer:
             lora_tokenizer = top_tokenizer
 
-        # Preserve the adapter's chat template (often only a standalone chat_template.jinja); rebuilding
-        # the tokenizer from the base loses it, which later breaks chat-template-dependent serving/eval.
-        chat_template = _resolve_chat_template(model_id, hf_token, is_local) or getattr(
-            base_tokenizer, "chat_template", None
-        )
-
         merge_dir = "/cache/merged_model"
         os.makedirs(merge_dir, exist_ok=True)
         merged.save_pretrained(merge_dir, safe_serialization=True)
         target_tokenizer = lora_tokenizer if len(lora_tokenizer) >= len(base_tokenizer) else base_tokenizer
-        if chat_template and not getattr(target_tokenizer, "chat_template", None):
-            target_tokenizer.chat_template = chat_template
+        # Carry the adapter's chat template onto the saved tokenizer (base selection would drop it).
+        ensure_chat_template(target_tokenizer, read_chat_template(model_id, hf_token), base_tokenizer.chat_template)
         target_tokenizer.save_pretrained(merge_dir)
-        if chat_template:
-            with open(os.path.join(merge_dir, CHAT_TEMPLATE_FILE), "w") as f:
-                f.write(chat_template)
         sanitize_tokenizer_config(merge_dir)
 
         del base_model, merged
@@ -273,46 +226,6 @@ def load_training_data(path: str) -> list[dict]:
     if isinstance(data, list):
         return data
     return []
-
-
-def sanitize_tokenizer_config(out_dir: str) -> None:
-    """Undo transformers-5 serialization quirks in tokenizer_config.json before publish.
-
-    save_pretrained under transformers>=5 writes tokenizer_class="TokenizersBackend" — an internal
-    backend marker, not a registered class — so any consumer's AutoTokenizer.from_pretrained crashes
-    with "Tokenizer class TokenizersBackend does not exist". Rewrite it to PreTrainedTokenizerFast
-    when the serialized tokenizer.json is present (loadable on transformers 4 and 5 alike), else drop
-    the key so AutoTokenizer falls back to autodetection.
-
-    It also writes extra_special_tokens as a list of token strings (e.g. Qwen2's im_start/im_end),
-    where transformers 4 requires a dict of {name: token} and calls .keys() on it — downstream
-    training on the augmented model crashes (or dies trying to rewrite the read-only model cache).
-    Normalize list → dict.
-    """
-    config_path = os.path.join(out_dir, "tokenizer_config.json")
-    if not os.path.exists(config_path):
-        return
-    with open(config_path) as f:
-        config = json.load(f)
-    changed = False
-
-    if config.get("tokenizer_class") == "TokenizersBackend":
-        if os.path.exists(os.path.join(out_dir, "tokenizer.json")):
-            config["tokenizer_class"] = "PreTrainedTokenizerFast"
-        else:
-            del config["tokenizer_class"]
-        changed = True
-        print(f"[model_prep] Sanitized TokenizersBackend tokenizer_class in {config_path}", flush=True)
-
-    extra_special_tokens = config.get("extra_special_tokens")
-    if isinstance(extra_special_tokens, list):
-        config["extra_special_tokens"] = {token: token for token in extra_special_tokens if isinstance(token, str)}
-        changed = True
-        print(f"[model_prep] Normalized extra_special_tokens list → dict in {config_path}", flush=True)
-
-    if changed:
-        with open(config_path, "w") as f:
-            json.dump(config, f, indent=2)
 
 
 def upload_augmented_model(model, tokenizer, repo_id: str, hf_token: str) -> None:

--- a/validator/evaluation/evaluators/environment.py
+++ b/validator/evaluation/evaluators/environment.py
@@ -15,8 +15,9 @@ from huggingface_hub import snapshot_download
 
 import core.constants.environments as env_cst
 import validator.evaluation.constants as vcst
-from core.constants.paths import CHAT_TEMPLATE_FILE
 from core.models.dataset_models import EnvironmentDatasetType
+from core.tokenizer_utils import ensure_chat_template
+from core.tokenizer_utils import read_chat_template
 from validator.evaluation.evaluation_logging import configure_eval_logging
 from validator.evaluation.model_checks import check_for_lora
 from validator.evaluation.model_checks import check_lora_has_added_tokens
@@ -78,28 +79,6 @@ def _download_lora_with_retry(repo_id: str, local_dir: str, max_retries: int = 3
             else:
                 logger.error("All download attempts failed")
                 raise
-
-
-def _read_chat_template(source_dir: str) -> str | None:
-    """Return a chat template string from a local model/adapter dir, or None.
-
-    A LoRA adapter frequently carries its chat template only as a standalone
-    chat_template.jinja file rather than inline in tokenizer_config.json, so a
-    plain merge that rebuilds the tokenizer from the base model silently loses it.
-    """
-    jinja_path = os.path.join(source_dir, CHAT_TEMPLATE_FILE)
-    if os.path.exists(jinja_path):
-        with open(jinja_path) as f:
-            template = f.read().strip()
-        if template:
-            return template
-    config_path = os.path.join(source_dir, "tokenizer_config.json")
-    if os.path.exists(config_path):
-        with open(config_path) as f:
-            template = json.load(f).get("chat_template")
-        if isinstance(template, str) and template.strip():
-            return template
-    return None
 
 
 def _merge_base_and_lora(
@@ -170,21 +149,13 @@ def _merge_base_and_lora(
     merged = model.merge_and_unload(safe_merge=False)
     logger.info("eval_setup merge: merge_and_unload done in %.1fs", time.time() - t2)
 
-    # Preserve the LoRA's chat template before saving. Miners often ship it only as a standalone
-    # chat_template.jinja; rebuilding the tokenizer from the base loses it, which breaks
-    # chat-template-dependent SGLang serving of the reconstructed base during eval.
-    chat_template = _read_chat_template(lora_dir) or getattr(base_tokenizer, "chat_template", None)
-
     os.makedirs(output_dir, exist_ok=True)
     t3 = time.time()
     logger.info("eval_setup merge: saving merged model to disk...")
     merged.save_pretrained(output_dir, safe_serialization=True, max_shard_size="5GB")
-    if chat_template and not getattr(target_tokenizer, "chat_template", None):
-        target_tokenizer.chat_template = chat_template
+    # Carry the adapter's chat template onto the saved tokenizer (base selection would drop it).
+    ensure_chat_template(target_tokenizer, read_chat_template(lora_dir), base_tokenizer.chat_template)
     target_tokenizer.save_pretrained(output_dir)
-    if chat_template:
-        with open(os.path.join(output_dir, CHAT_TEMPLATE_FILE), "w") as f:
-            f.write(chat_template)
     logger.info(
         "eval_setup merge: saved to %s in %.1fs (total merge wall %.1fs)",
         output_dir,

--- a/validator/evaluation/evaluators/intercode.py
+++ b/validator/evaluation/evaluators/intercode.py
@@ -58,6 +58,8 @@ from core.models.pvp_models import ToolCall
 from core.models.pvp_models import ToolSchema
 from core.pvp.chat import chat_completion
 from core.pvp.sglang_parsers import tool_call_parser_for
+from core.tokenizer_utils import ensure_chat_template
+from core.tokenizer_utils import read_chat_template
 from validator.evaluation.model_checks import check_for_lora
 from validator.evaluation.model_checks import check_lora_has_added_tokens
 from validator.evaluation.pvp.materialize import materialize_base_model
@@ -211,6 +213,8 @@ def _merge_base_and_lora(base_model_path: str, lora_dir: str, output_dir: str = 
     merged = model.merge_and_unload(safe_merge=False)
     os.makedirs(output_dir, exist_ok=True)
     merged.save_pretrained(output_dir, safe_serialization=True, max_shard_size="5GB")
+    # Carry the adapter's chat template onto the saved tokenizer (base selection would drop it).
+    ensure_chat_template(target_tokenizer, read_chat_template(lora_dir), base_tokenizer.chat_template)
     target_tokenizer.save_pretrained(output_dir)
     return output_dir
 

--- a/validator/evaluation/local_evaluation.py
+++ b/validator/evaluation/local_evaluation.py
@@ -476,7 +476,7 @@ async def run_evaluation_local_environment(
             env_logger.info(f"Starting SGLang container: {sglang_container_name} (GPU {gpu_id})")
             sglang_container = await asyncio.to_thread(
                 docker_client.containers.run,
-                "lmsysorg/sglang:latest",
+                "lmsysorg/sglang:v0.5.14",
                 command=sglang_args,
                 name=sglang_container_name,
                 detach=True,


### PR DESCRIPTION
Follow-up to #1294/#1295. The chat-template carry was pasted into three LoRA-merge sites as near-identical `_read_chat_template`/`_resolve_chat_template` helpers, a fourth merge site (intercode) had none, and each copy manually re-wrote `chat_template.jinja` after `save_pretrained` — redundant, and self-inconsistent in the adapter-has/target-has-different case.

Root cause of the mess: transformers major-version skew across the pipeline (v5 augmentation/validator, 4.57.1 downloader, sglang eval images). The skew is load-bearing (sglang, quasar arch), so it's reconciled at the boundaries — this PR centralizes that reconciliation and moves the one true v4 island (trainer-downloader) onto v5.

## Cleanup
- `core/tokenizer_utils.py`: `read_chat_template` (local dir or HF repo, guarded against malformed configs) / `ensure_chat_template` (graft if missing) / `sanitize_tokenizer_config` (moved from entrypoint, extended to fold jinja→inline).
- All three existing sites drop their local helper and the manual jinja write.
- **intercode `_merge_base_and_lora` now carries the template too** — it was silently dropping adapter templates on the added-tokens merge path.
- trainer-downloader runs `sanitize_tokenizer_config` on its merged `/cache` output so the dir stays loadable by the read-only, arbitrary-version miner training container.
- Net −128 lines at the call sites. 19 unit tests + an end-to-end merge smoke (base tokenizer selected, adapter jinja-only) verified on transformers 4.57.6: template round-trips, folds inline, `apply_chat_template` renders. No regressions in existing tests.

## Image bumps
- trainer-downloader: transformers 4.57.1/peft 0.17.1 → 5.12.1/0.19.1 (axolotl-validated stack; deps resolve clean via pip dry-run; CLIPTokenizer import, `torch_dtype=` kwarg, and the py3.10 floor all verified against the 5.12.1 source). Safe because the cleanup commit sanitizes its output.
- validator-env / validator-intercode / pvp-eval: `lmsysorg/sglang:latest` → `:v0.5.14` (what latest resolves to today; stops the floating-tag roulette). The local-eval docker launch in `validator/evaluation/local_evaluation.py` is pinned to the same tag.
- model-prep-text: correct the stale "sglang hard-pins transformers v4" comment (sglang ≥ v0.5.10 pins v5).
