### PR TITLE
Block remote model code execution during evaluation

### DIFF
--- a/core/pvp/sglang_launch.py
+++ b/core/pvp/sglang_launch.py
@@ -7,6 +7,22 @@ stay identical or the two paths drift apart flag by flag.
 """
 
 import os
+import shlex
+
+
+TRUST_REMOTE_CODE_FLAG = "--trust-remote-code"
+
+
+def ensure_remote_code_disabled(command: str) -> str:
+    """Reject SGLang commands that opt into executing model-repository code."""
+    try:
+        args = shlex.split(command)
+    except ValueError as exc:
+        raise ValueError(f"Invalid SGLang command: {exc}") from exc
+
+    if any(arg.split("=", maxsplit=1)[0].replace("_", "-") == TRUST_REMOTE_CODE_FLAG for arg in args):
+        raise ValueError(f"SGLang {TRUST_REMOTE_CODE_FLAG} is forbidden for miner model evaluation")
+    return command
 
 
 def build_base_command(model_path: str, port: int | str, seed: int) -> str:

--- a/tests/validator/evaluation/test_environment_lora_merge.py
+++ b/tests/validator/evaluation/test_environment_lora_merge.py
@@ -1,10 +1,14 @@
 import sys
 from types import SimpleNamespace
 
+import pytest
+
 from validator.evaluation.evaluators import environment
+from validator.evaluation.evaluators import intercode
 
 
-def test_merge_disables_stale_transformers_peft_state_before_saving(monkeypatch, tmp_path):
+@pytest.mark.parametrize("evaluator", [environment, intercode])
+def test_merge_disables_remote_code_and_stale_peft_state(monkeypatch, tmp_path, evaluator):
     class FakeTokenizer:
         chat_template = None
 
@@ -29,9 +33,18 @@ def test_merge_disables_stale_transformers_peft_state_before_saving(monkeypatch,
         float16=object(),
         cuda=SimpleNamespace(is_available=lambda: False, empty_cache=lambda: None),
     )
+
+    def load_tokenizer(*_args, **kwargs):
+        assert kwargs["trust_remote_code"] is False
+        return FakeTokenizer()
+
+    def load_model(*_args, **kwargs):
+        assert kwargs["trust_remote_code"] is False
+        return FakeBaseModel()
+
     fake_transformers = SimpleNamespace(
-        AutoModelForCausalLM=SimpleNamespace(from_pretrained=lambda *_args, **_kwargs: FakeBaseModel()),
-        AutoTokenizer=SimpleNamespace(from_pretrained=lambda *_args, **_kwargs: FakeTokenizer()),
+        AutoModelForCausalLM=SimpleNamespace(from_pretrained=load_model),
+        AutoTokenizer=SimpleNamespace(from_pretrained=load_tokenizer),
     )
     fake_peft = SimpleNamespace(
         PeftModel=SimpleNamespace(
@@ -41,13 +54,36 @@ def test_merge_disables_stale_transformers_peft_state_before_saving(monkeypatch,
         )
     )
 
-    monkeypatch.setattr(environment.importlib.util, "find_spec", lambda _name: object())
-    monkeypatch.setattr(environment, "ensure_chat_template", lambda *_args: None)
-    monkeypatch.setattr(environment, "read_chat_template", lambda *_args: None)
+    monkeypatch.setattr(evaluator.importlib.util, "find_spec", lambda _name: object())
+    monkeypatch.setattr(evaluator, "ensure_chat_template", lambda *_args: None)
+    monkeypatch.setattr(evaluator, "read_chat_template", lambda *_args: None)
     monkeypatch.setitem(sys.modules, "torch", fake_torch)
     monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
     monkeypatch.setitem(sys.modules, "peft", fake_peft)
 
     output_dir = tmp_path / "merged"
 
-    assert environment._merge_base_and_lora("base", "adapter", str(output_dir)) == str(output_dir)
+    assert evaluator._merge_base_and_lora("base", "adapter", str(output_dir)) == str(output_dir)
+
+
+@pytest.mark.parametrize("evaluator", [environment, intercode])
+def test_model_snapshot_downloads_exclude_python_modules(monkeypatch, evaluator):
+    calls = []
+
+    def fake_snapshot_download(*args, **kwargs):
+        calls.append((args, kwargs))
+        return kwargs.get("local_dir", "/tmp/model-snapshot")
+
+    monkeypatch.setattr(evaluator, "snapshot_download", fake_snapshot_download)
+
+    assert evaluator._download_model_with_retry("org/model") == "/tmp/model-snapshot"
+    assert evaluator._download_lora_with_retry("org/adapter", "/tmp/adapter") == "/tmp/adapter"
+    assert all(kwargs["ignore_patterns"] == ["*.py"] for _args, kwargs in calls)
+
+
+@pytest.mark.parametrize("evaluator", [environment, intercode])
+def test_environment_sglang_commands_reject_remote_code(monkeypatch, evaluator):
+    monkeypatch.setenv("SGLANG_ENV_EVAL_EXTRA_CLI", "--trust-remote-code")
+
+    with pytest.raises(ValueError, match="trust-remote-code"):
+        evaluator._build_sglang_command("/tmp/model", 42)

--- a/tests/validator/evaluation/test_pvp_coverage_gaps.py
+++ b/tests/validator/evaluation/test_pvp_coverage_gaps.py
@@ -254,6 +254,15 @@ class TestBuildSglangCommand:
 
         assert "--tool-call-parser qwen25" in cmd
 
+    def test_remote_code_flag_is_rejected(self, monkeypatch):
+        from validator.evaluation.pvp.server import build_sglang_command
+
+        monkeypatch.setenv("SGLANG_ENV_EVAL_EXTRA_CLI", "--trust_remote_code=true")
+        prepared = PreparedModel(sglang_model_path="org/model", inference_name="org/model")
+
+        with pytest.raises(ValueError, match="trust-remote-code"):
+            build_sglang_command(prepared, port=30000, seed=1)
+
 
 # =============================================================================
 # 4. Chat client retry logic

--- a/tests/validator/evaluation/test_swe_infinite_evaluator.py
+++ b/tests/validator/evaluation/test_swe_infinite_evaluator.py
@@ -259,3 +259,20 @@ async def test_prepare_sglang_command_full_weights_matches_pvp_startup(monkeypat
     assert "--port 31000" in command
     assert "--random-seed 7" in command
     assert "--tool-call-parser qwen25" in command
+
+
+@pytest.mark.asyncio
+async def test_prepare_sglang_command_rejects_remote_code_start_override(monkeypatch):
+    monkeypatch.setattr(swe, "check_for_lora", lambda *_args: False)
+    monkeypatch.setenv(
+        "SGLANG_START_CMD",
+        "python3 -m sglang.launch_server --model-path org/model --trust-remote-code",
+    )
+
+    with pytest.raises(ValueError, match="trust-remote-code"):
+        await swe._prepare_sglang_command(
+            model_repo="org/model",
+            original_model="org/base",
+            base_chain=[],
+            base_seed=7,
+        )

--- a/trainer/model_prep/env_stats.py
+++ b/trainer/model_prep/env_stats.py
@@ -30,6 +30,7 @@ from core.pvp.baseline import supports_in_harness_baseline
 from core.pvp.chat import chat_completion
 from core.pvp.chat import create_client
 from core.pvp.sglang_launch import build_base_command
+from core.pvp.sglang_launch import ensure_remote_code_disabled
 from core.pvp.sglang_parsers import tool_call_parser_for
 
 
@@ -75,7 +76,8 @@ def build_sglang_command(model_path: str, seed: int) -> str:
     if parser:
         base = f"{base} --tool-call-parser {parser}"
     extra = (os.getenv("SGLANG_ENV_EVAL_EXTRA_CLI") or SGLANG_EXTRA_CLI_DEFAULT).strip()
-    return f"{base} {extra}" if extra else base
+    command = f"{base} {extra}" if extra else base
+    return ensure_remote_code_disabled(command)
 
 
 def start_process(command: str, name: str, *, capture_stdout: bool = False) -> subprocess.Popen:

--- a/validator/evaluation/README.md
+++ b/validator/evaluation/README.md
@@ -32,6 +32,12 @@ matching PvP evaluation even when the adapter repository contains tokenizer or
 added-token artifacts. This preserves the base tokenizer/EOS serving contract and
 avoids constructing a SWE-only merged model with divergent tokenizer metadata.
 
+Environment, InterCode, SWE Infinite, and PvP evaluation do not opt into
+Hugging Face remote model code. Transformer merge loads explicitly disable
+`trust_remote_code`, downloaded snapshots exclude Python modules, and SGLang
+commands that contain `--trust-remote-code` are rejected. Models that require
+custom repository code therefore fail closed during evaluation.
+
 Each SWE task contributes one term to the final average. A task that still fails
 or exceeds the overall session timeout contributes `0.0`. Affinetes TCP connection
 setup failures are retried by default up to three total attempts, with exponential

--- a/validator/evaluation/evaluators/environment.py
+++ b/validator/evaluation/evaluators/environment.py
@@ -16,6 +16,7 @@ from huggingface_hub import snapshot_download
 import core.constants.environments as env_cst
 import validator.evaluation.constants as vcst
 from core.models.dataset_models import EnvironmentDatasetType
+from core.pvp.sglang_launch import ensure_remote_code_disabled
 from core.tokenizer_utils import ensure_chat_template
 from core.tokenizer_utils import read_chat_template
 from validator.evaluation.evaluation_logging import configure_eval_logging
@@ -39,7 +40,7 @@ def _download_model_with_retry(repo_id: str, max_retries: int = 3) -> str:
                 repo_id,
             )
             start = time.time()
-            path = snapshot_download(repo_id, local_files_only=False)
+            path = snapshot_download(repo_id, local_files_only=False, ignore_patterns=["*.py"])
             elapsed = time.time() - start
             logger.info("eval_setup base model snapshot_download done in %.1fs -> %s", elapsed, path)
             return path
@@ -66,7 +67,7 @@ def _download_lora_with_retry(repo_id: str, local_dir: str, max_retries: int = 3
                 local_dir,
             )
             start = time.time()
-            snapshot_download(repo_id, local_dir=local_dir, local_dir_use_symlinks=False)
+            snapshot_download(repo_id, local_dir=local_dir, local_dir_use_symlinks=False, ignore_patterns=["*.py"])
             elapsed = time.time() - start
             logger.info("eval_setup LoRA snapshot_download done in %.1fs", elapsed)
             return local_dir
@@ -112,8 +113,8 @@ def _merge_base_and_lora(
         output_dir,
     )
     logger.info("eval_setup merge: loading tokenizers...")
-    base_tokenizer = AutoTokenizer.from_pretrained(base_model_path, trust_remote_code=True)
-    lora_tokenizer = AutoTokenizer.from_pretrained(lora_dir, trust_remote_code=True)
+    base_tokenizer = AutoTokenizer.from_pretrained(base_model_path, trust_remote_code=False)
+    lora_tokenizer = AutoTokenizer.from_pretrained(lora_dir, trust_remote_code=False)
 
     t0 = time.time()
     logger.info("eval_setup merge: loading base weights (AutoModelForCausalLM.from_pretrained)...")
@@ -122,7 +123,7 @@ def _merge_base_and_lora(
         torch_dtype=torch.float16,
         low_cpu_mem_usage=True,
         device_map=(device or "cuda:0") if torch.cuda.is_available() else "auto",
-        trust_remote_code=True,
+        trust_remote_code=False,
     )
     logger.info("eval_setup merge: base weights in memory in %.1fs", time.time() - t0)
 
@@ -207,7 +208,8 @@ def _build_sglang_command(model_path: str, seed: int) -> str:
         f"--enable-deterministic-inference --random-seed {seed}"
     )
     extra = (os.getenv("SGLANG_ENV_EVAL_EXTRA_CLI") or vcst.SGLANG_ENV_EVAL_EXTRA_CLI).strip()
-    return f"{base} {extra}" if extra else base
+    command = f"{base} {extra}" if extra else base
+    return ensure_remote_code_disabled(command)
 
 
 def _start_process(command: str, name: str) -> subprocess.Popen:
@@ -578,6 +580,7 @@ async def _run() -> None:
             model_path_for_sglang,
             inference_model_name,
         )
+        sglang_command = ensure_remote_code_disabled(sglang_command)
         logger.info("eval_setup SGLang command: %s", sglang_command)
         _min_ws = vcst.SGLANG_FLASHINFER_WORKSPACE_MIN_BYTES
         try:

--- a/validator/evaluation/evaluators/intercode.py
+++ b/validator/evaluation/evaluators/intercode.py
@@ -57,6 +57,7 @@ from core.models.pvp_models import FunctionSchema
 from core.models.pvp_models import ToolCall
 from core.models.pvp_models import ToolSchema
 from core.pvp.chat import chat_completion
+from core.pvp.sglang_launch import ensure_remote_code_disabled
 from core.pvp.sglang_parsers import tool_call_parser_for
 from core.tokenizer_utils import ensure_chat_template
 from core.tokenizer_utils import read_chat_template
@@ -143,7 +144,7 @@ def _download_model_with_retry(repo_id: str, max_retries: int = DEFAULT_DOWNLOAD
                 attempt, max_retries, repo_id,
             )
             start = time.time()
-            path = snapshot_download(repo_id, local_files_only=False)
+            path = snapshot_download(repo_id, local_files_only=False, ignore_patterns=["*.py"])
             logger.info("eval_setup base model snapshot_download done in %.1fs -> %s", time.time() - start, path)
             return path
         except Exception as exc:
@@ -162,7 +163,7 @@ def _download_lora_with_retry(repo_id: str, local_dir: str, max_retries: int = D
         try:
             logger.info("eval_setup download LoRA (attempt %s/%s): %s -> %s", attempt, max_retries, repo_id, local_dir)
             start = time.time()
-            snapshot_download(repo_id, local_dir=local_dir, local_dir_use_symlinks=False)
+            snapshot_download(repo_id, local_dir=local_dir, local_dir_use_symlinks=False, ignore_patterns=["*.py"])
             logger.info("eval_setup LoRA snapshot_download done in %.1fs", time.time() - start)
             return local_dir
         except Exception as exc:
@@ -192,15 +193,15 @@ def _merge_base_and_lora(base_model_path: str, lora_dir: str, output_dir: str = 
     from transformers import AutoTokenizer
 
     logger.info("eval_setup merge: start base=%s lora=%s out=%s", base_model_path, lora_dir, output_dir)
-    base_tokenizer = AutoTokenizer.from_pretrained(base_model_path, trust_remote_code=True)
-    lora_tokenizer = AutoTokenizer.from_pretrained(lora_dir, trust_remote_code=True)
+    base_tokenizer = AutoTokenizer.from_pretrained(base_model_path, trust_remote_code=False)
+    lora_tokenizer = AutoTokenizer.from_pretrained(lora_dir, trust_remote_code=False)
 
     base = AutoModelForCausalLM.from_pretrained(
         base_model_path,
         torch_dtype=torch.float16,
         low_cpu_mem_usage=True,
         device_map="cuda:0" if torch.cuda.is_available() else "auto",
-        trust_remote_code=True,
+        trust_remote_code=False,
     )
 
     base_vocab_size = base.get_input_embeddings().weight.shape[0]
@@ -281,7 +282,8 @@ def _build_sglang_command(model_path: str, seed: int, *, parser_model_id: str | 
     if parser:
         base = f"{base} --tool-call-parser {parser}"
     extra = (os.getenv("SGLANG_ENV_EVAL_EXTRA_CLI") or DEFAULT_SGLANG_EXTRA_CLI).strip()
-    return f"{base} {extra}" if extra else base
+    command = f"{base} {extra}" if extra else base
+    return ensure_remote_code_disabled(command)
 
 
 def _start_process(command: str, name: str, *, capture_stdout: bool = True) -> subprocess.Popen:
@@ -1005,6 +1007,7 @@ async def _run() -> None:
         if _cur_ws < _min_ws:
             os.environ["SGLANG_FLASHINFER_WORKSPACE_SIZE"] = str(_min_ws)
 
+        sglang_command = ensure_remote_code_disabled(sglang_command)
         logger.info("eval_setup SGLang command: %s", sglang_command)
         sglang_proc = _start_process(sglang_command, "sglang", capture_stdout=LOG_SGLANG_STDOUT)
         if LOG_SGLANG_STDOUT:

--- a/validator/evaluation/evaluators/swe.py
+++ b/validator/evaluation/evaluators/swe.py
@@ -22,6 +22,7 @@ import core.constants.environments as env_cst
 import validator.evaluation.constants as vcst
 from core.models.dataset_models import EnvironmentDatasetType
 from core.models.pvp_models import PreparedModel
+from core.pvp.sglang_launch import ensure_remote_code_disabled
 from core.pvp.sglang_parsers import tool_call_parser_for
 from validator.evaluation.evaluation_logging import configure_eval_logging
 from validator.evaluation.evaluators.environment import _start_process
@@ -400,7 +401,7 @@ async def _prepare_sglang_command(
     sglang_command = os.getenv("SGLANG_START_CMD")
     if sglang_command:
         logger.info("eval_setup SGLang: using SGLANG_START_CMD from environment")
-        return model_repo, model_repo, sglang_command
+        return model_repo, model_repo, ensure_remote_code_disabled(sglang_command)
 
     if is_lora:
         # Keep SWE model serving identical to PvP: SGLang loads the submitted adapter

--- a/validator/evaluation/local_evaluation.py
+++ b/validator/evaluation/local_evaluation.py
@@ -31,6 +31,7 @@ from core.models.dataset_models import GrpoDatasetType
 from core.models.dataset_models import InstructTextDatasetType
 from core.models.image_models import ImageModelType
 from core.models.payload_models import DockerEvaluationResults
+from core.pvp.sglang_launch import ensure_remote_code_disabled
 from validator.evaluation.evaluators.environment import _build_sglang_command
 from validator.evaluation.evaluators.environment import _download_lora_with_retry
 from validator.evaluation.evaluators.environment import _download_model_with_retry
@@ -470,6 +471,7 @@ async def run_evaluation_local_environment(
                 inference_model_name = repo
                 sglang_args = _build_local_sglang_command(model_path_for_sglang, base_seed)
 
+            sglang_args = ensure_remote_code_disabled(sglang_args)
             local_sglang_port = int(os.getenv("SGLANG_PORT", str(vcst.LOCAL_ENV_SGLANG_PORT)))
             sglang_container_name = f"{eval_id}-sglang"
             env_container_name = f"{eval_id}-env"

--- a/validator/evaluation/pvp/server.py
+++ b/validator/evaluation/pvp/server.py
@@ -13,6 +13,7 @@ import threading
 import validator.evaluation.constants as vcst
 from core.models.pvp_models import PreparedModel
 from core.pvp.sglang_launch import build_base_command
+from core.pvp.sglang_launch import ensure_remote_code_disabled
 from core.pvp.sglang_parsers import tool_call_parser_for
 from validator.evaluation.evaluators.environment import _wait_for_health
 
@@ -33,7 +34,7 @@ def build_sglang_command(prepared: PreparedModel, port: int, seed: int) -> str:
         cmd = f"{cmd} {cli_extra}"
     if prepared.extra_sglang_args:
         cmd = f"{cmd} {prepared.extra_sglang_args}"
-    return cmd
+    return ensure_remote_code_disabled(cmd)
 
 
 def start_sglang(prepared: PreparedModel, gpu_id: int, port: int, seed: int) -> subprocess.Popen:


### PR DESCRIPTION
Summary
-Disable trust_remote_code for InterCode and environment model/tokenizer loads.
-Protect SWE and PvP through their shared model-materialization and SGLang paths.
-Exclude Python modules from downloaded evaluation snapshots.
-Reject SGLang commands containing --trust-remote-code.
-Preserve Quasar text-tournament support through its existing audited remote-code pinning.