### PR TITLE
Update tournament group size constants and adjust related tests for e…

### DIFF
--- a/tests/validator/tournament/test_env_group_and_perf.py
+++ b/tests/validator/tournament/test_env_group_and_perf.py
@@ -47,34 +47,34 @@ class TestEnvGroupFormation:
         )
 
     def test_6_participants_small_field(self):
-        """6 plus reserved boss slot -> 3 round-1 groups of 2."""
+        """6 plus reserved boss slot -> 2 round-1 groups of 3."""
         nodes = self._make_nodes(6)
         result = self._form_groups(nodes)
-        assert len(result.groups) == 3
-        assert sorted(len(group.member_ids) for group in result.groups) == [2, 2, 2]
+        assert len(result.groups) == 2
+        assert sorted(len(group.member_ids) for group in result.groups) == [3, 3]
 
-    def test_7_participants_three_small_groups(self):
-        """7 plus reserved boss slot -> 3 round-1 groups sized 3+2+2."""
+    def test_7_participants_two_small_groups(self):
+        """7 plus reserved boss slot -> 2 round-1 groups sized 3+4."""
         nodes = self._make_nodes(7)
         result = self._form_groups(nodes)
-        assert len(result.groups) == 3
+        assert len(result.groups) == 2
         sizes = sorted([len(g.member_ids) for g in result.groups])
-        assert sizes == [2, 2, 3]
+        assert sizes == [3, 4]
 
-    def test_12_participants_four_groups(self):
-        """12 plus reserved boss slot -> 4 groups of 3."""
+    def test_12_participants_three_groups(self):
+        """12 plus reserved boss slot -> 3 groups of 4."""
         nodes = self._make_nodes(12)
         result = self._form_groups(nodes)
-        assert len(result.groups) == 4
-        assert all(len(g.member_ids) == 3 for g in result.groups)
+        assert len(result.groups) == 3
+        assert all(len(g.member_ids) == 4 for g in result.groups)
 
-    def test_13_participants_four_groups(self):
-        """13 plus reserved boss slot -> 4 roughly balanced groups."""
+    def test_13_participants_three_groups(self):
+        """13 plus reserved boss slot -> 3 roughly balanced groups."""
         nodes = self._make_nodes(13)
         result = self._form_groups(nodes)
-        assert len(result.groups) == 4
+        assert len(result.groups) == 3
         sizes = sorted(len(g.member_ids) for g in result.groups)
-        assert sizes == [3, 3, 3, 4]
+        assert sizes == [4, 4, 5]
         assert sum(sizes) == 13
         assert min(sizes) >= t_cst.MIN_ENVIRONMENT_GROUP_SIZE
 

--- a/validator/tournament/constants.py
+++ b/validator/tournament/constants.py
@@ -90,14 +90,14 @@ SMALL_TOURNAMENT_MAX_PARTICIPANTS = 14  # i.e. fewer than 15 at tournament start
 SMALL_TOURNAMENT_GROUP_TASKS = 3
 SMALL_TOURNAMENT_ADVANCE = 2
 MIN_ENVIRONMENT_GROUP_SIZE = 2
-# Cap includes the injected boss. With 4 members, a group evaluates at most
-# C(4, 2) = 6 PvP pairs.
-MAX_ENVIRONMENT_GROUP_SIZE = 4
+# Cap includes the injected boss. With 5 members, a group evaluates at most
+# C(5, 2) = 10 PvP pairs.
+MAX_ENVIRONMENT_GROUP_SIZE = 5
 # Small env tournaments collapse too fast (one big group advancing 1 contender). When the
 # field is smaller than SMALL_ENVIRONMENT_MAX_PARTICIPANTS, cap the group size lower so there
 # are more groups, more contenders survive each round, and the bracket plays out over more rounds.
 SMALL_ENVIRONMENT_MAX_PARTICIPANTS = 7  # i.e. fewer than 8
-SMALL_ENVIRONMENT_GROUP_SIZE = 3
+SMALL_ENVIRONMENT_GROUP_SIZE = 4
 
 
 # Environment tournament round structure


### PR DESCRIPTION
…nvironment group formation

- Increased MAX_ENVIRONMENT_GROUP_SIZE from 4 to 5 to allow for more PvP pairs.
- Adjusted SMALL_ENVIRONMENT_GROUP_SIZE from 3 to 4 to enhance group dynamics.
- Updated test cases to reflect changes in group sizes for 6, 7, 12, and 13 participants, ensuring correct group formations and sizes in the tests.