### PR TITLE
docs: fix min field size, bracket formation, and dead file reference in miner.md

### DIFF
--- a/docs/miner.md
+++ b/docs/miner.md
@@ -120,8 +120,8 @@ A pending tournament activates only after enough validated miners are available:
 
 | Tournament type | Minimum validated miners |
 | --- | --- |
-| Text | 8 |
-| Image | 8 |
+| Text | 4 |
+| Image | 4 |
 | Environment | 5 |
 
 If too few miners validate, the pending tournament waits and retries participant collection.
@@ -404,10 +404,10 @@ Requested datasets are mounted read-only.
 
 Text tournaments use `InstructTextTask`, `DpoTask`, and `GrpoTask`.
 
-- If the field has more than 8 miners, the first round is a group round.
-- Group rounds create one instruct task per group.
-- The top 8 scored miners across group tasks advance.
-- Once the field is 8 or fewer, rounds become pairwise knockout rounds.
+- Round 1 bracket formation depends on field size (`validator/tournament/constants.py`):
+  - 3-14 miners: a "small tournament" — a single group plays `SMALL_TOURNAMENT_GROUP_TASKS` (3) instruct tasks, and only the top `SMALL_TOURNAMENT_ADVANCE` (2) miners advance.
+  - 4-8 miners outside that band, or later rounds down to 8 or fewer: pairwise knockout.
+  - More than 14 (or more than 8 in later rounds): a group round with groups sized around `EXPECTED_GROUP_SIZE` (32, min `MIN_GROUP_SIZE` 20), each playing one instruct task per group. Up to `TOP_WINNERS_TO_ADVANCE` (8) advance **per group**, so the total advancing can exceed 8 when there are multiple groups.
 - Knockout pairs receive one task, selected probabilistically from instruct, DPO, and GRPO.
 - The final boss round creates 6 tasks: 2 instruct, 1 DPO, 1 GRPO, and one continuous-SFT chat task per lineage (currently 2: `quasar` and `qwen`). Each continuous-SFT lineage carries across tournaments — every round trains the next chunk starting from that lineage's previous winner (or a fixed seed model on the first run). Some final tasks may use larger models.
 - Each boss-round task is won by beating the boss's score by at least `BOSS_ROUND_WIN_MARGIN` (currently a fixed 1%, applied additively on the magnitude of the boss's score so it stays correct for zero/negative GRPO rewards).
@@ -419,10 +419,7 @@ For instruct, DPO, and continuous-SFT (chat) tasks, lower adjusted loss is bette
 
 Image tournaments use `ImageTask`.
 
-- If the field has more than 8 miners, the first round is a group round.
-- Group rounds create one image task per group.
-- The top 8 scored miners across group tasks advance.
-- Once the field is 8 or fewer, rounds become pairwise knockout rounds.
+- Round 1 bracket formation follows the same field-size rules as text tournaments (see above), with one image task per group/small-tournament match instead of an instruct task.
 - Knockout pairs receive one image task.
 - The final boss round creates 6 image tasks. Up to 3 can be Z-Image or Qwen-Image tasks.
 - Each boss-round task is won by beating the boss's score by at least `BOSS_ROUND_WIN_MARGIN` (currently a fixed 1%, applied additively on the magnitude of the boss's score).
@@ -508,8 +505,6 @@ A rollout function:
 - Sends actions or completions to the environment server.
 - Collects rewards and trajectory data.
 - Returns the prompt tokens, completion tokens, logprobs, and reward values expected by your trainer.
-
-The base repository includes reference rollout functions in `ops/docker/environment_functions`.
 
 Rules for environment tournaments:
 


### PR DESCRIPTION
## Summary
Follow-up to #1319 (already merged) — a deeper audit of the rest of `docs/miner.md` against current code turned up three more discrepancies:

- **Minimum field size table** said 8 validated miners for text/image; the actual constant is `MIN_MINERS_FOR_TOURN = 4` (`validator/tournament/constants.py`).
- **Round-1 bracket formation** was described as a flat "&gt;8 miners → group round, top 8 advance / ≤8 → knockout", which misses real behavior in `organise_tournament_round` / `get_group_winners`:
  - Fields of 3-14 miners hit a distinct **"small tournament"** path (`SMALL_TOURNAMENT_MIN/MAX_PARTICIPANTS`): a single group plays `SMALL_TOURNAMENT_GROUP_TASKS` (3) matches, and only the top `SMALL_TOURNAMENT_ADVANCE` (2) miners advance.
  - In large-field group rounds, `TOP_WINNERS_TO_ADVANCE` (8) is applied **per group**, not as a single global cutoff — with multiple groups, more than 8 miners total can advance.
- **Dead file reference**: `ops/docker/environment_functions` doesn't exist anywhere in the repo; removed the claim.

Docs-only change, no code behavior affected.

## Test plan
- [x] Cross-checked against `validator/tournament/constants.py` (`MIN_MINERS_FOR_TOURN`, `SMALL_TOURNAMENT_*`, `EXPECTED_GROUP_SIZE`, `MIN_GROUP_SIZE`) and the bracket-formation logic in `validator/tournament/tournament_manager.py::organise_tournament_round` and `validator/tournament/round_results.py::get_group_winners`
- [x] Confirmed `ops/docker/environment_functions` doesn't exist via `find`
- [ ] Docs review by a maintainer

🤖 Generated with [Claude Code](https://claude.com/claude-code)