### PR TITLE
Block tournament advancement when a group has no valid scores

### DIFF
--- a/tests/validator/tournament/test_empty_score_group_guard.py
+++ b/tests/validator/tournament/test_empty_score_group_guard.py
@@ -1,0 +1,137 @@
+"""Tests for the zero-score group guard that blocks tournament advancement.
+
+Regression cover for tourn_10592fcefa2f37ad_20260810: two of three round-1 groups lost their
+evaluation data after miners were re-trained, scored 0/NaN across the board, and were silently
+skipped by the winner functions. The round then advanced with one challenger instead of three.
+"""
+
+from unittest.mock import AsyncMock
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from validator.tournament.models import RoundStatus
+from validator.tournament.models import RoundType
+from validator.tournament.models import TournamentRoundData
+from validator.tournament.models import TournamentTask
+from validator.tournament.round_results import find_groups_with_no_valid_scores
+
+
+MODULE = "validator.tournament.round_results"
+
+
+def _round(round_type: RoundType = RoundType.GROUP) -> TournamentRoundData:
+    return TournamentRoundData(
+        round_id="tourn_test_round_001",
+        tournament_id="tourn_test",
+        round_number=1,
+        round_type=round_type,
+        is_final_round=False,
+        status=RoundStatus.COMPLETED,
+    )
+
+
+def _task(group_id: str, task_id: str) -> TournamentTask:
+    return TournamentTask(
+        tournament_id="tourn_test",
+        round_id="tourn_test_round_001",
+        task_id=task_id,
+        group_id=group_id,
+    )
+
+
+def _member(hotkey: str):
+    member = AsyncMock()
+    member.hotkey = hotkey
+    return member
+
+
+def _result(hotkey: str, adjusted_loss):
+    result = AsyncMock()
+    result.hotkey = hotkey
+    result.adjusted_loss = adjusted_loss
+    return result
+
+
+@pytest.fixture
+def patched():
+    """Patch the three DB reads find_groups_with_no_valid_scores depends on."""
+    with (
+        patch(f"{MODULE}.get_tournament_tasks", new_callable=AsyncMock) as tasks,
+        patch(f"{MODULE}.get_tournament_group_members", new_callable=AsyncMock) as members,
+        patch(f"{MODULE}.get_task_results_for_ranking", new_callable=AsyncMock) as results,
+        patch(f"{MODULE}.calculate_miner_ranking_and_scores") as ranked,
+    ):
+        members.return_value = [_member("5A"), _member("5B")]
+        yield tasks, members, results, ranked
+
+
+class TestFindGroupsWithNoValidScores:
+    async def test_healthy_group_is_not_flagged(self, patched):
+        tasks, _members, results, ranked = patched
+        tasks.return_value = [_task("group_001", "task-1")]
+        results.return_value = [object()]
+        ranked.return_value = [_result("5A", 0.4), _result("5B", 0.6)]
+
+        assert await find_groups_with_no_valid_scores(_round(), AsyncMock()) == []
+
+    async def test_group_with_no_scored_rows_is_flagged(self, patched):
+        # get_task_results_for_ranking drops NaN/None test_loss, so a wiped group arrives empty.
+        tasks, _members, results, ranked = patched
+        tasks.return_value = [_task("group_002", "task-2")]
+        results.return_value = []
+        ranked.return_value = []
+
+        flagged = await find_groups_with_no_valid_scores(_round(), AsyncMock())
+
+        assert len(flagged) == 1
+        assert flagged[0].group_id == "group_002"
+        assert flagged[0].task_id == "task-2"
+        assert flagged[0].participants == 2
+
+    async def test_group_scored_entirely_nan_is_flagged(self, patched):
+        # Rows survive ranking but carry no usable loss — the shape task_nodes was left in.
+        tasks, _members, results, ranked = patched
+        tasks.return_value = [_task("group_003", "task-3")]
+        results.return_value = [object()]
+        ranked.return_value = [_result("5A", np.nan), _result("5B", None)]
+
+        flagged = await find_groups_with_no_valid_scores(_round(), AsyncMock())
+
+        assert [group.group_id for group in flagged] == ["group_003"]
+
+    async def test_flags_only_the_broken_groups_in_a_mixed_round(self, patched):
+        """The exact production shape: group 1 healthy, groups 2 and 3 wiped."""
+        tasks, _members, results, ranked = patched
+        tasks.return_value = [
+            _task("group_001", "task-1"),
+            _task("group_002", "task-2"),
+            _task("group_003", "task-3"),
+        ]
+        results.side_effect = [[object()], [], []]
+        ranked.side_effect = [[_result("5A", 0.4), _result("5B", 0.6)]]
+
+        flagged = await find_groups_with_no_valid_scores(_round(), AsyncMock())
+
+        assert [group.group_id for group in flagged] == ["group_002", "group_003"]
+
+    async def test_knockout_rounds_are_not_covered(self, patched):
+        tasks, _members, results, ranked = patched
+        tasks.return_value = [_task("group_001", "task-1")]
+        results.return_value = []
+        ranked.return_value = []
+
+        assert await find_groups_with_no_valid_scores(_round(RoundType.KNOCKOUT), AsyncMock()) == []
+        tasks.assert_not_called()
+
+    async def test_group_with_no_members_is_skipped(self, patched):
+        # An empty group has nothing to lose, so it is not evidence of missing eval data.
+        tasks, members, results, ranked = patched
+        tasks.return_value = [_task("group_001", "task-1")]
+        members.return_value = []
+        results.return_value = []
+        ranked.return_value = []
+
+        assert await find_groups_with_no_valid_scores(_round(), AsyncMock()) == []
+        results.assert_not_called()

--- a/validator/tournament/models.py
+++ b/validator/tournament/models.py
@@ -226,6 +226,14 @@ class MatchRanking(BaseModel):
     ranked_hotkeys: list[str]
 
 
+class EmptyScoreGroup(BaseModel):
+    """A group whose task produced no usable scores — evaluation data is missing, not merely bad."""
+
+    group_id: str
+    task_id: str
+    participants: int
+
+
 class GroupMatchStanding(BaseModel):
     """A competitor's standing across all matches in a small tournament group."""
 

--- a/validator/tournament/round_results.py
+++ b/validator/tournament/round_results.py
@@ -20,6 +20,7 @@ from validator.evaluation.pvp.models import GameOutcome
 from validator.scoring.constants import EMISSION_BURN_HOTKEY
 from validator.scoring.tasks import calculate_miner_ranking_and_scores
 from validator.tournament import constants as t_cst
+from validator.tournament.models import EmptyScoreGroup
 from validator.tournament.models import GroupMatchStanding
 from validator.tournament.models import MatchRanking
 from validator.tournament.models import RoundType
@@ -601,6 +602,52 @@ async def get_knockout_winners(
         winners = [boss_round_winner]
 
     return winners
+
+
+async def find_groups_with_no_valid_scores(
+    completed_round: TournamentRoundData, psql_db: PSQLDB
+) -> list[EmptyScoreGroup]:
+    """Group tasks that finished with participants but not a single usable score.
+
+    A group can legitimately advance nobody — the boss retains, everyone is eliminated on a
+    tie — but it can never legitimately produce *no scores at all*. That means the evaluation
+    data was lost or never written, so any winner set derived from this round is wrong: the
+    silent `continue` in the winner functions below would just drop the group and advance a
+    smaller field. Callers use this to refuse advancement instead.
+
+    Knockout rounds are decided per-pair rather than per-group, so they are not covered here.
+    """
+    if completed_round.round_type != RoundType.GROUP:
+        return []
+
+    round_tasks = await get_tournament_tasks(completed_round.round_id, psql_db)
+    empty_groups: list[EmptyScoreGroup] = []
+
+    for task in round_tasks:
+        if not task.group_id:
+            continue
+
+        participants = await get_tournament_group_members(task.group_id, psql_db)
+        if not participants:
+            continue
+
+        miner_results = await get_task_results_for_ranking(task.task_id, psql_db)
+        ranked_results = calculate_miner_ranking_and_scores(miner_results) if miner_results else []
+        has_valid_score = any(
+            result.adjusted_loss is not None and not np.isnan(result.adjusted_loss) for result in ranked_results
+        )
+
+        if not has_valid_score:
+            empty_groups.append(
+                EmptyScoreGroup(
+                    group_id=task.group_id,
+                    task_id=task.task_id,
+                    participants=len(participants),
+                )
+            )
+
+    return empty_groups
+
 
 async def get_environment_group_winners(
     completed_round: TournamentRoundData, round_tasks: list[TournamentTask], psql_db: PSQLDB, config: Config

--- a/validator/tournament/tournament_manager.py
+++ b/validator/tournament/tournament_manager.py
@@ -68,6 +68,7 @@ from validator.tournament.github_validation import deduplicate_by_ip_address
 from validator.tournament.github_validation import validate_github_tokens
 from validator.tournament.github_validation import validate_repo_license
 from validator.tournament.github_validation import validate_repo_obfuscation
+from validator.tournament.models import EmptyScoreGroup
 from validator.tournament.models import Group
 from validator.tournament.models import GroupRound
 from validator.tournament.models import KnockoutRound
@@ -92,6 +93,7 @@ from validator.tournament.participants import get_latest_tournament_winner_parti
 from validator.tournament.repo_uploader import upload_tournament_participant_repository
 from validator.tournament.reports import generate_diff_report_and_notify_tournament_completed
 from validator.tournament.round_results import determine_env_tournament_winner
+from validator.tournament.round_results import find_groups_with_no_valid_scores
 from validator.tournament.round_results import get_round_winners
 from validator.tournament.task_creator import create_environment_tournament_tasks
 from validator.tournament.task_creator import create_image_tournament_tasks
@@ -100,6 +102,10 @@ from validator.tournament.task_creator import replace_tournament_task
 
 
 logger = get_logger(__name__)
+
+# Rounds we have already pinged Discord about for having zero-score groups. Process-local on
+# purpose: a restart re-alerts, which is the right behaviour for a condition needing a human.
+_EMPTY_SCORE_ROUNDS_ALERTED: set[str] = set()
 
 
 def exceeds_failure_threshold(trainings: dict[str, str]) -> bool:
@@ -589,6 +595,14 @@ async def advance_tournament(tournament: TournamentData, completed_round: Tourna
             return
 
         logger.info(f"Advancing tournament {tournament.tournament_id} from round {completed_round.round_id}")
+
+        # A group with zero usable scores means its evaluation data is missing, not that its
+        # miners lost. Advancing would silently drop that group and promote a smaller field, so
+        # refuse to advance at all and let a human sort the data out first.
+        empty_score_groups = await find_groups_with_no_valid_scores(completed_round, psql_db)
+        if empty_score_groups:
+            await _alert_empty_score_groups(tournament, completed_round, empty_score_groups, config)
+            return
 
         winners = await get_round_winners(completed_round, psql_db, config)
         logger.info(f"Round winners: {winners}")
@@ -1311,6 +1325,41 @@ async def process_active_tournaments(config: Config):
             logger.error(f"Error processing active tournaments: {e}", exc_info=True)
         finally:
             await asyncio.sleep(t_cst.TOURNAMENT_ACTIVE_CYCLE_INTERVAL)
+
+
+async def _alert_empty_score_groups(
+    tournament: TournamentData,
+    completed_round: TournamentRoundData,
+    empty_score_groups: list[EmptyScoreGroup],
+    config: Config,
+) -> None:
+    """Shout about a round we refuse to advance, once per round per process.
+
+    The log line repeats every cycle so the wedge stays visible in `pm2 logs`; the Discord ping
+    does not, because this fires on a 60s loop and would otherwise hammer the webhook until
+    someone intervenes.
+    """
+    detail = "\n".join(
+        f"  {group.group_id} (task {group.task_id}, {group.participants} participants)" for group in empty_score_groups
+    )
+    logger.error(
+        f"REFUSING TO ADVANCE tournament {tournament.tournament_id} from round {completed_round.round_id}: "
+        f"{len(empty_score_groups)} group(s) finished with no valid scores.\n{detail}"
+    )
+
+    if completed_round.round_id in _EMPTY_SCORE_ROUNDS_ALERTED:
+        return
+    _EMPTY_SCORE_ROUNDS_ALERTED.add(completed_round.round_id)
+
+    await _notify_discord(
+        f"Tournament advancement BLOCKED\n"
+        f"Tournament: {tournament.tournament_id} ({tournament.tournament_type.value})\n"
+        f"Round: {completed_round.round_id}\n"
+        f"{len(empty_score_groups)} group(s) completed with no valid scores:\n{detail}\n"
+        f"The next round has NOT been created and no one has been eliminated. "
+        f"Evaluation data is missing for these groups — fix the scores, then the cycle will advance on its own.",
+        config,
+    )
 
 
 async def _notify_discord(message: str, config: Config) -> None:


### PR DESCRIPTION
## Problem

A group can legitimately advance nobody. It can never legitimately produce **no scores at all** — that means the evaluation data was lost or never written. Both winner functions silently `continue` past such a group (`round_results.py:646` for environment, `:796` for text/image), so the round advances with a smaller field and that group's miners are eliminated without ever being ranked.

This hit `tourn_10592fcefa2f37ad_20260810`. Two of three round-1 groups were re-trained after their PvP evals had already completed, wiping their scores to NaN:

```
group_001 | 4 members | 2 scored rows | 2 usable for ranking  -> healthy
group_002 | 4 members | 4 scored rows | 0 usable for ranking  -> silently dropped
group_003 | 4 members | 4 scored rows | 0 usable for ranking  -> silently dropped
```

Advancement had already resolved correctly at 13:45 (3 winners, one per group). But `advance_tournament` is re-entrant — `tournament_manager.py:1302-1309` re-calls it every cycle for an already-completed round — and the 19:58 re-entry recomputed winners from the corrupted scores, promoting 1 challenger instead of 3. Two group winners were un-promoted and marked eliminated, and the boss round was built as a 1v1.

## Change

`find_groups_with_no_valid_scores()` flags any group-round task whose group has participants but no rows usable for ranking. `advance_tournament` refuses to advance when that set is non-empty: no eliminations, no next round, an ERROR log every cycle and one Discord ping per round per process.

Covers all tournament types. Knockout rounds are decided per pair rather than per group and are not affected.

## Scope

Fixes the consequence, not the cause. It does not address the trainer dropping task history and triggering the re-train, and it only catches corruption that yields *zero* scores — re-advancement silently overwriting an earlier decision is still possible if a future wipe leaves non-empty-but-wrong scores. That needs a separate change to make an advancement decision immutable once the next round exists.

Note this also covers final group rounds, so an environment boss round whose evals come back empty will block tournament completion rather than declare a champion on missing data.

## Testing

6 new tests in `tests/validator/tournament/test_empty_score_group_guard.py`, including the exact production shape (1 healthy group, 2 wiped). `166 passed` across `tests/validator/tournament/`. The predicate was also verified directly against the production rows above.