### PR TITLE
Fix degenerate-dataset filter so it actually rejects near-zero-loss DPO datasets

### DIFF
--- a/tests/validator/tasks/test_degenerate_dataset_filter.py
+++ b/tests/validator/tasks/test_degenerate_dataset_filter.py
@@ -1,0 +1,85 @@
+"""Tests for the degenerate-dataset filter used at synthetic task creation time."""
+
+import pytest
+
+import validator.tasks.synthetics.constants as synth_cst
+import validator.tasks.synthetics.scheduler as scheduler
+import validator.tournament  # noqa: F401  (import-order: tournament package must init before scheduler)
+from core.models.task_models import TaskType
+
+
+@pytest.fixture
+def stub_losses(monkeypatch):
+    """Stub the DB lookup so the filter can be exercised on fixed loss histories."""
+
+    def _stub(losses: list[float]) -> None:
+        async def fake_get_dataset_test_losses(ds_name: str, psql_db, lookback_days: int) -> list[float]:
+            assert lookback_days == synth_cst.DEGENERATE_LOSS_LOOKBACK_DAYS
+            return losses
+
+        monkeypatch.setattr(scheduler, "get_dataset_test_losses", fake_get_dataset_test_losses)
+
+    return _stub
+
+
+async def _is_degenerate(task_type: TaskType) -> bool:
+    return await scheduler._is_dataset_degenerate("some/dataset", task_type, psql_db=None)
+
+
+@pytest.mark.asyncio
+async def test_no_history_is_allowed(stub_losses):
+    stub_losses([])
+    assert await _is_degenerate(TaskType.DPOTASK) is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("best_loss", [0.0212, 0.0215, 0.0491])
+async def test_dpo_near_zero_loss_is_rejected(stub_losses, best_loss):
+    """Real boss-round offenders bottomed out at 0.02-0.05, above the generic 0.01 floor."""
+    stub_losses([best_loss, 1.4, 2.2])
+    assert await _is_degenerate(TaskType.DPOTASK) is True
+
+
+@pytest.mark.asyncio
+async def test_dpo_healthy_loss_is_allowed(stub_losses):
+    stub_losses([0.5756, 0.59, 1.1])
+    assert await _is_degenerate(TaskType.DPOTASK) is False
+
+
+@pytest.mark.asyncio
+async def test_instruct_keeps_the_tighter_collapse_floor(stub_losses):
+    """0.02 is a plausible instruct loss; only DPO gets the 0.05 floor."""
+    stub_losses([0.02, 0.4])
+    assert await _is_degenerate(TaskType.INSTRUCTTEXTTASK) is False
+
+    stub_losses([0.005, 0.4])
+    assert await _is_degenerate(TaskType.INSTRUCTTEXTTASK) is True
+
+
+@pytest.mark.asyncio
+async def test_dpo_noise_band_uses_best_not_mean(stub_losses):
+    """Nobody beat ln(2) -> reject, even though weak submissions pull the mean out of the band."""
+    stub_losses([0.6931, 1.9, 3.4])
+    assert await _is_degenerate(TaskType.DPOTASK) is True
+
+
+@pytest.mark.asyncio
+async def test_dpo_beating_noise_is_allowed(stub_losses):
+    """A single miner well under ln(2) means the dataset is learnable, not random."""
+    stub_losses([0.35, 0.6931, 1.9])
+    assert await _is_degenerate(TaskType.DPOTASK) is False
+
+
+@pytest.mark.asyncio
+async def test_instruct_unlearnable_data_is_rejected(stub_losses):
+    stub_losses([2.5, 3.1])
+    assert await _is_degenerate(TaskType.INSTRUCTTEXTTASK) is True
+
+
+@pytest.mark.asyncio
+async def test_db_failure_allows_the_dataset(monkeypatch):
+    async def boom(ds_name: str, psql_db, lookback_days: int) -> list[float]:
+        raise RuntimeError("connection reset")
+
+    monkeypatch.setattr(scheduler, "get_dataset_test_losses", boom)
+    assert await _is_degenerate(TaskType.DPOTASK) is False

--- a/validator/db/sql/tasks.py
+++ b/validator/db/sql/tasks.py
@@ -1,3 +1,4 @@
+import math
 from datetime import datetime
 from typing import Literal
 from uuid import UUID
@@ -36,8 +37,14 @@ from validator.tasks.models import NetworkStats
 logger = get_logger(__name__)
 
 
-async def get_dataset_test_losses(ds_name: str, psql_db: PSQLDB) -> list[float]:
-    """Get all historical test_loss values for tasks that used a given dataset."""
+async def get_dataset_test_losses(ds_name: str, psql_db: PSQLDB, lookback_days: int) -> list[float]:
+    """Get recent historical test_loss values for tasks that used a given dataset.
+
+    Failed evals are persisted as NaN, which passes ``IS NOT NULL`` — a single one poisons any
+    downstream mean and silently disables loss-based dataset filtering, so they are excluded here
+    (Postgres compares NaN = NaN as true) alongside a final ``isfinite`` guard for infinities.
+    Losses older than ``lookback_days`` predate the current eval methodology and are dropped.
+    """
     async with await psql_db.connection() as connection:
         connection: Connection
         rows = await connection.fetch(
@@ -47,10 +54,13 @@ async def get_dataset_test_losses(ds_name: str, psql_db: PSQLDB) -> list[float]:
             JOIN {cst.TASKS_TABLE} t ON tn.{cst.TASK_ID}::text = t.{cst.TASK_ID}::text
             WHERE t.{cst.DS} = $1
             AND tn.{cst.TEST_LOSS} IS NOT NULL
+            AND tn.{cst.TEST_LOSS} <> 'NaN'
+            AND t.{cst.CREATED_AT} > NOW() - make_interval(days => $2)
             """,
             ds_name,
+            lookback_days,
         )
-        return [float(row[cst.TEST_LOSS]) for row in rows]
+        return [loss for loss in (float(row[cst.TEST_LOSS]) for row in rows) if math.isfinite(loss)]
 
 
 async def get_lowest_loss_repo_for_task(task_id: UUID, psql_db: PSQLDB) -> str | None:

--- a/validator/tasks/synthetics/constants.py
+++ b/validator/tasks/synthetics/constants.py
@@ -94,6 +94,17 @@ PROMPT_GEN_ENDPOINT = "https://llm.chutes.ai/v1/chat/completions"
 IMAGE_GEN_ENDPOINT = "https://image.chutes.ai/generate"
 NINETEEN_API_KEY = os.getenv("NINETEEN_API_KEY")
 
+# Degenerate-dataset filtering (see _is_dataset_degenerate). Only losses from the last
+# DEGENERATE_LOSS_LOOKBACK_DAYS count — older ones predate the current eval methodology.
+DEGENERATE_LOSS_LOOKBACK_DAYS = 90
+DEGENERATE_COLLAPSE_LOSS = 0.01
+# DPO pairs that are trivially separable bottom out around 0.02-0.05 rather than collapsing to 0,
+# so the generic floor never fires for them and boss rounds kept drawing near-zero-loss datasets.
+DEGENERATE_DPO_COLLAPSE_LOSS = 0.05
+DEGENERATE_INSTRUCT_MAX_BEST_LOSS = 2.0
+# Around ln(2) ~= 0.6931: the DPO loss of a model making random preference predictions.
+DEGENERATE_DPO_NOISE_BAND = (0.68, 0.71)
+
 MIN_NUM_REWARD_FUNCTIONS = 2
 MAX_NUM_REWARD_FUNCTIONS = 4
 

--- a/validator/tasks/synthetics/scheduler.py
+++ b/validator/tasks/synthetics/scheduler.py
@@ -330,15 +330,19 @@ def _get_training_hours_for_environment_task(round_number: int = 1) -> float:
 
 
 async def _is_dataset_degenerate(ds_name: str, task_type: TaskType, psql_db: PSQLDB) -> bool:
-    """Check if a dataset has historically produced degenerate test_loss scores.
+    """Check if a dataset has recently produced degenerate test_loss scores.
 
     Returns True (degenerate) if:
-    - Any historical test_loss < 0.01 (model collapse)
+    - Any recent test_loss below the collapse floor (0.01, or 0.05 for DPO)
     - For instruct tasks: best (min) test_loss > 2.0 (garbage / unlearnable data)
-    - For DPO tasks: average test_loss in [0.68, 0.71] (random noise around ln(2))
+    - For DPO tasks: best (min) test_loss in [0.68, 0.71] (nobody beat random noise around ln(2))
+
+    Both task-type checks key off the *best* loss, not the mean: the mean is dominated by weak
+    submissions across every miner that ever touched the dataset and effectively never lands in
+    a rejection band.
     """
     try:
-        losses = await get_dataset_test_losses(ds_name, psql_db)
+        losses = await get_dataset_test_losses(ds_name, psql_db, synth_cst.DEGENERATE_LOSS_LOOKBACK_DAYS)
     except Exception as e:
         logger.warning(f"Failed to query historical losses for {ds_name}, allowing dataset: {e}")
         return False
@@ -346,20 +350,28 @@ async def _is_dataset_degenerate(ds_name: str, task_type: TaskType, psql_db: PSQ
     if not losses:
         return False
 
-    if any(loss < 0.01 for loss in losses):
-        logger.warning(f"Dataset {ds_name} rejected: has test_loss < 0.01 (model collapse)")
+    best_loss = min(losses)
+    collapse_floor = (
+        synth_cst.DEGENERATE_DPO_COLLAPSE_LOSS if task_type == TaskType.DPOTASK else synth_cst.DEGENERATE_COLLAPSE_LOSS
+    )
+    if best_loss < collapse_floor:
+        logger.warning(f"Dataset {ds_name} rejected: test_loss {best_loss:.4f} < {collapse_floor} (model collapse)")
         return True
 
-    if task_type == TaskType.INSTRUCTTEXTTASK:
-        best_loss = min(losses)
-        if best_loss > 2.0:
-            logger.warning(f"Dataset {ds_name} rejected: best instruct test_loss {best_loss:.4f} > 2.0 (garbage data)")
-            return True
+    if task_type == TaskType.INSTRUCTTEXTTASK and best_loss > synth_cst.DEGENERATE_INSTRUCT_MAX_BEST_LOSS:
+        logger.warning(
+            f"Dataset {ds_name} rejected: best instruct test_loss {best_loss:.4f} > "
+            f"{synth_cst.DEGENERATE_INSTRUCT_MAX_BEST_LOSS} (garbage data)"
+        )
+        return True
 
     if task_type == TaskType.DPOTASK:
-        avg_loss = sum(losses) / len(losses)
-        if 0.68 <= avg_loss <= 0.71:
-            logger.warning(f"Dataset {ds_name} rejected: avg DPO test_loss {avg_loss:.4f} in noise range [0.68, 0.71]")
+        noise_low, noise_high = synth_cst.DEGENERATE_DPO_NOISE_BAND
+        if noise_low <= best_loss <= noise_high:
+            logger.warning(
+                f"Dataset {ds_name} rejected: best DPO test_loss {best_loss:.4f} in noise range "
+                f"[{noise_low}, {noise_high}]"
+            )
             return True
 
     return False


### PR DESCRIPTION
Boss rounds kept drawing DPO datasets that train to near-zero loss. The guard for this (`_is_dataset_degenerate`) has been in place since #1151/#1152 and is correctly wired into the boss-round path — it just never fires for DPO. Three reasons, all fixed here.

### 1. NaN silently disabled the DPO check

Failed evals are persisted as NaN, which passes `IS NOT NULL`. A single one makes the mean NaN, and `0.68 <= nan <= 0.71` is `False`, so the ln(2) noise check has never fired for any dataset with a failed eval in its history. On prod that's 52 of 92 rows for `Turkish-DPO-Pairs` and 35 of 96 for `orca_dpo_pairs_dutch_cleaned`.

Now excluded in SQL (Postgres compares `NaN = NaN` as true) with an `isfinite` guard for infinities.

### 2. The 0.01 collapse floor sat below every real offender

Recent boss-round DPO minimums were 0.021–0.055 — trivially separable pairs bottom out there rather than collapsing to 0, so `any(loss < 0.01)` never triggered. DPO now gets its own 0.05 floor; other task types keep 0.01.

### 3. The ln(2) check used the mean

The mean is taken over every miner that ever touched the dataset, so it is dominated by weak submissions and effectively never lands in `[0.68, 0.71]` (clean means for both offenders above are ~1.2). Both task-type checks now key off the best loss.

Also bounds the history to 90 days — older losses predate the current eval methodology.

### Verification

Query run against prod. Under the new logic:

| dataset | best loss (90d) | verdict |
|---|---|---|
| suayptalha/Turkish-DPO-Pairs | 0.0491 | rejected |
| BramVanroy/orca_dpo_pairs_dutch_cleaned | 0.0215 | rejected |
| ContextualAI/ultrafeedback_clair_32k | 0.0212 | rejected |
| MBZUAI/ArabicMMLU | 0.5756 | allowed |

All three offenders blocked, the healthy dataset still drawn.

10 new tests in `tests/validator/tasks/test_degenerate_dataset_filter.py` covering the real offender values, the DPO-vs-instruct floor split, min-vs-mean noise banding, empty history and DB-failure fallthrough. `tests/validator/tasks/` + `tests/validator/db/`: 43 passed, 1 pre-existing unrelated failure (`test_training_hours.py::test_floor_for_tiny_tasks`, fails on clean `main` too).

### Not addressed here

- **First use of a dataset is still unguarded.** The filter is history-only, so a fresh trivially-separable dataset gets one boss round before it can be rejected. A pre-flight base-model eval would be the real fix.
- **In-flight reuse.** Two boss tasks drew `orca_dpo_pairs_dutch_cleaned` 2h15m apart, before the first had produced any `test_loss`. Needs a "dataset has an in-flight tournament task" check, not a loss threshold.
- **The boss-round win margin itself** — a 1% relative margin on a 0.02 loss is a 0.0002 bar. Being handled separately.