### PR TITLE
fix(validator): read the dynamic emission split in performance endpoints

### DIFF
--- a/tests/validator/scoring/test_tournament_scoring_pipeline.py
+++ b/tests/validator/scoring/test_tournament_scoring_pipeline.py
@@ -515,7 +515,7 @@ class TestCalculateTournamentTypeScores:
         )
 
     def test_none_tournament_data(self):
-        result = calculate_tournament_type_scores_from_data(TournamentType.TEXT, None)
+        result = calculate_tournament_type_scores_from_data(TournamentType.TEXT, None, cts.TOURNAMENT_TEXT_WEIGHT)
         assert result.scores == []
         assert result.prev_winner_hotkey is None
         assert result.prev_winner_won_final is False
@@ -534,7 +534,7 @@ class TestCalculateTournamentTypeScores:
             ],
             winner_hotkey=ALICE,
         )
-        result = calculate_tournament_type_scores_from_data(TournamentType.TEXT, data)
+        result = calculate_tournament_type_scores_from_data(TournamentType.TEXT, data, cts.TOURNAMENT_TEXT_WEIGHT)
         hotkeys_with_scores = {s.hotkey for s in result.scores}
         assert ALICE not in hotkeys_with_scores
         assert BOB in hotkeys_with_scores
@@ -559,7 +559,7 @@ class TestCalculateTournamentTypeScores:
             ],
             winner_hotkey=None,
         )
-        result = calculate_tournament_type_scores_from_data(TournamentType.ENVIRONMENT, data)
+        result = calculate_tournament_type_scores_from_data(TournamentType.ENVIRONMENT, data, cts.TOURNAMENT_ENVIRONMENT_WEIGHT)
         scores_by_hotkey = {s.hotkey: s.score for s in result.scores}
 
         # Higher test_loss = better for env → Alice ranked 1st, Bob 2nd, Carol 3rd
@@ -586,7 +586,7 @@ class TestCalculateTournamentTypeScores:
             winner_hotkey=cts.EMISSION_BURN_HOTKEY,
             base_winner_hotkey="real_champ",
         )
-        result = calculate_tournament_type_scores_from_data(TournamentType.ENVIRONMENT, data)
+        result = calculate_tournament_type_scores_from_data(TournamentType.ENVIRONMENT, data, cts.TOURNAMENT_ENVIRONMENT_WEIGHT)
         hotkeys_with_scores = {s.hotkey for s in result.scores}
 
         assert cts.EMISSION_BURN_HOTKEY not in hotkeys_with_scores
@@ -607,7 +607,7 @@ class TestCalculateTournamentTypeScores:
             ],
             winner_hotkey=ALICE,
         )
-        result = calculate_tournament_type_scores_from_data(TournamentType.TEXT, data)
+        result = calculate_tournament_type_scores_from_data(TournamentType.TEXT, data, cts.TOURNAMENT_TEXT_WEIGHT)
         assert result.prev_winner_won_final is True
         assert result.prev_winner_hotkey == ALICE
 
@@ -648,7 +648,7 @@ class TestCalculateTournamentTypeScores:
             winner_hotkey=ALICE,
         )
 
-        result = calculate_tournament_type_scores_from_data(TournamentType.TEXT, data)
+        result = calculate_tournament_type_scores_from_data(TournamentType.TEXT, data, cts.TOURNAMENT_TEXT_WEIGHT)
         scores_by_hotkey = {score.hotkey: score.score for score in result.scores}
 
         assert BOB not in scores_by_hotkey
@@ -679,7 +679,7 @@ class TestCalculateTournamentTypeScores:
             winner_hotkey=None,
         )
 
-        result = calculate_tournament_type_scores_from_data(TournamentType.ENVIRONMENT, data)
+        result = calculate_tournament_type_scores_from_data(TournamentType.ENVIRONMENT, data, cts.TOURNAMENT_ENVIRONMENT_WEIGHT)
 
         assert result.scores == []
 

--- a/tests/validator/tournament/test_tournament_analytics.py
+++ b/tests/validator/tournament/test_tournament_analytics.py
@@ -272,9 +272,12 @@ def mock_tournament_scoring():
 
 @pytest.fixture
 def mock_constants():
-    with patch('validator.endpoints.tournament_analytics.cts') as mock:
-        mock.TOURNAMENT_TEXT_WEIGHT = 1.0
-        mock.TOURNAMENT_IMAGE_WEIGHT = 0.5
+    with patch('validator.endpoints.tournament_analytics.get_dynamic_base_weights') as mock:
+        mock.return_value = {
+            TournamentType.TEXT: 1.0,
+            TournamentType.IMAGE: 0.5,
+            TournamentType.ENVIRONMENT: 0.25,
+        }
         yield mock
 
 
@@ -393,7 +396,7 @@ if __name__ == "__main__":
         with patch('validator.endpoints.tournament_analytics.tournament_sql') as mock_sql, \
              patch('validator.endpoints.tournament_analytics.task_sql') as mock_task_sql, \
              patch('validator.endpoints.tournament_analytics.calculate_tournament_type_scores_from_data') as mock_scoring, \
-             patch('validator.endpoints.tournament_analytics.cts') as mock_cts:
+             patch('validator.endpoints.tournament_analytics.get_dynamic_base_weights') as mock_base_weights:
             
             # Setup mocks
             mock_sql.get_tournament = AsyncMock(return_value=MOCK_TOURNAMENT)
@@ -411,8 +414,11 @@ if __name__ == "__main__":
             
             mock_task_sql.get_task = AsyncMock(side_effect=get_mock_task_details)
             mock_scoring.return_value = MOCK_TOURNAMENT_TYPE_RESULT
-            mock_cts.TOURNAMENT_TEXT_WEIGHT = 1.0
-            mock_cts.TOURNAMENT_IMAGE_WEIGHT = 0.5
+            mock_base_weights.return_value = {
+                TournamentType.TEXT: 1.0,
+                TournamentType.IMAGE: 0.5,
+                TournamentType.ENVIRONMENT: 0.25,
+            }
             
             try:
                 result = await get_tournament_details(MOCK_TOURNAMENT_ID, config)

--- a/validator/endpoints/performance.py
+++ b/validator/endpoints/performance.py
@@ -5,6 +5,7 @@ import validator.scoring.constants as cts
 from validator.app.config import Config
 from validator.app.dependencies import get_config
 from validator.db.sql.tournaments import get_latest_completed_tournament
+from validator.scoring.emission_balance import get_dynamic_base_weights
 from validator.scoring.tournaments import get_tournament_weights_from_data
 from validator.scoring.weights import build_tournament_audit_data
 from validator.scoring.weights import get_tournament_burn_details
@@ -140,11 +141,15 @@ async def get_weight_projection(
     environment_win_pct: float = 80.0,
     config: Config = Depends(get_config),
 ) -> WeightProjectionResponse:
+    # Project against the live participation-driven split rather than the static anchors, so a
+    # miner choosing a track sees the base they would actually compete for.
+    base_weights = await get_dynamic_base_weights(config.psql_db)
+
     text_projection = await calculate_tournament_projection(
         config.psql_db,
         TournamentType.TEXT,
         percentage_improvement,
-        cts.TOURNAMENT_TEXT_WEIGHT,
+        base_weights[TournamentType.TEXT],
         cts.MAX_TEXT_TOURNAMENT_WEIGHT,
     )
 
@@ -152,7 +157,7 @@ async def get_weight_projection(
         config.psql_db,
         TournamentType.IMAGE,
         percentage_improvement,
-        cts.TOURNAMENT_IMAGE_WEIGHT,
+        base_weights[TournamentType.IMAGE],
         cts.MAX_IMAGE_TOURNAMENT_WEIGHT,
     )
 
@@ -161,7 +166,7 @@ async def get_weight_projection(
         config.psql_db,
         TournamentType.ENVIRONMENT,
         percentage_improvement,
-        cts.TOURNAMENT_ENVIRONMENT_WEIGHT,
+        base_weights[TournamentType.ENVIRONMENT],
         cts.MAX_ENVIRONMENT_TOURNAMENT_WEIGHT,
         win_pct=environment_win_pct / 100.0,
     )
@@ -180,13 +185,16 @@ async def get_weight_projection_static(
 ) -> MultiWeightProjectionResponse:
     percentage_improvements = [5.0, 10.0, 15.0, 20.0]
 
+    # Resolved once: the split is the same for every projected improvement level.
+    base_weights = await get_dynamic_base_weights(config.psql_db)
+
     projections = []
     for percentage_improvement in percentage_improvements:
         text_projection = await calculate_tournament_projection(
             config.psql_db,
             TournamentType.TEXT,
             percentage_improvement,
-            cts.TOURNAMENT_TEXT_WEIGHT,
+            base_weights[TournamentType.TEXT],
             cts.MAX_TEXT_TOURNAMENT_WEIGHT,
         )
 
@@ -194,7 +202,7 @@ async def get_weight_projection_static(
             config.psql_db,
             TournamentType.IMAGE,
             percentage_improvement,
-            cts.TOURNAMENT_IMAGE_WEIGHT,
+            base_weights[TournamentType.IMAGE],
             cts.MAX_IMAGE_TOURNAMENT_WEIGHT,
         )
 
@@ -202,7 +210,7 @@ async def get_weight_projection_static(
             config.psql_db,
             TournamentType.ENVIRONMENT,
             percentage_improvement,
-            cts.TOURNAMENT_ENVIRONMENT_WEIGHT,
+            base_weights[TournamentType.ENVIRONMENT],
             cts.MAX_ENVIRONMENT_TOURNAMENT_WEIGHT,
         )
 

--- a/validator/endpoints/tournament_analytics.py
+++ b/validator/endpoints/tournament_analytics.py
@@ -11,7 +11,6 @@ from fastapi import APIRouter
 from fastapi import Depends
 from fastapi import HTTPException
 
-import validator.scoring.constants as cts
 import validator.tournament.constants as tourn_cst
 from core.logging import get_logger
 from core.models.payload_models import GpuRequirementSummary
@@ -25,6 +24,7 @@ from validator.db.sql import gpu_costs
 from validator.db.sql import tasks as task_sql
 from validator.db.sql import tournaments as tournament_sql
 from validator.infrastructure.service_constants import TASK_DETAILS_ENDPOINT
+from validator.scoring.emission_balance import get_dynamic_base_weights
 from validator.scoring.tournaments import calculate_tournament_type_scores_from_data
 from validator.scoring.weights import get_tournament_burn_details
 from validator.tournament.constants import LATEST_TOURNAMENTS_CACHE_KEY
@@ -94,7 +94,12 @@ async def get_tournament_details(
         if not tournament:
             raise HTTPException(status_code=404, detail="Tournament not found")
 
-        is_environment_tournament = TournamentType(tournament.tournament_type) == TournamentType.ENVIRONMENT
+        tournament_type = TournamentType(tournament.tournament_type)
+        is_environment_tournament = tournament_type == TournamentType.ENVIRONMENT
+
+        # Participation-driven split, not the static anchors — these are the live weights the
+        # weight setter is using, so the reported figures match what actually gets set on chain.
+        base_weights = await get_dynamic_base_weights(config.psql_db)
 
         detailed_rounds = []
         for round_data in rounds:
@@ -204,7 +209,7 @@ async def get_tournament_details(
             final_positions={p.hotkey: p.final_position for p in participants if p.final_position is not None},
         )
         tournament_type_result = calculate_tournament_type_scores_from_data(
-            TournamentType(tournament.tournament_type), tournament_results_with_winners
+            tournament_type, tournament_results_with_winners, base_weights[tournament_type]
         )
 
         boss_round_performance = None
@@ -235,9 +240,9 @@ async def get_tournament_details(
             participants=_participants_without_github_tokens(participants),
             rounds=detailed_rounds,
             final_scores=tournament_type_result.scores,
-            text_tournament_weight=cts.TOURNAMENT_TEXT_WEIGHT,
-            image_tournament_weight=cts.TOURNAMENT_IMAGE_WEIGHT,
-            environment_tournament_weight=cts.TOURNAMENT_ENVIRONMENT_WEIGHT,
+            text_tournament_weight=base_weights[TournamentType.TEXT],
+            image_tournament_weight=base_weights[TournamentType.IMAGE],
+            environment_tournament_weight=base_weights[TournamentType.ENVIRONMENT],
             boss_round_performance=boss_round_performance,
             sync_performance=sync_performance,
         )

--- a/validator/scoring/tournaments.py
+++ b/validator/scoring/tournaments.py
@@ -209,20 +209,19 @@ def compute_pvp_tournament_points(
 
 
 def calculate_tournament_type_scores_from_data(
-    tournament_type: TournamentType, tournament_data: TournamentResultsWithWinners | None
+    tournament_type: TournamentType,
+    tournament_data: TournamentResultsWithWinners | None,
+    type_weight: float,
 ) -> TournamentTypeResult:
-    """Calculate tournament scores from tournament data without database access."""
+    """Calculate tournament scores from tournament data without database access.
+
+    ``type_weight`` is this type's emission base. It is the participation-driven dynamic split
+    (validator.scoring.emission_balance), not the static anchor, so the caller resolves it and
+    passes it in — this function stays DB-free.
+    """
     if not tournament_data:
         return TournamentTypeResult(scores=[], prev_winner_hotkey=None, prev_winner_won_final=False)
 
-    if tournament_type == TournamentType.TEXT:
-        type_weight = cts.TOURNAMENT_TEXT_WEIGHT
-    elif tournament_type == TournamentType.IMAGE:
-        type_weight = cts.TOURNAMENT_IMAGE_WEIGHT
-    elif tournament_type == TournamentType.ENVIRONMENT:
-        type_weight = cts.TOURNAMENT_ENVIRONMENT_WEIGHT
-    else:
-        raise ValueError(f"Unknown tournament type: {tournament_type}")
     score_dict = {}
     prev_winner_won_final = False
 

--- a/validator/scoring/weights.py
+++ b/validator/scoring/weights.py
@@ -41,10 +41,10 @@ import core.constants.network as ccst
 import validator.scoring.constants as cts
 from core.constants.credentials import BUCKET_NAME
 from core.logging import get_logger
-from validator.scoring.emission_balance import get_dynamic_base_weights
 from validator.app.config import Config
 from validator.app.config import load_config
 from validator.db.sql.nodes import get_vali_node_id
+from validator.scoring.emission_balance import get_dynamic_base_weights
 from validator.tasks.details import save_json_to_temp_file
 from validator.tasks.details import try_db_connections
 from validator.tasks.details import upload_file_to_minio
@@ -215,18 +215,6 @@ def calculate_hybrid_decays(
         new_decay = emission_time_decay_fraction(days_as_champion)
         logger.debug(f"Post-cutoff champion: new_decay={new_decay:.4f} (reign={days_as_champion:.1f} days)")
         return (0.0, new_decay, False)
-
-
-def get_base_weight_by_tournament_type(tournament_type: TournamentType) -> float:
-    """Get the base weight for a tournament type."""
-    if tournament_type == TournamentType.TEXT:
-        return cts.TOURNAMENT_TEXT_WEIGHT
-    elif tournament_type == TournamentType.IMAGE:
-        return cts.TOURNAMENT_IMAGE_WEIGHT
-    elif tournament_type == TournamentType.ENVIRONMENT:
-        return cts.TOURNAMENT_ENVIRONMENT_WEIGHT
-    else:
-        raise ValueError(f"Unknown tournament type: {tournament_type}")
 
 
 def get_max_weight_by_tournament_type(tournament_type: TournamentType) -> float:


### PR DESCRIPTION
The auto-balancer (#1334) moved the text/image/env base off the static anchors, but the miner-facing endpoints still report the anchors.

Live split vs what the endpoints were reporting:

| | reported (anchor) | actual (balancer) |
|---|---|---|
| text | 0.35 | 0.500 |
| image | 0.25 | 0.191 |
| environment | 0.25 | 0.115 |

So `weight-projection` under-reported text and over-reported environment by more than 2x — telling miners the opposite of what the balancer is trying to incentivise.

## Changes

- `performance.py` — both `weight-projection` endpoints resolve the live split via `get_dynamic_base_weights`. `-static` resolves once outside the loop rather than per improvement level.
- `tournament_analytics.py` — tournament details report the live split.
- `calculate_tournament_type_scores_from_data` takes `type_weight` as an argument instead of reading the anchor, so it stays DB-free as documented; the caller resolves the split.
- Dropped `get_base_weight_by_tournament_type` — dead since #1334 and returning the stale anchor.

Historical tournaments now report today's split rather than the one they ran under. Storing the split per tournament would be the correct fix; that needs a migration and is left for a follow-up.

Tests: 184 pass. Two fixtures that patched `cts` directly now patch `get_dynamic_base_weights`.

## Not in this PR

Two things worth separate issues, found while checking the audit path:

1. `TournamentAuditData.text/image/environment_base_weight` default to the static anchors. A validator on new code ingesting audit JSON from one still on old code silently substitutes 0.35/0.25/0.25 instead of failing loudly — a ~3% of total emission discrepancy with nothing logged. For a field whose purpose is cross-validator reproducibility this should be required, or `None` with an explicit warning branch.
2. `compute_dynamic_base_weights` and `get_recent_completed_entrant_counts` have no test coverage.