### PR TITLE
Fix auditor RetryError by bumping fiber to async-substrate-interface 2.x

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -80,6 +80,12 @@ tasks:
   install:
     cmds:
       - . $HOME/.venv/bin/activate
+      # fiber v2.7.0+ moved to async-substrate-interface 2.x, which depends on
+      # `cyscale` instead of `scalecodec`/`substrate-interface` (same import
+      # namespace as scalecodec, so it refuses to load if either is still
+      # around). `pip install -e .` won't remove those on its own since
+      # they're no longer required by anything, so clear them out first.
+      - pip uninstall -y substrate-interface scalecodec cyscale || true
       - pip install -e .
 
   auditor:
@@ -118,21 +124,21 @@ tasks:
           echo "  LOKI_PASSWORD=your-loki-password"
           exit 1
         fi
-        
+
         # Load variables from .vali.env
         export $(cat .vali.env | grep -v '^#' | xargs)
-        
+
         # Auto-detect OBSERVABILITY_DOMAIN if not set
         if [ -z "$OBSERVABILITY_DOMAIN" ]; then
           # Try to get public IP
           OBSERVABILITY_DOMAIN=$(curl -s ifconfig.me || curl -s icanhazip.com || hostname -I | awk '{print $1}')
           echo "Auto-detected OBSERVABILITY_DOMAIN: $OBSERVABILITY_DOMAIN"
         fi
-        
+
         # Use default passwords if not set
         GRAFANA_TRAINING_PASSWORD=${GRAFANA_TRAINING_PASSWORD:-changeme123}
         LOKI_PASSWORD=${LOKI_PASSWORD:-trainerlogs123}
-        
+
         # Create observability env from .vali.env variables
         cat > .env.observability << EOF
         OBSERVABILITY_DOMAIN=${OBSERVABILITY_DOMAIN}
@@ -192,10 +198,10 @@ tasks:
           echo "  LOKI_PASSWORD=your-loki-password"
           exit 1
         fi
-        
+
         # Load variables from .trainer.env
         export $(cat .trainer.env | grep -v '^#' | xargs)
-        
+
         # Check required variables
         if [ -z "$LOKI_ENDPOINT" ] || [ -z "$LOKI_PASSWORD" ]; then
           echo "ERROR: Missing required variables in .trainer.env:"
@@ -203,7 +209,7 @@ tasks:
           echo "  LOKI_PASSWORD=${LOKI_PASSWORD:-<not set>}"
           exit 1
         fi
-        
+
         # Create trainer env for Vector
         cat > .env.trainer-logs << EOF
         LOKI_ENDPOINT=${LOKI_ENDPOINT}

--- a/ops/auditing/audit_no_hotkey.py
+++ b/ops/auditing/audit_no_hotkey.py
@@ -10,12 +10,12 @@ from dataclasses import dataclass
 
 import httpx
 import websocket
+from async_substrate_interface import SubstrateInterface
 from fiber.chain import interface
-from substrateinterface import SubstrateInterface
 
+from core.logging import get_logger
 from ops.auditing.audit import audit_weights
 from validator.db.database import PSQLDB
-from core.logging import get_logger
 
 
 logger = get_logger(__name__)

--- a/ops/validator_ops/autoupdate_auditor_steps.sh
+++ b/ops/validator_ops/autoupdate_auditor_steps.sh
@@ -2,6 +2,13 @@
 # Change each time but take caution
 
 . $HOME/.venv/bin/activate
+
+# fiber v2.7.0+ moved to async-substrate-interface 2.x, which depends on `cyscale`
+# instead of `scalecodec`/`substrate-interface` (same import namespace as scalecodec,
+# so it refuses to load if the old packages are still around). `pip install -e .`
+# won't remove those on its own since they're no longer required by anything, so an
+# in-place upgrade from an older checkout needs them cleared out first.
+pip uninstall -y substrate-interface scalecodec cyscale || true
 pip install -e .
 
 task auditor

--- a/ops/validator_ops/autoupdate_validator_steps.sh
+++ b/ops/validator_ops/autoupdate_validator_steps.sh
@@ -3,6 +3,13 @@
 
 
 . $HOME/.venv/bin/activate
+
+# fiber v2.7.0+ moved to async-substrate-interface 2.x, which depends on `cyscale`
+# instead of `scalecodec`/`substrate-interface` (same import namespace as scalecodec,
+# so it refuses to load if the old packages are still around). `pip install -e .`
+# won't remove those on its own since they're no longer required by anything, so an
+# in-place upgrade from an older checkout needs them cleared out first.
+pip uninstall -y substrate-interface scalecodec cyscale || true
 pip install -e .
 
 task validator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "fastapi>=0.110.3,<0.113.0",
     "uvicorn>=0.30.5,<0.32.0",
     "setuptools<81",
-    "fiber @ git+https://github.com/besimray/fiber.git@v2.6.0",
+    "fiber @ git+https://github.com/besimray/fiber.git@v2.7.0",
     "asyncpg==0.29.0",
     "httpx==0.27.0",
     "loguru==0.7.2",
@@ -44,6 +44,7 @@ dependencies = [
     "gitpython",
     "astor",
     "rich>=13.7.0",
+    "websocket-client",
 ]
 
 [project.optional-dependencies]

--- a/validator/app/config.py
+++ b/validator/app/config.py
@@ -9,14 +9,14 @@ from dataclasses import dataclass
 
 import httpx
 import websocket
+from async_substrate_interface import SubstrateInterface
+from bittensor_wallet.keypair import Keypair
 from fiber.chain import chain_utils
 from fiber.chain import interface
 from redis.asyncio import Redis
-from substrateinterface import Keypair
-from substrateinterface import SubstrateInterface
 
-from validator.db.database import PSQLDB
 from core.logging import get_logger
+from validator.db.database import PSQLDB
 
 
 logger = get_logger(__name__)

--- a/validator/infrastructure/substrate.py
+++ b/validator/infrastructure/substrate.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from substrateinterface import SubstrateInterface
+from async_substrate_interface import SubstrateInterface
 
 from core.logging import get_logger
 

--- a/validator/scoring/weights.py
+++ b/validator/scoring/weights.py
@@ -31,11 +31,11 @@ import json
 from datetime import timezone
 from uuid import UUID
 
+from async_substrate_interface import SubstrateInterface
 from fiber.chain import fetch_nodes
 from fiber.chain import weights
 from fiber.chain.chain_utils import query_substrate
 from fiber.chain.models import Node
-from substrateinterface import SubstrateInterface
 
 import core.constants.network as ccst
 import validator.scoring.constants as cts

--- a/validator/tasks/synthetics/scheduler.py
+++ b/validator/tasks/synthetics/scheduler.py
@@ -7,7 +7,7 @@ from typing import Any
 from typing import AsyncGenerator
 from uuid import UUID
 
-from substrateinterface import Keypair
+from bittensor_wallet.keypair import Keypair
 
 import validator.infrastructure.service_constants as service_cst
 import validator.tasks.datasets.constants as data_cst


### PR DESCRIPTION
## Summary
- One validator's `auditor` pm2 process was crashing with `tenacity.RetryError[<Future ... raised ValueError>]` inside `fetch_nodes._get_nodes_for_uid`.
- Root cause: Subtensor's `SubnetInfoRuntimeApi.get_metagraph` runtime call now wraps its `netuid` param in a composite/newtype instead of a bare `u16`. Every `async-substrate-interface` 1.x release (including the previously pinned `1.1.1`, and the last-ever 1.x release, `1.6.4`) fails to encode a raw int against that type — reproduced live against mainnet finney.
- Fixed by bumping the `fiber` pin to [`besimray/fiber@v2.7.0`](https://github.com/besimray/fiber/releases/tag/v2.7.0), which moves to `async-substrate-interface` 2.x (encodes it correctly, verified live).
- ASI 2.x is a breaking rewrite (`cyscale` instead of `scalecodec`, no more `.value`-wrapped `runtime_call` results), so fiber also drops `substrate-interface` (py-substrate-interface, which conflicts with `cyscale`) in favor of `bittensor_wallet.keypair.Keypair`.
- Since `substrate-interface` only ever entered G.O.D's dependency tree transitively through fiber, dropping it surfaced two things G.O.D relied on without declaring:
  - `Keypair`/`SubstrateInterface` imported directly from `substrateinterface` in 5 files — swapped to `bittensor_wallet.keypair.Keypair` / `async_substrate_interface.SubstrateInterface`
  - `websocket-client` (used directly in `config.py`, `audit_no_hotkey.py`, `comfy_gateway.py`) was only present because `substrate-interface` pulled it in transitively — now declared explicitly

## Test plan
- [x] Reproduced the exact `RetryError`/`ValueError` live against mainnet finney with the old pin
- [x] Verified fiber v2.7.0 fixes `fetch_nodes._get_nodes_for_uid`, chain queries (`query_substrate`), and extrinsic compose/sign live against mainnet finney
- [x] Built a from-scratch venv from this branch's `pyproject.toml` (no cached/dev-machine leftovers) — clean install, no dependency conflicts
- [x] Confirmed all touched modules import cleanly from that clean venv
- [x] Ran `tests/validator/nodes/test_refresh.py` and `tests/validator/tournament/test_separated_burn_dynamics.py` — 10 passed
- [x] fiber's own test suite shows zero regressions vs. the unmodified fork (same pre-existing unrelated failures before/after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)