### PR TITLE
Validate downloader image caches and document FLUX layout

### DIFF
--- a/ops/docker/README.md
+++ b/ops/docker/README.md
@@ -15,7 +15,8 @@ Dockerfiles and container support files for miner, trainer, validator, evaluatio
 - `pvp-eval.dockerfile`: PvP evaluation image.
 - `standalone-image-toolkit-trainer.dockerfile`: ai-toolkit image trainer expected in miner repos.
 - `standalone-text-trainer.dockerfile`: text trainer image expected in miner repos.
-- `trainer-downloader.dockerfile`: model/dataset downloader image.
+- `trainer-downloader.dockerfile`: model/dataset downloader image, including image-model cache validation and legacy FLUX
+  checkpoint layout normalization; see `trainer/containers/README.md` for its cache and deployment contract.
 - `validator.dockerfile`: base validator image.
 - `validator-diffusion.dockerfile`: image evaluation validator image.
 - `validator-env.dockerfile`: environment evaluation validator image.

--- a/tests/trainer/README.md
+++ b/tests/trainer/README.md
@@ -6,4 +6,5 @@ Tests for trainer behavior, model prep, dataset/cache flow, and anonymization.
 
 - `model_prep/`: tests for model-prep statistics, sidecars, and roundtrips.
 - `test_dataset_and_anonymizer_flow.py`: trainer dataset download/cache and model anonymizer flow tests.
+- `test_downloader_image_cache.py`: network-free image-model cache classification, migration, validation, and atomicity tests.
 - `__init__.py`: package marker.

--- a/tests/trainer/test_dataset_and_anonymizer_flow.py
+++ b/tests/trainer/test_dataset_and_anonymizer_flow.py
@@ -6,14 +6,14 @@ import json
 import os
 import tempfile
 
-from core.models.payload_models import TrainingRepoResponse
-from validator.tournament.models import TaskTrainingAssignment
-from validator.tournament.models import TournamentParticipant
 from core.datasets.whitelist import MAX_REQUESTED_DATASETS
 from core.datasets.whitelist import WHITELISTED_SFT_DATASETS
 from core.datasets.whitelist import validate_requested_datasets
+from core.models.payload_models import TrainingRepoResponse
 from trainer.model_artifacts import get_anonymous_model_dir
 from trainer.model_artifacts import scrub_model_identity
+from validator.tournament.models import TaskTrainingAssignment
+from validator.tournament.models import TournamentParticipant
 
 
 # --- 7a: validate_requested_datasets ---

--- a/tests/trainer/test_downloader_image_cache.py
+++ b/tests/trainer/test_downloader_image_cache.py
@@ -1,0 +1,278 @@
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from core.models.image_models import ImageModelType
+from trainer.containers import downloader
+from trainer.model_artifacts import get_anonymous_model_dir
+
+
+def _legacy_image_base_model_resolver(base_path: Path) -> Path:
+    files = [
+        filename
+        for filename in os.listdir(base_path)
+        if os.path.isfile(os.path.join(base_path, filename))
+    ]
+    if len(files) == 1 and files[0].endswith(".safetensors"):
+        return base_path / files[0]
+    return base_path
+
+
+def _write_repo_files(root: Path, files: dict[str, bytes]) -> None:
+    for relative_path, contents in files.items():
+        path = root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(contents)
+
+
+def _mock_repo_tree(monkeypatch, files: dict[str, bytes]) -> None:
+    metadata = [SimpleNamespace(path=path, size=len(contents)) for path, contents in files.items()]
+    monkeypatch.setattr(downloader.hf_api, "list_repo_tree", lambda **kwargs: metadata)
+
+
+def _mock_snapshot_download(monkeypatch, files: dict[str, bytes], calls: list[dict] | None = None) -> None:
+    def fake_snapshot_download(**kwargs):
+        if calls is not None:
+            calls.append(kwargs)
+        local_dir = Path(kwargs["local_dir"])
+        _write_repo_files(local_dir, files)
+        return str(local_dir)
+
+    monkeypatch.setattr(downloader, "snapshot_download", fake_snapshot_download)
+
+
+@pytest.mark.asyncio
+async def test_new_standalone_flux_downloads_only_root_checkpoint(monkeypatch, tmp_path):
+    repo_id = "dataautogpt3/FLUX-MonochromeManga"
+    checkpoint_name = "FLUX-DEV_MonochromeManga.safetensors"
+    repo_files = {
+        ".gitattributes": b"lfs",
+        "README.md": b"model card",
+        checkpoint_name: b"checkpoint weights",
+    }
+    _mock_repo_tree(monkeypatch, repo_files)
+
+    def fake_hf_hub_download(**kwargs):
+        assert kwargs["filename"] == checkpoint_name
+        checkpoint_path = Path(kwargs["local_dir"]) / checkpoint_name
+        checkpoint_path.write_bytes(repo_files[checkpoint_name])
+        return str(checkpoint_path)
+
+    monkeypatch.setattr(downloader, "hf_hub_download", fake_hf_hub_download)
+    monkeypatch.setattr(
+        downloader,
+        "snapshot_download",
+        lambda **kwargs: pytest.fail("standalone FLUX checkpoints must not download a full snapshot"),
+    )
+
+    result = Path(await downloader.download_base_model(repo_id, str(tmp_path), ImageModelType.FLUX, anonymize=False))
+
+    assert result == tmp_path / "dataautogpt3--FLUX-MonochromeManga"
+    assert [path.name for path in result.iterdir() if path.is_file()] == [checkpoint_name]
+    assert _legacy_image_base_model_resolver(result) == result / checkpoint_name
+
+
+@pytest.mark.asyncio
+async def test_existing_standalone_flux_snapshot_is_normalized(monkeypatch, tmp_path):
+    repo_id = "dataautogpt3/FLUX-MonochromeManga"
+    checkpoint_name = "FLUX-DEV_MonochromeManga.safetensors"
+    repo_files = {
+        ".gitattributes": b"lfs",
+        "README.md": b"model card",
+        checkpoint_name: b"checkpoint weights",
+    }
+    cache_path = tmp_path / "dataautogpt3--FLUX-MonochromeManga"
+    _write_repo_files(cache_path, repo_files)
+    _mock_repo_tree(monkeypatch, repo_files)
+    monkeypatch.setattr(
+        downloader,
+        "hf_hub_download",
+        lambda **kwargs: pytest.fail("a complete checkpoint must not be downloaded again"),
+    )
+
+    result = Path(await downloader.download_base_model(repo_id, str(tmp_path), "flux", anonymize=False))
+
+    assert result == cache_path
+    assert [path.name for path in cache_path.iterdir() if path.is_file()] == [checkpoint_name]
+    assert _legacy_image_base_model_resolver(cache_path) == cache_path / checkpoint_name
+
+
+@pytest.mark.asyncio
+async def test_genuine_diffusers_layout_is_not_normalized(monkeypatch, tmp_path):
+    repo_id = "example/diffusers-flux"
+    repo_files = {
+        ".gitattributes": b"lfs",
+        "README.md": b"model card",
+        "model_index.json": b"{}",
+        "extra.safetensors": b"root weights",
+        "transformer/config.json": b"{}",
+        "transformer/diffusion_pytorch_model.safetensors": b"transformer weights",
+    }
+    cache_path = tmp_path / "example--diffusers-flux"
+    _write_repo_files(cache_path, repo_files)
+    _mock_repo_tree(monkeypatch, repo_files)
+    monkeypatch.setattr(
+        downloader,
+        "snapshot_download",
+        lambda **kwargs: pytest.fail("a complete Diffusers snapshot must not be downloaded again"),
+    )
+
+    result = Path(await downloader.download_base_model(repo_id, str(tmp_path), ImageModelType.FLUX, anonymize=False))
+
+    assert result == cache_path
+    assert (cache_path / "README.md").is_file()
+    assert (cache_path / "model_index.json").is_file()
+    assert (cache_path / "transformer/diffusion_pytorch_model.safetensors").is_file()
+    assert _legacy_image_base_model_resolver(cache_path) == cache_path
+
+
+@pytest.mark.asyncio
+async def test_sharded_flux_snapshot_is_not_treated_as_standalone(monkeypatch, tmp_path):
+    repo_id = "example/sharded-flux"
+    shard_name = "model-00001-of-00001.safetensors"
+    index_contents = json.dumps({"weight_map": {"transformer.weight": shard_name}}).encode()
+    repo_files = {
+        "README.md": b"model card",
+        "model.safetensors.index.json": index_contents,
+        shard_name: b"sharded weights",
+    }
+    cache_path = tmp_path / "example--sharded-flux"
+    _write_repo_files(cache_path, repo_files)
+    _mock_repo_tree(monkeypatch, repo_files)
+    monkeypatch.setattr(
+        downloader,
+        "snapshot_download",
+        lambda **kwargs: pytest.fail("a complete sharded snapshot must not be downloaded again"),
+    )
+    monkeypatch.setattr(
+        downloader,
+        "hf_hub_download",
+        lambda **kwargs: pytest.fail("a sharded checkpoint must not use the standalone download path"),
+    )
+
+    await downloader.download_base_model(repo_id, str(tmp_path), ImageModelType.FLUX, anonymize=False)
+
+    assert (cache_path / "README.md").is_file()
+    assert (cache_path / "model.safetensors.index.json").is_file()
+    assert (cache_path / shard_name).is_file()
+
+
+@pytest.mark.asyncio
+async def test_incomplete_existing_snapshot_is_repaired(monkeypatch, tmp_path):
+    repo_id = "example/incomplete-flux"
+    shard_name = "transformer-00001-of-00001.safetensors"
+    index_contents = json.dumps({"weight_map": {"transformer.weight": shard_name}}).encode()
+    repo_files = {
+        "README.md": b"model card",
+        "model.safetensors.index.json": index_contents,
+        shard_name: b"sharded weights",
+    }
+    cache_path = tmp_path / "example--incomplete-flux"
+    _write_repo_files(
+        cache_path,
+        {
+            "README.md": repo_files["README.md"],
+            "model.safetensors.index.json": index_contents,
+        },
+    )
+    _mock_repo_tree(monkeypatch, repo_files)
+    snapshot_calls = []
+    _mock_snapshot_download(monkeypatch, repo_files, snapshot_calls)
+
+    result = Path(await downloader.download_base_model(repo_id, str(tmp_path), ImageModelType.FLUX, anonymize=False))
+
+    assert result == cache_path
+    assert (cache_path / shard_name).read_bytes() == repo_files[shard_name]
+    assert len(snapshot_calls) == 1
+    assert Path(snapshot_calls[0]["local_dir"]).parent == tmp_path
+    assert Path(snapshot_calls[0]["local_dir"]) != cache_path
+
+
+@pytest.mark.asyncio
+async def test_failed_download_does_not_leave_final_cache(monkeypatch, tmp_path):
+    repo_id = "example/failed-qwen-image"
+    repo_files = {
+        "model_index.json": b"{}",
+        "transformer/config.json": b"{}",
+    }
+    _mock_repo_tree(monkeypatch, repo_files)
+
+    def failing_snapshot_download(**kwargs):
+        _write_repo_files(Path(kwargs["local_dir"]), {"model_index.json": b"{}"})
+        raise RuntimeError("simulated download failure")
+
+    monkeypatch.setattr(downloader, "snapshot_download", failing_snapshot_download)
+
+    with pytest.raises(RuntimeError, match="simulated download failure"):
+        await downloader.download_base_model(repo_id, str(tmp_path), ImageModelType.QWEN_IMAGE, anonymize=False)
+
+    assert not (tmp_path / "example--failed-qwen-image").exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_anonymous_model_directory_naming_is_unchanged(monkeypatch, tmp_path):
+    repo_id = "example/private-image-model"
+    repo_files = {
+        "config.json": json.dumps({"_name_or_path": repo_id, "hidden_size": 1}).encode(),
+        "model_index.json": b"{}",
+        "transformer/config.json": b"{}",
+    }
+    monkeypatch.setenv("MODEL_HASH_SALT", "cache-layout-test-salt")
+    monkeypatch.setenv("HUGGINGFACE_TOKEN", "test-huggingface-token")
+    _mock_repo_tree(monkeypatch, repo_files)
+    snapshot_calls = []
+    _mock_snapshot_download(monkeypatch, repo_files, snapshot_calls)
+
+    result = Path(await downloader.download_base_model(repo_id, str(tmp_path), ImageModelType.KREA2, anonymize=True))
+    cached_result = Path(await downloader.download_base_model(repo_id, str(tmp_path), ImageModelType.KREA2, anonymize=True))
+
+    assert result == tmp_path / get_anonymous_model_dir(repo_id)
+    assert cached_result == result
+    assert "_name_or_path" not in json.loads((result / "config.json").read_text())
+    assert len(snapshot_calls) == 1
+    assert snapshot_calls[0]["token"] == "test-huggingface-token"
+
+
+@pytest.mark.asyncio
+async def test_non_flux_image_model_keeps_full_snapshot(monkeypatch, tmp_path):
+    repo_id = "example/z-image-checkpoint"
+    repo_files = {
+        "README.md": b"model card",
+        "z-image.safetensors": b"checkpoint weights",
+    }
+    _mock_repo_tree(monkeypatch, repo_files)
+    snapshot_calls = []
+    _mock_snapshot_download(monkeypatch, repo_files, snapshot_calls)
+    monkeypatch.setattr(
+        downloader,
+        "hf_hub_download",
+        lambda **kwargs: pytest.fail("non-FLUX models must retain full snapshot behavior"),
+    )
+
+    result = Path(await downloader.download_base_model(repo_id, str(tmp_path), ImageModelType.Z_IMAGE, anonymize=False))
+
+    assert len(snapshot_calls) == 1
+    assert (result / "README.md").is_file()
+    assert (result / "z-image.safetensors").is_file()
+    assert _legacy_image_base_model_resolver(result) == result
+
+
+@pytest.mark.asyncio
+async def test_image_dataset_download_does_not_log_signed_url(monkeypatch, tmp_path, capsys):
+    signed_url = "https://datasets.example/task.zip?X-Amz-Signature=secret"
+    local_path = tmp_path / "task.zip"
+
+    async def fake_download_s3_file(url, destination):
+        assert url == signed_url
+        return destination
+
+    monkeypatch.setattr(downloader, "download_s3_file", fake_download_s3_file)
+    monkeypatch.setattr(downloader.train_paths, "get_image_training_zip_save_path", lambda task_id: str(local_path))
+
+    await downloader.download_image_dataset(signed_url, "task-id", str(tmp_path))
+
+    assert signed_url not in capsys.readouterr().out

--- a/trainer/containers/README.md
+++ b/trainer/containers/README.md
@@ -9,3 +9,22 @@ Helpers for support containers launched by the trainer runtime.
 - `downloader.py`: pre-downloads models and task datasets before training.
 - `uploader.py`: uploads completed model artifacts to Hugging Face.
 - `__init__.py`: package marker.
+
+## Image model cache layouts
+
+The downloader preserves two image-model layouts. A FLUX repository is treated as a standalone checkpoint only when its
+repository tree has exactly one root `.safetensors` file, no root `model_index.json`, no Diffusers component directories,
+and no sharded-weight index. Its final cache directory has that checkpoint as its only top-level file. This contract keeps
+pinned miner repositories compatible with their legacy resolver, which selects a checkpoint only when it is the sole
+top-level file.
+
+Diffusers repositories and the Z-Image, Qwen-Image, Ideogram4, and Krea2 AI Toolkit model types retain complete snapshots;
+their component files are never flattened or relocated. Before reusing any image-model cache, the downloader compares it
+with Hugging Face repository metadata and checks sharded-index references. A complete standalone FLUX cache that still has
+root metadata such as `README.md` or `.gitattributes` is normalized automatically. Incomplete caches are replaced from a
+validated temporary sibling directory, and new downloads are promoted only after validation succeeds.
+
+This behavior lives in the downloader image, not in miner training repositories. To deploy a change, rebuild
+`ops/docker/trainer-downloader.dockerfile`, publish and configure an actually built versioned image tag, pull it on trainer
+hosts, and restart trainer services as needed. Do not rely solely on the mutable `latest` tag; already-running services and
+locally cached downloader images do not acquire the fix automatically.

--- a/trainer/containers/downloader.py
+++ b/trainer/containers/downloader.py
@@ -2,18 +2,16 @@ import argparse
 import asyncio
 import json
 import os
+import re
 import shutil
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
+from pathlib import PurePosixPath
 
-import torch
 from huggingface_hub import HfApi
 from huggingface_hub import hf_hub_download
 from huggingface_hub import snapshot_download
-from peft import PeftModel
-from transformers import AutoModelForCausalLM
-from transformers import AutoTokenizer
-from transformers import CLIPTokenizer
 
 import trainer.training_paths as train_paths
 from core.downloads import download_s3_file
@@ -31,9 +29,27 @@ from trainer.model_artifacts import scrub_model_identity
 LORA_ADAPTER_CONFIG = "adapter_config.json"
 IDEOGRAM4_TEXT_ENCODER_REPO = "Qwen/Qwen3-VL-8B-Instruct"
 KREA2_TEXT_ENCODER_REPO = "Qwen/Qwen3-VL-4B-Instruct"
+DIFFUSERS_COMPONENT_DIRS = {
+    "scheduler",
+    "text_encoder",
+    "text_encoder_2",
+    "tokenizer",
+    "tokenizer_2",
+    "transformer",
+    "unet",
+    "vae",
+}
+SHARDED_CHECKPOINT_PATTERN = re.compile(r"-\d{5}-of-\d{5}\.safetensors$")
+WEIGHT_INDEX_SUFFIXES = (".bin.index.json", ".safetensors.index.json")
 
 
 hf_api = HfApi()
+
+
+@dataclass(frozen=True)
+class RepoFileMetadata:
+    path: str
+    size: int | None
 
 
 async def download_text_dataset(task_id, dataset_url, file_format, dataset_dir):
@@ -59,27 +75,191 @@ async def download_text_dataset(task_id, dataset_url, file_format, dataset_dir):
 async def download_image_dataset(dataset_zip_url, task_id, dataset_dir):
     os.makedirs(dataset_dir, exist_ok=True)
     local_zip_path = train_paths.get_image_training_zip_save_path(task_id)
-    print(f"Downloading dataset from: {dataset_zip_url}")
+    print(f"Downloading image dataset for task {task_id}")
     local_path = await download_s3_file(dataset_zip_url, local_zip_path)
-    print(f"Downloaded dataset to: {local_path}")
+    print(f"Downloaded image dataset to: {local_path}")
     return local_path
 
 
-def is_safetensors_available(repo_id: str) -> tuple[bool, str | None]:
-    files_metadata = hf_api.list_repo_tree(repo_id=repo_id, repo_type="model")
-    check_size_in_gb = 6
-    total_check_size = check_size_in_gb * 1024 * 1024 * 1024
-    largest_file = None
+def _huggingface_token() -> str | None:
+    return os.environ.get("HUGGINGFACE_TOKEN") or None
 
-    for file in files_metadata:
-        if hasattr(file, "size") and file.size is not None:
-            if file.path.endswith(".safetensors") and file.size > total_check_size:
-                if largest_file is None or file.size > largest_file.size:
-                    largest_file = file
 
-    if largest_file:
-        return True, largest_file.path
-    return False, None
+def _repo_file_metadata(repo_id: str) -> tuple[RepoFileMetadata, ...]:
+    repo_files = []
+    for entry in hf_api.list_repo_tree(
+        repo_id=repo_id,
+        repo_type="model",
+        recursive=True,
+        token=_huggingface_token(),
+    ):
+        if not hasattr(entry, "size"):
+            continue
+
+        path = str(entry.path)
+        if path.startswith("./"):
+            path = path[2:]
+        parsed_path = PurePosixPath(path)
+        if parsed_path.is_absolute() or ".." in parsed_path.parts:
+            raise ValueError(f"Unsafe path returned for Hugging Face repository {repo_id}")
+        repo_files.append(RepoFileMetadata(path=path, size=entry.size))
+
+    if not repo_files:
+        raise RuntimeError(f"Hugging Face repository {repo_id} contains no model files")
+    return tuple(repo_files)
+
+
+def _is_flux_model_type(model_type: ImageModelType | str) -> bool:
+    return model_type == ImageModelType.FLUX or model_type == ImageModelType.FLUX.value
+
+
+def _standalone_flux_checkpoint(
+    model_type: ImageModelType | str,
+    repo_files: tuple[RepoFileMetadata, ...],
+) -> RepoFileMetadata | None:
+    if not _is_flux_model_type(model_type):
+        return None
+
+    paths = [PurePosixPath(repo_file.path) for repo_file in repo_files]
+    root_checkpoints = [
+        repo_file
+        for repo_file, path in zip(repo_files, paths)
+        if len(path.parts) == 1 and path.suffix == ".safetensors"
+    ]
+    if len(root_checkpoints) != 1:
+        return None
+    if any(path == PurePosixPath("model_index.json") for path in paths):
+        return None
+    if any(path.parts[0] in DIFFUSERS_COMPONENT_DIRS for path in paths if len(path.parts) > 1):
+        return None
+    if any(repo_file.path.endswith(WEIGHT_INDEX_SUFFIXES) for repo_file in repo_files):
+        return None
+    if SHARDED_CHECKPOINT_PATTERN.search(root_checkpoints[0].path):
+        return None
+    return root_checkpoints[0]
+
+
+def _local_repo_path(root: Path, repo_path: str) -> Path:
+    return root.joinpath(*PurePosixPath(repo_path).parts)
+
+
+def _file_matches_metadata(path: Path, expected_size: int | None) -> bool:
+    if not path.is_file():
+        return False
+    if expected_size is None:
+        return True
+    return path.stat().st_size == expected_size
+
+
+def _standalone_checkpoint_is_complete(cache_path: Path, checkpoint: RepoFileMetadata) -> bool:
+    checkpoint_path = _local_repo_path(cache_path, checkpoint.path)
+    return (
+        cache_path.is_dir()
+        and not checkpoint_path.is_symlink()
+        and _file_matches_metadata(checkpoint_path, checkpoint.size)
+        and (checkpoint.size is not None or checkpoint_path.stat().st_size > 0)
+    )
+
+
+def _weight_index_references_exist(cache_path: Path) -> bool:
+    for index_path in cache_path.rglob("*.index.json"):
+        if not index_path.name.endswith(WEIGHT_INDEX_SUFFIXES):
+            continue
+        try:
+            with index_path.open(encoding="utf-8") as index_file:
+                weight_map = json.load(index_file).get("weight_map")
+        except (AttributeError, json.JSONDecodeError, OSError):
+            return False
+        if not isinstance(weight_map, dict) or not weight_map:
+            return False
+        for shard_path in set(weight_map.values()):
+            if not isinstance(shard_path, str):
+                return False
+            parsed_path = PurePosixPath(shard_path)
+            if parsed_path.is_absolute() or ".." in parsed_path.parts:
+                return False
+            relative_parts = parsed_path.parts
+            if not any(
+                candidate.is_file()
+                for candidate in (
+                    index_path.parent.joinpath(*relative_parts),
+                    cache_path.joinpath(*relative_parts),
+                )
+            ):
+                return False
+    return True
+
+
+def _snapshot_is_complete(
+    cache_path: Path,
+    repo_files: tuple[RepoFileMetadata, ...],
+    anonymized: bool,
+) -> bool:
+    if not cache_path.is_dir():
+        return False
+    for repo_file in repo_files:
+        local_path = _local_repo_path(cache_path, repo_file.path)
+        if not local_path.is_file():
+            return False
+        if anonymized and repo_file.path == "config.json":
+            continue
+        if repo_file.size is not None and local_path.stat().st_size != repo_file.size:
+            return False
+    return _weight_index_references_exist(cache_path)
+
+
+def _normalize_standalone_checkpoint(cache_path: Path, checkpoint: RepoFileMetadata) -> None:
+    checkpoint_name = PurePosixPath(checkpoint.path).name
+    for entry in cache_path.iterdir():
+        if entry.name != checkpoint_name and (entry.is_file() or entry.is_symlink()):
+            entry.unlink()
+
+    top_level_files = [entry for entry in cache_path.iterdir() if entry.is_file() or entry.is_symlink()]
+    if len(top_level_files) != 1 or top_level_files[0].name != checkpoint_name or top_level_files[0].is_symlink():
+        raise RuntimeError(f"Failed to normalize standalone FLUX checkpoint cache at {cache_path}")
+
+
+def _remove_path(path: Path) -> None:
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+    elif path.exists():
+        shutil.rmtree(path)
+
+
+def _promote_directory(download_path: Path, save_path: Path) -> None:
+    if not os.path.lexists(save_path):
+        os.rename(download_path, save_path)
+        return
+
+    backup_path = Path(tempfile.mkdtemp(prefix=f".{save_path.name}.backup-", dir=save_path.parent))
+    backup_path.rmdir()
+    os.rename(save_path, backup_path)
+    try:
+        os.rename(download_path, save_path)
+    except BaseException:
+        os.rename(backup_path, save_path)
+        raise
+    else:
+        _remove_path(backup_path)
+
+
+def _download_standalone_checkpoint(repo_id: str, checkpoint: RepoFileMetadata, download_path: Path) -> None:
+    checkpoint_path = _local_repo_path(download_path, checkpoint.path)
+    downloaded_path = Path(
+        hf_hub_download(
+            repo_id=repo_id,
+            filename=checkpoint.path,
+            local_dir=str(download_path),
+            local_dir_use_symlinks=False,
+            token=_huggingface_token(),
+        )
+    )
+    if not checkpoint_path.is_file() and downloaded_path.is_file():
+        checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(downloaded_path, checkpoint_path)
+    if not _standalone_checkpoint_is_complete(download_path, checkpoint):
+        raise RuntimeError(f"Standalone FLUX checkpoint download is incomplete for {repo_id}")
+    _normalize_standalone_checkpoint(download_path, checkpoint)
 
 
 def write_environment_task_proxy_dataset(
@@ -99,42 +279,63 @@ def write_environment_task_proxy_dataset(
     print(f"Wrote {len(records)} records to {out_path} with field '{prompt_field}'")
 
 
-def download_from_huggingface(repo_id: str, filename: str, local_dir: str) -> str:
-    try:
-        local_dir = os.path.expanduser(local_dir)
-        local_filename = f"{repo_id.replace('/', '_')}.safetensors"
-        final_path = os.path.join(local_dir, local_filename)
-        os.makedirs(local_dir, exist_ok=True)
-        if os.path.exists(final_path):
-            print(f"File {filename} already exists. Skipping download.")
-        else:
-            with tempfile.TemporaryDirectory() as temp_dir:
-                temp_file_path = hf_hub_download(repo_id=repo_id, filename=filename, local_dir=temp_dir)
-                shutil.move(temp_file_path, final_path)
-            print(f"File {filename} downloaded successfully")
-        return final_path
-    except Exception as e:
-        raise e
-
-
 def _model_dir_name(repo_id: str, anonymize: bool) -> str:
     if anonymize:
         return get_anonymous_model_dir(repo_id)
     return repo_id.replace("/", "--")
 
 
-async def download_base_model(repo_id: str, save_root: str, model_type: ImageModelType, anonymize: bool = True) -> str:
+async def download_base_model(
+    repo_id: str,
+    save_root: str,
+    model_type: ImageModelType | str,
+    anonymize: bool = True,
+) -> str:
     model_name = _model_dir_name(repo_id, anonymize)
-    save_path = os.path.join(save_root, model_name)
-    if os.path.exists(save_path):
-        print(f"Model already cached at {save_path}. Skipping download.")
-        return save_path
+    save_root_path = Path(save_root)
+    save_path = save_root_path / model_name
+    save_root_path.mkdir(parents=True, exist_ok=True)
+
+    repo_files = _repo_file_metadata(repo_id)
+    standalone_checkpoint = _standalone_flux_checkpoint(model_type, repo_files)
+
+    if standalone_checkpoint and _standalone_checkpoint_is_complete(save_path, standalone_checkpoint):
+        _normalize_standalone_checkpoint(save_path, standalone_checkpoint)
+        print(f"Standalone FLUX checkpoint cache is ready at {save_path}. Skipping download.", flush=True)
+        return str(save_path)
+    if standalone_checkpoint is None and _snapshot_is_complete(save_path, repo_files, anonymize):
+        print(f"Model cache is complete at {save_path}. Skipping download.", flush=True)
+        return str(save_path)
+
+    if os.path.lexists(save_path):
+        print(f"Model cache at {save_path} is incomplete. Replacing it safely.", flush=True)
     else:
-        snapshot_download(repo_id=repo_id, repo_type="model", local_dir=save_path, local_dir_use_symlinks=False)
-        result = save_path
+        print(f"Downloading model to {save_path}.", flush=True)
+
+    download_path = Path(tempfile.mkdtemp(prefix=f".{model_name}.download-", dir=save_root_path))
+    try:
+        if standalone_checkpoint:
+            _download_standalone_checkpoint(repo_id, standalone_checkpoint, download_path)
+        else:
+            snapshot_download(
+                repo_id=repo_id,
+                repo_type="model",
+                local_dir=str(download_path),
+                local_dir_use_symlinks=False,
+                token=_huggingface_token(),
+            )
+            if not _snapshot_is_complete(download_path, repo_files, anonymized=False):
+                raise RuntimeError(f"Hugging Face snapshot download is incomplete for {repo_id}")
+
         if anonymize:
-            scrub_model_identity(save_path)
-        return result
+            scrub_model_identity(str(download_path))
+        _promote_directory(download_path, save_path)
+    except BaseException:
+        _remove_path(download_path)
+        raise
+
+    print(f"Model cache is ready at {save_path}.", flush=True)
+    return str(save_path)
 
 
 def _detect_and_merge_lora(model_dir: str) -> None:
@@ -146,6 +347,11 @@ def _detect_and_merge_lora(model_dir: str) -> None:
     adapter_config_path = os.path.join(model_dir, LORA_ADAPTER_CONFIG)
     if not os.path.exists(adapter_config_path):
         return
+
+    import torch
+    from peft import PeftModel
+    from transformers import AutoModelForCausalLM
+    from transformers import AutoTokenizer
 
     with open(adapter_config_path) as f:
         adapter_config = json.load(f)
@@ -369,6 +575,8 @@ async def main():
                 adapters_dir,
             )
             print(f"Krea 2 text encoder downloaded to: {text_encoder_path}", flush=True)
+
+        from transformers import CLIPTokenizer
 
         print("Downloading clip models", flush=True)
         CLIPTokenizer.from_pretrained("openai/clip-vit-large-patch14", cache_dir=cst.HUGGINGFACE_CACHE_PATH)


### PR DESCRIPTION
Summary
- Fixes FLUX image-model cache compatibility for pinned miner repositories.
- Detects standalone FLUX checkpoints using repository layout instead of file size.
- Preserves the single-file cache layout expected by legacy miner resolvers.
- Automatically normalizes existing caches containing root metadata.
- Keeps Diffusers and AI Toolkit snapshots intact.
- Validates caches and uses atomic downloads to prevent incomplete cache reuse.
- Adds focused network-free tests and deployment documentation.

Verification
-Ruff passed.
-25 focused trainer tests passed