### PR TITLE
feat(validator): add deployment verification for PvP pairs

### DIFF
--- a/tests/validator/evaluation/test_eval_reconcile.py
+++ b/tests/validator/evaluation/test_eval_reconcile.py
@@ -65,8 +65,15 @@ def test_evaluations_ghost_within_ghost_grace_protected():
 
 # ---- PvP ghost release (short grace, pair-scoped) ----
 
-def _pvp(dep_id, age, task="t1", a="hkA", b="hkB"):
-    return PvpPairReservation(task_id=task, hotkey_a=a, hotkey_b=b, deployment_id=dep_id, updated_at=_ago(age))
+def _pvp(dep_id, age, task="t1", a="hkA", b="hkB", verified=True):
+    return PvpPairReservation(
+        task_id=task,
+        hotkey_a=a,
+        hotkey_b=b,
+        deployment_id=dep_id,
+        verified=verified,
+        updated_at=_ago(age),
+    )
 
 
 def test_pvp_ghost_released_after_ghost_grace():
@@ -89,8 +96,20 @@ def test_pvp_ghost_within_ghost_grace_protected():
 
 def test_pvp_reservation_without_deployment_id_is_not_a_ghost():
     # booting pair (deployment_id NULL) is handled by the long stale sweep, never the ghost path
-    plan = _plan(pvp=[PvpPairReservation("t1", "hkA", "hkB", None, _ago(60))])
+    plan = _plan(pvp=[PvpPairReservation("t1", "hkA", "hkB", None, False, _ago(60))])
     assert plan.ghost_pvp_pairs == ()
+
+
+def test_pvp_unverified_id_older_than_ghost_grace_but_within_orphan_grace_is_protected():
+    # Unverified marker can persist during long deploy startup; do not ghost at short grace.
+    plan = _plan(pvp=[_pvp("pvp-booting", 5, verified=False)])
+    assert plan.ghost_pvp_pairs == ()
+
+
+def test_pvp_unverified_id_older_than_orphan_grace_is_ghosted():
+    plan = _plan(pvp=[_pvp("pvp-boot-stalled", 35, verified=False)])
+    assert len(plan.ghost_pvp_pairs) == 1
+    assert plan.ghost_pvp_pairs[0].deployment_id == "pvp-boot-stalled"
 
 
 # ---- combined ----

--- a/validator/db/constants.py
+++ b/validator/db/constants.py
@@ -62,6 +62,7 @@ PVP_DRAWS = "draws"
 PVP_TOTAL_GAMES = "total_games"
 PVP_N_ATTEMPTS = "n_attempts"
 PVP_DEPLOYMENT_ID = "deployment_id"
+PVP_DEPLOYMENT_VERIFIED = "deployment_verified"
 PVP_STATUS_PENDING = PvPStatus.PENDING
 PVP_STATUS_COMPLETE = PvPStatus.COMPLETE
 

--- a/validator/db/migrations/20260720160000_add_pvp_pair_deployment_verified.sql
+++ b/validator/db/migrations/20260720160000_add_pvp_pair_deployment_verified.sql
@@ -1,0 +1,13 @@
+-- migrate:up
+ALTER TABLE pvp_pair_results
+ADD COLUMN IF NOT EXISTS deployment_verified BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_pvp_pair_results_deployment_verified
+ON pvp_pair_results(deployment_verified)
+WHERE deployment_id IS NOT NULL;
+
+-- migrate:down
+DROP INDEX IF EXISTS idx_pvp_pair_results_deployment_verified;
+
+ALTER TABLE pvp_pair_results
+DROP COLUMN IF EXISTS deployment_verified;

--- a/validator/db/sql/tasks.py
+++ b/validator/db/sql/tasks.py
@@ -2069,6 +2069,7 @@ async def release_pvp_pair_gpus(
             UPDATE {cst.PVP_PAIR_RESULTS_TABLE}
             SET {cst.GPU_COUNT} = NULL,
                 {cst.PVP_DEPLOYMENT_ID} = NULL,
+                {cst.PVP_DEPLOYMENT_VERIFIED} = FALSE,
                 {cst.UPDATED_AT} = CURRENT_TIMESTAMP
             WHERE {cst.TASK_ID} = $1 AND {cst.PVP_HOTKEY_A} = $2 AND {cst.PVP_HOTKEY_B} = $3
             """,

--- a/validator/db/sql/tournaments.py
+++ b/validator/db/sql/tournaments.py
@@ -1529,6 +1529,7 @@ async def set_pvp_pair_deployment_id(
     hotkey_a: str,
     hotkey_b: str,
     deployment_id: str | None,
+    verified: bool,
     psql_db: PSQLDB,
 ) -> None:
     """Store the Basilica deployment ID for all env rows belonging to a PvP pair."""
@@ -1537,11 +1538,12 @@ async def set_pvp_pair_deployment_id(
         db_result = await connection.execute(f"""
             UPDATE {cst.PVP_PAIR_RESULTS_TABLE}
             SET {cst.PVP_DEPLOYMENT_ID} = $4,
+                {cst.PVP_DEPLOYMENT_VERIFIED} = $5,
                 {cst.UPDATED_AT} = CURRENT_TIMESTAMP
             WHERE {cst.TASK_ID} = $1
                 AND {cst.PVP_HOTKEY_A} = $2
                 AND {cst.PVP_HOTKEY_B} = $3
-        """, task_id, hk_a, hk_b, deployment_id)
+        """, task_id, hk_a, hk_b, deployment_id, verified)
         updated_rows = _row_count(db_result)
         if updated_rows == 0:
             logger.warning(
@@ -1582,6 +1584,7 @@ async def get_active_pvp_pair_reservations(psql_db: PSQLDB) -> list[dict]:
                    {cst.PVP_HOTKEY_A} AS hotkey_a,
                    {cst.PVP_HOTKEY_B} AS hotkey_b,
                    MAX({cst.PVP_DEPLOYMENT_ID}) AS deployment_id,
+                   bool_or({cst.PVP_DEPLOYMENT_VERIFIED}) AS deployment_verified,
                    MAX({cst.UPDATED_AT}) AS updated_at
             FROM {cst.PVP_PAIR_RESULTS_TABLE}
             WHERE {cst.STATUS} != $1

--- a/validator/evaluation/docker_evaluation.py
+++ b/validator/evaluation/docker_evaluation.py
@@ -453,6 +453,7 @@ async def _persist_pvp_deployment_id(
     psql_db: PSQLDB | None,
     hotkeys: list[str],
     deployment_name: str,
+    verified: bool,
     ctx: _BasilicaEvalContext,
 ) -> None:
     if task_id is None or psql_db is None or not hotkeys:
@@ -466,6 +467,7 @@ async def _persist_pvp_deployment_id(
                 hotkeys[0],
                 hotkeys[1],
                 deployment_name,
+                verified,
                 psql_db,
             ),
             "set_pvp_pair_deployment_id",
@@ -640,6 +642,7 @@ async def _deploy_pvp_eval(
                     psql_db=psql_db,
                     hotkeys=hotkeys,
                     deployment_name=deployment_name,
+                    verified=False,
                     ctx=ctx,
                 )
             log_step(
@@ -662,6 +665,7 @@ async def _deploy_pvp_eval(
                         psql_db=psql_db,
                         hotkeys=hotkeys,
                         deployment_name=verified_deployment_name,
+                        verified=True,
                         ctx=ctx,
                     )
                 except Exception as persist_exc:

--- a/validator/evaluation/reconcile.py
+++ b/validator/evaluation/reconcile.py
@@ -55,6 +55,7 @@ class PvpPairReservation:
     hotkey_a: str
     hotkey_b: str
     deployment_id: str | None
+    verified: bool
     updated_at: datetime.datetime
 
 
@@ -84,9 +85,11 @@ def plan_eval_reconcile(
     - ORPHAN reaping (live deployment with no backing) and boot-window stale-release use the LONG
       `orphan_grace` — a deployment may legitimately be mid-startup (reserved but not yet backing).
     - GHOST release (a reservation whose deployment is provably absent from a fresh `list()`) uses
-      the SHORT `ghost_grace`: a reservation only carries a deployment id once it was stamped
-      post-readiness, so a still-booting eval is never a ghost, and a dead deployment's GPUs should
-      be freed fast rather than pinning the cap for the full orphan grace.
+      grace by verification state:
+      - verified deployment ids (post-readiness stamp) use SHORT `ghost_grace`, so dead deployments
+        free GPU reservations quickly.
+      - unverified deployment ids (pre-deploy boot marker) use LONG `orphan_grace`, so a booting
+        deployment is never falsely ghosted before the ready window expires.
 
     `active` are the `evaluations` rows carrying a deployment id (individual evals); `pvp_reservations`
     are the per-pair reservations on `pvp_pair_results` (PvP evals).
@@ -101,7 +104,9 @@ def plan_eval_reconcile(
     ghost_pvp = tuple(
         r
         for r in pvp_reservations
-        if r.deployment_id and r.deployment_id not in live_names and (now - r.updated_at) >= ghost_grace
+        if r.deployment_id
+        and r.deployment_id not in live_names
+        and (now - r.updated_at) >= (ghost_grace if r.verified else orphan_grace)
     )
     return ReconcilePlan(orphan_deployments=orphans, ghost_deployment_ids=ghosts, ghost_pvp_pairs=ghost_pvp)
 
@@ -159,6 +164,7 @@ async def reconcile_eval_deployments(psql_db: PSQLDB) -> ReconcilePlan | None:
             hotkey_a=row["hotkey_a"],
             hotkey_b=row["hotkey_b"],
             deployment_id=row.get("deployment_id"),
+            verified=bool(row.get("deployment_verified")),
             updated_at=row["updated_at"],
         )
         for row in pvp_reservation_rows


### PR DESCRIPTION
- Introduced a new boolean field `deployment_verified` in the `pvp_pair_results` table to track the verification state of deployments.
- Updated relevant functions and tests to handle the new `verified` parameter, ensuring proper ghosting behavior based on deployment verification status.
- Adjusted the reconciliation logic to differentiate between verified and unverified deployments, affecting ghost release timing.

This change enhances the handling of PvP pair reservations, allowing for more accurate management of deployment states.