### PR TITLE
Downweight continuous reward templates in GRPO task sampling

### DIFF
--- a/validator/tasks/rewards/templates.py
+++ b/validator/tasks/rewards/templates.py
@@ -61,6 +61,13 @@ class ParamSpec(BaseModel):
         raise ValueError(f"Unknown param type: {self.param_type}")
 
 
+# Continuous metrics (langcheck, textstat, keyword counts) are easily ground
+# down by a targeted training run — sample them ~10x less often. 0.03 (not 0.1)
+# because sampling n groups without replacement from 7 blunts the raw weight:
+# empirically 0.03 → ~10-12x fewer appearances per task.
+CONTINUOUS_SAMPLING_WEIGHT = 0.03
+
+
 class RewardTemplate(BaseModel):
     """A parameterized reward function template.
 
@@ -74,6 +81,7 @@ class RewardTemplate(BaseModel):
     scoring_mode: ScoringMode
     code_template: str = Field(..., description="Python function string with {param} placeholders")
     params: dict[str, ParamSpec] = Field(default_factory=dict)
+    sampling_weight: float = Field(default=1.0, description="Relative sampling probability")
 
     def instantiate(self, rng: random.Random | None = None) -> str:
         """Sample all parameters and return a concrete function string."""
@@ -206,6 +214,7 @@ KEYWORD_PRESENCE = RewardTemplate(
             ],
         ),
     },
+    sampling_weight=CONTINUOUS_SAMPLING_WEIGHT,
 )
 
 
@@ -234,6 +243,7 @@ TEXTSTAT_DIRECTIONAL = RewardTemplate(
         ),
         "sign": ParamSpec(param_type=ParamType.CHOICE, choices=[1, -1]),
     },
+    sampling_weight=CONTINUOUS_SAMPLING_WEIGHT,
 )
 
 _TEXTSTAT_TARGET_CODE = textwrap.dedent("""\
@@ -257,6 +267,7 @@ GRADE_LEVEL_TARGET = RewardTemplate(
         "target": ParamSpec(param_type=ParamType.FLOAT, min_val=3.0, max_val=16.0),
         "scale": ParamSpec(param_type=ParamType.FLOAT, min_val=3.0, max_val=8.0),
     },
+    sampling_weight=CONTINUOUS_SAMPLING_WEIGHT,
 )
 
 READING_EASE_TARGET = RewardTemplate(
@@ -269,6 +280,7 @@ READING_EASE_TARGET = RewardTemplate(
         "target": ParamSpec(param_type=ParamType.FLOAT, min_val=20.0, max_val=90.0),
         "scale": ParamSpec(param_type=ParamType.FLOAT, min_val=10.0, max_val=30.0),
     },
+    sampling_weight=CONTINUOUS_SAMPLING_WEIGHT,
 )
 
 WORDS_PER_SENTENCE_TARGET = RewardTemplate(
@@ -281,6 +293,7 @@ WORDS_PER_SENTENCE_TARGET = RewardTemplate(
         "target": ParamSpec(param_type=ParamType.FLOAT, min_val=5.0, max_val=35.0),
         "scale": ParamSpec(param_type=ParamType.FLOAT, min_val=5.0, max_val=15.0),
     },
+    sampling_weight=CONTINUOUS_SAMPLING_WEIGHT,
 )
 
 CHARS_PER_WORD_TARGET = RewardTemplate(
@@ -293,6 +306,7 @@ CHARS_PER_WORD_TARGET = RewardTemplate(
         "target": ParamSpec(param_type=ParamType.FLOAT, min_val=3.0, max_val=7.0),
         "scale": ParamSpec(param_type=ParamType.FLOAT, min_val=1.0, max_val=3.0),
     },
+    sampling_weight=CONTINUOUS_SAMPLING_WEIGHT,
 )
 
 SYLLABLES_PER_WORD_TARGET = RewardTemplate(
@@ -305,6 +319,7 @@ SYLLABLES_PER_WORD_TARGET = RewardTemplate(
         "target": ParamSpec(param_type=ParamType.FLOAT, min_val=1.0, max_val=3.5),
         "scale": ParamSpec(param_type=ParamType.FLOAT, min_val=0.5, max_val=2.0),
     },
+    sampling_weight=CONTINUOUS_SAMPLING_WEIGHT,
 )
 
 DIFFICULT_WORD_RATIO = RewardTemplate(
@@ -327,6 +342,7 @@ DIFFICULT_WORD_RATIO = RewardTemplate(
     params={
         "sign": ParamSpec(param_type=ParamType.CHOICE, choices=[1, -1]),
     },
+    sampling_weight=CONTINUOUS_SAMPLING_WEIGHT,
 )
 
 
@@ -348,6 +364,7 @@ LANGCHECK_SCORE = RewardTemplate(
         "metric": ParamSpec(param_type=ParamType.CHOICE, choices=["sentiment", "fluency"]),
         "sign": ParamSpec(param_type=ParamType.CHOICE, choices=[1, -1]),
     },
+    sampling_weight=CONTINUOUS_SAMPLING_WEIGHT,
 )
 
 
@@ -400,11 +417,37 @@ TEMPLATE_REGISTRY: list[RewardTemplate] = [
 ]
 
 
+def _weighted_sample_without_replacement(
+    items: list[str],
+    weights: list[float],
+    n: int,
+    rng: random.Random,
+) -> list[str]:
+    pool = list(zip(items, weights))
+    chosen = []
+    for _ in range(n):
+        total = sum(w for _, w in pool)
+        r = rng.uniform(0.0, total)
+        acc = 0.0
+        for i, (item, weight) in enumerate(pool):
+            acc += weight
+            if r <= acc:
+                chosen.append(item)
+                pool.pop(i)
+                break
+    return chosen
+
+
 def sample_template_groups(
     n: int,
     rng: random.Random | None = None,
 ) -> list[str]:
     """Sample n distinct groups and instantiate one template per group.
+
+    Group selection is weighted by the max sampling_weight of its members, so a
+    group whose templates are all downweighted is itself rarely picked, while a
+    group with one strong template stays fully in play and the within-group
+    weighted choice suppresses its downweighted members.
 
     Returns a list of concrete Python function strings ready to store on a task.
     Two functions from the same group never appear together, preventing
@@ -413,10 +456,13 @@ def sample_template_groups(
     rng = rng or random.Random()
 
     group_names = list(TEMPLATE_GROUPS.keys())
+    group_weights = [max(t.sampling_weight for t in TEMPLATE_GROUPS[name]) for name in group_names]
     n = min(n, len(group_names))
-    selected_groups = rng.sample(group_names, n)
+    selected_groups = _weighted_sample_without_replacement(group_names, group_weights, n, rng)
 
-    return [
-        rng.choice(TEMPLATE_GROUPS[group_name]).instantiate(rng)
-        for group_name in selected_groups
-    ]
+    sampled = []
+    for group_name in selected_groups:
+        templates = TEMPLATE_GROUPS[group_name]
+        template = rng.choices(templates, weights=[t.sampling_weight for t in templates], k=1)[0]
+        sampled.append(template.instantiate(rng))
+    return sampled


### PR DESCRIPTION
## Motivation

Reward templates fall into two flavours:

- **Saturating / discrete** (`regex_format`, `word_count`, `sentence_count`, `unique_word_ratio`): once a model satisfies the check the score maxes out.
- **Continuous / optimisable** (langcheck sentiment/fluency, textstat metrics, `keyword_presence`): smooth score surfaces with no natural ceiling — a training run that optimises hard against the metric can always squeeze out more (stuff another keyword, nudge readability decimals), rewarding metric-hacking rather than better training code.

Downweight the continuous ones so task outcomes are driven less by RNG handing out easily-gamed metrics.

## Change

- Add `sampling_weight` (default 1.0) to `RewardTemplate`; set `CONTINUOUS_SAMPLING_WEIGHT = 0.03` on the 9 langcheck/textstat/keyword templates.
- `sample_template_groups` now samples groups weighted by the **max** member weight (so `sentence_structure` and `vocabulary` stay fully in play via their clean members) and picks within-group by member weight.

## Why 0.03 and not 0.1

Sampling n∈[2,4] groups without replacement from 7 blunts the raw weight: with only 4 unflagged groups, the 4th slot is often forced into a flagged group. Empirically (30k simulated tasks):

| weight | langcheck | keyword | textstat |
|---|---|---|---|
| 0.1 | 4x fewer | 4x | 4x |
| **0.03** | **13x** | **10x** | **12x** |

Final per-task appearance rates: langcheck 43%→3.4%, keyword_presence 21%→2.2%, textstat family →~9% total. Kept non-zero rather than removing them outright.

Verified: seeded determinism preserved, all instantiated functions compile, unflagged template rates unchanged.