### PR TITLE
Align trainer stale-timeout clock with container start.

### DIFF
--- a/tests/trainer/test_job_state_started_at.py
+++ b/tests/trainer/test_job_state_started_at.py
@@ -1,0 +1,52 @@
+"""Tests for refreshing training started_at when the train container starts."""
+
+from datetime import datetime
+from datetime import timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from core.models.task_models import TaskStatus
+from trainer import job_state
+
+
+@pytest.mark.asyncio
+async def test_update_training_started_at_refreshes_clock(monkeypatch: pytest.MonkeyPatch):
+    accept_time = datetime.utcnow() - timedelta(hours=1)
+    task = SimpleNamespace(status=TaskStatus.TRAINING, started_at=accept_time)
+    saved = {"n": 0}
+
+    monkeypatch.setattr(job_state, "load_task_history", lambda: None)
+    monkeypatch.setattr(job_state, "get_task", lambda task_id, hotkey: task)
+
+    async def _save():
+        saved["n"] += 1
+
+    monkeypatch.setattr(job_state, "save_task_history", _save)
+
+    container_start = datetime.utcnow()
+    await job_state.update_training_started_at("task-1", "hotkey-a", started_at=container_start)
+
+    assert task.started_at == container_start
+    assert task.started_at > accept_time
+    assert saved["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_update_training_started_at_skips_non_training(monkeypatch: pytest.MonkeyPatch):
+    accept_time = datetime.utcnow() - timedelta(hours=1)
+    task = SimpleNamespace(status=TaskStatus.FAILURE, started_at=accept_time)
+    saved = {"n": 0}
+
+    monkeypatch.setattr(job_state, "load_task_history", lambda: None)
+    monkeypatch.setattr(job_state, "get_task", lambda task_id, hotkey: task)
+
+    async def _save():
+        saved["n"] += 1
+
+    monkeypatch.setattr(job_state, "save_task_history", _save)
+
+    await job_state.update_training_started_at("task-1", "hotkey-a", started_at=datetime.utcnow())
+
+    assert task.started_at == accept_time
+    assert saved["n"] == 0

--- a/trainer/README.md
+++ b/trainer/README.md
@@ -5,12 +5,12 @@ Service that receives work from the validator, clones miner repositories, builds
 ## Contents
 
 - `asgi.py`: FastAPI app factory, startup cleanup, and service entrypoint.
-- `cleanup.py`: background cleanup loop for stale trainer state and cache.
+- `cleanup.py`: background cleanup loop for stale trainer state and cache (training stale timeout uses `started_at`, refreshed when the train container starts).
 - `constants.py`: trainer Docker images, volumes, resource defaults, and container paths.
 - `containers/`: downloader, uploader, cache cleanup, and miner dataset cache helpers.
 - `endpoints.py`: trainer API routes called by validators.
 - `host.py`: host/GPU inspection, repository cloning, and Docker host helpers.
-- `job_state.py`: persisted trainer task/model-prep state.
+- `job_state.py`: persisted trainer task/model-prep state (`started_at` is set on accept and refreshed at container start for training jobs).
 - `dataset_adapters.py`: text dataset column adapters used by training entrypoints.
 - `diffusion_dataset.py`: diffusion image dataset extraction/arrangement helpers.
 - `model_artifacts.py`: model artifact path and metadata helpers.

--- a/trainer/cleanup.py
+++ b/trainer/cleanup.py
@@ -38,8 +38,13 @@ async def periodically_cleanup_tasks_and_cache(poll_interval_seconds: int = 600)
                 if job.status != TaskStatus.TRAINING or not job.started_at:
                     continue
 
+                # Training jobs refresh started_at when the train container starts (see
+                # update_training_started_at), so this deadline tracks container.wait rather than
+                # download/image-build time. Status-only: does not kill the container.
                 if isinstance(job, TrainerTaskLog):
-                    timeout = timedelta(hours=job.training_data.hours_to_complete) + timedelta(minutes=cst.STALE_TASK_GRACE_MINUTES)
+                    timeout = timedelta(hours=job.training_data.hours_to_complete) + timedelta(
+                        minutes=cst.STALE_TASK_GRACE_MINUTES
+                    )
                 else:
                     timeout = timedelta(minutes=cst.MODEL_PREP_TIMEOUT_MINUTES)
 
@@ -68,7 +73,7 @@ async def periodically_cleanup_tasks_and_cache(poll_interval_seconds: int = 600)
                     detach=True,
                 )
 
-                log_task = asyncio.create_task(asyncio.to_thread(stream_container_logs, container, get_all_context_tags()))
+                asyncio.create_task(asyncio.to_thread(stream_container_logs, container, get_all_context_tags()))
 
                 logger.info("Cleanup container finished.")
 

--- a/trainer/job_state.py
+++ b/trainer/job_state.py
@@ -124,6 +124,31 @@ async def update_container_name(task_id: str, hotkey: str, container_name: str):
             logger.warning(f"Task not found for task_id={task_id} and hotkey={hotkey}")
 
 
+async def update_training_started_at(task_id: str, hotkey: str, started_at: datetime | None = None) -> None:
+    """Refresh started_at when the training container actually starts.
+
+    Job accept sets an initial started_at (before download/image build). Cleanup's stale-timeout
+    clock uses started_at, so without this refresh it can mark FAILURE while container.wait is
+    still inside hours_to_complete. Align the clock with the container.wait budget.
+    """
+    async with _task_lock:
+        load_task_history()
+
+        task = get_task(task_id, hotkey)
+        if task is None:
+            logger.warning(f"Task not found for task_id={task_id} and hotkey={hotkey}")
+            return
+        if task.status != TaskStatus.TRAINING:
+            logger.warning(
+                f"Refusing to refresh started_at for task {task_id} hotkey={hotkey}: status={task.status}"
+            )
+            return
+
+        task.started_at = started_at or datetime.utcnow()
+        await save_task_history()
+        logger.info(f"Updated started_at for task {task_id} to {task.started_at.isoformat()}")
+
+
 # ---------------------------------------------------------------------------
 # Model prep job helpers
 # ---------------------------------------------------------------------------

--- a/trainer/runtime.py
+++ b/trainer/runtime.py
@@ -41,6 +41,7 @@ from trainer.host import extract_container_error
 from trainer.job_state import complete_task
 from trainer.job_state import log_task
 from trainer.job_state import update_container_name
+from trainer.job_state import update_training_started_at
 from trainer.job_state import update_wandb_url
 from trainer.model_artifacts import get_anonymous_model_dir
 from trainer.telemetry import logger
@@ -1029,6 +1030,8 @@ async def start_training_task(task: TrainerProxyRequest, local_repo_path: str):
             )
 
         await update_container_name(training_data.task_id, task.hotkey, container.name)
+        # Align cleanup's stale-timeout clock with container.wait (not job-accept time).
+        await update_training_started_at(training_data.task_id, task.hotkey)
         await log_task(training_data.task_id, task.hotkey, f"Container started: {container.name}")
         await log_task(training_data.task_id, task.hotkey, f"Waiting for container to finish (timeout={timeout_seconds})...")
         wait_task = asyncio.create_task(asyncio.to_thread(container.wait))


### PR DESCRIPTION
Cleanup was marking jobs FAILURE from job-accept started_at (before download/build), while container.wait still had budget left and left the train container running. Refresh started_at when the training container starts so the clocks match.