### PR TITLE
Hold champion emissions at a 15% floor instead of decaying to zero

### DIFF
--- a/tests/validator/tournament/test_hybrid_decay_system.py
+++ b/tests/validator/tournament/test_hybrid_decay_system.py
@@ -17,12 +17,12 @@ from datetime import timezone
 # Constants matching validator/scoring/constants.py
 EMISSION_BOOST_DECAY_PER_WIN = 0.01  # 1% per win (old system)
 # Piecewise-linear retention curve (multiplier on full day-0 emission weight):
-# fast early drop, a glide, then a cliff to zero at 40 days. (days, retention).
+# fast early drop, a glide, then a 15% floor held from 40 days on. (days, retention).
 EMISSION_TIME_DECAY_CURVE = (
     (0.0, 1.00),
     (7.0, 0.50),
     (30.0, 0.30),
-    (40.0, 0.00),
+    (40.0, 0.15),
 )
 EMISSION_TIME_DECAY_START_DATE = date(2025, 11, 26)
 SECONDS_PER_DAY = 86400.0

--- a/tests/validator/tournament/test_projection_alpha.py
+++ b/tests/validator/tournament/test_projection_alpha.py
@@ -1,8 +1,8 @@
 """Cumulative-alpha projections must integrate the piecewise decay curve.
 
-The old trapezoid between day 0 and the horizon kept accruing alpha long after
-the champion's weight hit the curve's zero-cliff (day 40), overstating 90/180
-day totals several-fold.
+A trapezoid between day 0 and the horizon would misstate the totals: the curve
+decays steeply early, then holds at a floor from day 40 on, so alpha keeps
+accruing past day 40 but at that flat floor rate.
 """
 
 from unittest.mock import patch
@@ -16,7 +16,7 @@ from validator.tournament.models import TournamentType
 from validator.tournament.performance_utils import calculate_tournament_projection
 
 
-DECAY_ZERO_DAY = cts.EMISSION_TIME_DECAY_CURVE[-1][0]
+DECAY_FLOOR_DAY, DECAY_FLOOR_RETENTION = cts.EMISSION_TIME_DECAY_CURVE[-1]
 
 
 async def project(percentage_improvement: float = 10.0):
@@ -34,15 +34,16 @@ async def project(percentage_improvement: float = 10.0):
 
 
 @pytest.mark.asyncio
-async def test_no_alpha_accrues_after_decay_cliff():
+async def test_weight_holds_at_floor_after_decay_settles():
     projection = await project()
     by_days = {p.days: p for p in projection.projections}
 
-    assert by_days[90].weight == 0.0
-    assert by_days[180].weight == 0.0
-    # Weight is zero from day 40 on, so the 90 and 180 day totals must be equal.
-    assert by_days[90].total_alpha == pytest.approx(by_days[180].total_alpha)
-    assert by_days[90].total_alpha > by_days[30].total_alpha
+    floor_weight = projection.initial_weight * DECAY_FLOOR_RETENTION
+    assert by_days[90].weight == pytest.approx(floor_weight)
+    assert by_days[180].weight == pytest.approx(floor_weight)
+    # Alpha keeps accruing past the floor day, at the flat floor rate.
+    expected_extra = (180 - 90) * floor_weight * cts.DAILY_ALPHA_TO_MINERS
+    assert by_days[180].total_alpha - by_days[90].total_alpha == pytest.approx(expected_extra, rel=1e-6)
 
 
 @pytest.mark.asyncio
@@ -51,10 +52,12 @@ async def test_total_alpha_matches_curve_integral():
     by_days = {p.days: p for p in projection.projections}
 
     initial_weight = projection.initial_weight
-    # Analytic area under the retention curve up to the zero-cliff, in weight-days.
+    # Analytic area under the retention curve, in weight-days: the piecewise ramp
+    # down to the floor, then a flat floor out to the horizon.
     curve = cts.EMISSION_TIME_DECAY_CURVE
-    area = sum((d1 - d0) * (r0 + r1) / 2.0 for (d0, r0), (d1, r1) in zip(curve, curve[1:]))
-    expected = initial_weight * area * cts.DAILY_ALPHA_TO_MINERS
+    ramp_area = sum((d1 - d0) * (r0 + r1) / 2.0 for (d0, r0), (d1, r1) in zip(curve, curve[1:]))
+    floor_area = (180 - DECAY_FLOOR_DAY) * DECAY_FLOOR_RETENTION
+    expected = initial_weight * (ramp_area + floor_area) * cts.DAILY_ALPHA_TO_MINERS
 
     assert by_days[180].total_alpha == pytest.approx(expected, rel=1e-6)
 

--- a/validator/scoring/constants.py
+++ b/validator/scoring/constants.py
@@ -41,12 +41,13 @@ EMISSION_MULTIPLIER_RATE = 2.0
 EMISSION_BOOST_DECAY_PER_WIN = 0.01
 # Champion emission decays on a piecewise-linear *retention* curve (multiplier on
 # the champion's full day-0 emission weight = base + boost). Fast early drop, a
-# plateau, then a cliff to zero at 40 days. (days_since_reign_start, retention).
+# plateau, then a floor of 15% held from day 40 onwards — a champion's emission
+# never drops below this. (days_since_reign_start, retention).
 EMISSION_TIME_DECAY_CURVE: tuple[tuple[float, float], ...] = (
     (0.0, 1.00),
     (7.0, 0.50),
     (30.0, 0.30),
-    (40.0, 0.00),
+    (40.0, 0.15),
 )
 EMISSION_TIME_DECAY_START_DATE = date(2025, 11, 26)
 SECONDS_PER_DAY = 86400.0

--- a/validator/scoring/weights.py
+++ b/validator/scoring/weights.py
@@ -146,9 +146,10 @@ def emission_time_retention(days_as_champion: float) -> float:
     """
     Piecewise-linear retention multiplier for a champion's emission weight.
 
-    Decays fast at first, plateaus, then drops to zero on a cliff. Anchored on
-    EMISSION_TIME_DECAY_CURVE (100% at day 0 -> 0% at day 40). Returns a value in
-    [0, 1] applied multiplicatively to the champion's full day-0 emission weight.
+    Decays fast at first, plateaus, then holds at a floor. Anchored on
+    EMISSION_TIME_DECAY_CURVE (100% at day 0 -> 15% at day 40, held from then on).
+    Returns a value in [0, 1] applied multiplicatively to the champion's full
+    day-0 emission weight.
     """
     curve = cts.EMISSION_TIME_DECAY_CURVE
     if days_as_champion <= curve[0][0]:

--- a/validator/tournament/performance_utils.py
+++ b/validator/tournament/performance_utils.py
@@ -196,8 +196,8 @@ async def calculate_tournament_projection(
             return winner_share * raw_weight * scale_factor
 
         # Cumulative alpha must integrate the piecewise decay curve, not interpolate
-        # linearly between day 0 and the horizon: the weight hits zero at the curve's
-        # cliff, after which no further alpha accrues.
+        # linearly between day 0 and the horizon: the weight falls to the curve's
+        # floor and accrues at that flat rate thereafter.
         max_days = max(projection_days)
         daily_weights = [weight_on_day(day) for day in range(max_days + 1)]
         cumulative_weight_days = [0.0]


### PR DESCRIPTION
## What

The champion emission retention curve cliffed to `0.00` at day 40, cutting a long-reigning champion's emissions off entirely. This changes the day-40 anchor to `0.15`: retention ramps down to that floor and holds there indefinitely, so emissions never drop below 15% of the day-0 weight.

```
EMISSION_TIME_DECAY_CURVE = (
    (0.0, 1.00),
    (7.0, 0.50),
    (30.0, 0.30),
    (40.0, 0.15),   # was 0.00
)
```

## Why it's a one-line change

`emission_time_retention` already clamps to the final anchor's value for any day past the end of the curve, so the floor needs no new branch. `calculate_tournament_projection` integrates the curve day by day, so it picks up the flat tail on its own — only its comment needed correcting.

## Verification

Retention sampled across day 0 → 2000: ramps 1.00 → 0.50 → 0.30 → 0.15 by day 40 and stays at exactly 0.15 thereafter. Minimum over the whole range is 0.15.

`tests/validator/tournament` + `tests/validator/scoring`: 180 passed. Two tests in `test_projection_alpha.py` encoded the zero-cliff and were rewritten for the floor semantics — weight now holds at the floor past day 40, and cumulative alpha keeps accruing at that flat rate (the integral check now adds the floor tail out to the horizon).

`test_env_tournament_advancement.py::test_round_3_envs_capped_at_total` fails, but it fails identically on a clean tree — pre-existing and unrelated.