### PR TITLE
Gate majority-training-failure behind manual review instead of wedging

### DIFF
--- a/ops/tools/tournament/approve_task_failure_review.py
+++ b/ops/tools/tournament/approve_task_failure_review.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""List and approve majority-training-failure review gates.
+
+A task whose trainings are >50% failed is held back from completing until a human confirms
+the failures belong to the miners rather than the infrastructure. This tool is that human
+step: inspect what failed, then approve so the round can advance.
+
+If the failures were an infrastructure fault, do NOT approve — reset those trainings to
+pending instead and let them run again. The gate clears on its own once the ratio drops.
+
+    python -m ops.tools.tournament.approve_task_failure_review --list
+    python -m ops.tools.tournament.approve_task_failure_review --task-id <uuid> [--notes "..."]
+"""
+
+import argparse
+import asyncio
+import os
+
+import asyncpg
+from dotenv import load_dotenv
+from rich.console import Console
+from rich.table import Table
+
+
+console = Console()
+
+load_dotenv(".vali.env")
+DATABASE_URL = os.getenv("DATABASE_URL")
+
+TABLE = "tournament_task_failure_reviews"
+
+
+async def list_pending(conn: asyncpg.Connection) -> None:
+    rows = await conn.fetch(
+        f"""
+        SELECT r.task_id, r.tournament_id, r.round_id, r.status, r.failed_hotkeys,
+               r.total_trainings, r.created_at, r.reviewed_at
+        FROM {TABLE} r
+        ORDER BY r.status, r.created_at
+        """
+    )
+    if not rows:
+        console.print("No majority-failure reviews on record.", style="green")
+        return
+
+    table = Table(title="Majority-training-failure reviews")
+    table.add_column("task_id", overflow="fold")
+    table.add_column("round")
+    table.add_column("status")
+    table.add_column("failed")
+    table.add_column("opened")
+    for row in rows:
+        failed = row["failed_hotkeys"]
+        failed_count = len(failed) if isinstance(failed, list) else 0
+        style = "yellow" if row["status"] == "pending_review" else "green"
+        table.add_row(
+            str(row["task_id"]),
+            row["round_id"],
+            f"[{style}]{row['status']}[/{style}]",
+            f"{failed_count}/{row['total_trainings']}",
+            row["created_at"].strftime("%Y-%m-%d %H:%M"),
+        )
+    console.print(table)
+
+
+async def show_detail(conn: asyncpg.Connection, task_id: str) -> asyncpg.Record | None:
+    review = await conn.fetchrow(f"SELECT * FROM {TABLE} WHERE task_id = $1", task_id)
+    if not review:
+        console.print(f"No review row for task {task_id}", style="red")
+        return None
+
+    console.print(f"\n[bold]{task_id}[/bold]  round={review['round_id']}  status={review['status']}")
+    trainings = await conn.fetch(
+        """
+        SELECT hotkey, training_status, n_training_attempts, trainer_ip
+        FROM tournament_task_hotkey_trainings WHERE task_id = $1 ORDER BY training_status, hotkey
+        """,
+        task_id,
+    )
+    table = Table(title="Trainings")
+    table.add_column("hotkey")
+    table.add_column("status")
+    table.add_column("attempts")
+    table.add_column("trainer")
+    for row in trainings:
+        style = "red" if row["training_status"] == "failure" else "green"
+        table.add_row(
+            row["hotkey"][:12],
+            f"[{style}]{row['training_status']}[/{style}]",
+            str(row["n_training_attempts"]),
+            row["trainer_ip"] or "-",
+        )
+    console.print(table)
+    return review
+
+
+async def approve(conn: asyncpg.Connection, task_id: str, notes: str | None) -> None:
+    review = await show_detail(conn, task_id)
+    if not review:
+        return
+    if review["status"] == "approved":
+        console.print("Already approved; nothing to do.", style="yellow")
+        return
+
+    console.print(
+        "\n[bold yellow]Approving accepts these failures as legitimate.[/bold yellow] "
+        "The task will complete and the round will advance."
+    )
+    if input("Type the task_id to confirm: ").strip() != task_id:
+        console.print("Aborted.", style="red")
+        return
+
+    await conn.execute(
+        f"UPDATE {TABLE} SET status='approved', reviewed_at=now(), notes=COALESCE($2, notes) WHERE task_id = $1",
+        task_id,
+        notes,
+    )
+    console.print(f"Approved {task_id}. The next tournament cycle will let the round through.", style="green")
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--list", action="store_true", help="list all review rows")
+    parser.add_argument("--task-id", help="task to inspect and approve")
+    parser.add_argument("--notes", help="why this was approved")
+    args = parser.parse_args()
+
+    if not DATABASE_URL:
+        console.print("DATABASE_URL not set (source .vali.env)", style="red")
+        return
+
+    conn = await asyncpg.connect(DATABASE_URL)
+    try:
+        if args.task_id:
+            await approve(conn, args.task_id, args.notes)
+        else:
+            await list_pending(conn)
+    finally:
+        await conn.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/validator/tournament/test_majority_failure_gate.py
+++ b/tests/validator/tournament/test_majority_failure_gate.py
@@ -1,0 +1,129 @@
+"""Tests for the majority-training-failure manual review gate.
+
+Regression cover for env task 46e18d06 (tourn_10592fcefa2f37ad_20260810_round_001): 3 of its
+5 trainings failed legitimately, so is_tourn_task_completed returned False forever on a task
+whose status was SUCCESS. The round could never complete and the Discord warning re-fired
+every ~60s. The gate keeps the block deliberate but gives a human a way to clear it.
+"""
+
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from core.models.task_models import TaskStatus
+from validator.tournament import tournament_manager
+from validator.tournament.models import TaskFailureReviewStatus
+from validator.tournament.models import TournamentTask
+from validator.tournament.models import TournamentTaskFailureReview
+
+
+MODULE = "validator.tournament.tournament_manager"
+
+TASK_ID = "46e18d06-f1de-40c6-b39d-54107d3cb0c6"
+MOSTLY_FAILED = {"5CAMXmFr": "failure", "5CkiAXSu": "failure", "5EqKHiZG": "failure", "5EgpWgYv": "success", "5GU4Xkd3": "success"}
+MOSTLY_PASSED = {"5A": "success", "5B": "success", "5C": "failure"}
+
+
+def _task() -> TournamentTask:
+    return TournamentTask(
+        tournament_id="tourn_test",
+        round_id="tourn_test_round_001",
+        task_id=TASK_ID,
+        group_id="tourn_test_round_001_group_001",
+    )
+
+
+def _review(status: TaskFailureReviewStatus) -> TournamentTaskFailureReview:
+    return TournamentTaskFailureReview(
+        task_id=TASK_ID,
+        tournament_id="tourn_test",
+        round_id="tourn_test_round_001",
+        status=status,
+        failed_hotkeys=["5CAMXmFr", "5CkiAXSu", "5EqKHiZG"],
+        total_trainings=5,
+    )
+
+
+@pytest.fixture
+def gate():
+    with (
+        patch(f"{MODULE}.get_training_status_for_task", new_callable=AsyncMock) as trainings,
+        patch(f"{MODULE}.task_failure_reviews_sql") as reviews,
+        patch(f"{MODULE}._notify_discord", new_callable=AsyncMock) as notify,
+    ):
+        reviews.get_task_failure_review = AsyncMock(return_value=None)
+        reviews.insert_task_failure_review = AsyncMock(return_value=True)
+        yield trainings, reviews, notify
+
+
+class TestMajorityFailureGate:
+    async def test_blocks_and_opens_a_review_when_majority_failed(self, gate):
+        trainings, reviews, notify = gate
+        trainings.return_value = MOSTLY_FAILED
+
+        blocked = await tournament_manager._majority_failure_blocks_completion(_task(), MagicMock())
+
+        assert blocked is True
+        reviews.insert_task_failure_review.assert_awaited_once()
+        opened = reviews.insert_task_failure_review.await_args.args[0]
+        assert sorted(opened.failed_hotkeys) == ["5CAMXmFr", "5CkiAXSu", "5EqKHiZG"]
+        assert opened.total_trainings == 5
+        notify.assert_awaited_once()
+
+    async def test_approved_review_lets_the_task_through(self, gate):
+        trainings, reviews, notify = gate
+        trainings.return_value = MOSTLY_FAILED
+        reviews.get_task_failure_review = AsyncMock(return_value=_review(TaskFailureReviewStatus.APPROVED))
+
+        blocked = await tournament_manager._majority_failure_blocks_completion(_task(), MagicMock())
+
+        assert blocked is False
+        reviews.insert_task_failure_review.assert_not_awaited()
+        notify.assert_not_awaited()
+
+    async def test_pending_review_keeps_blocking_without_re_alerting(self, gate):
+        """The gate is re-checked every cycle; only the cycle that opened it should ping."""
+        trainings, reviews, notify = gate
+        trainings.return_value = MOSTLY_FAILED
+        reviews.get_task_failure_review = AsyncMock(return_value=_review(TaskFailureReviewStatus.PENDING_REVIEW))
+        reviews.insert_task_failure_review = AsyncMock(return_value=False)  # row already exists
+
+        blocked = await tournament_manager._majority_failure_blocks_completion(_task(), MagicMock())
+
+        assert blocked is True
+        notify.assert_not_awaited()
+
+    async def test_does_not_block_below_threshold(self, gate):
+        trainings, reviews, notify = gate
+        trainings.return_value = MOSTLY_PASSED
+
+        blocked = await tournament_manager._majority_failure_blocks_completion(_task(), MagicMock())
+
+        assert blocked is False
+        reviews.get_task_failure_review.assert_not_awaited()
+        notify.assert_not_awaited()
+
+
+class TestIsTournTaskCompleted:
+    async def test_success_task_is_held_while_review_pending(self, gate):
+        trainings, _reviews, _notify = gate
+        trainings.return_value = MOSTLY_FAILED
+        task_obj = MagicMock(status=TaskStatus.SUCCESS.value, task_id=TASK_ID)
+
+        completed, reason = await tournament_manager.is_tourn_task_completed(_task(), task_obj, MagicMock())
+
+        assert completed is False
+        assert "manual review" in reason
+
+    async def test_success_task_completes_once_approved(self, gate):
+        trainings, reviews, _notify = gate
+        trainings.return_value = MOSTLY_FAILED
+        reviews.get_task_failure_review = AsyncMock(return_value=_review(TaskFailureReviewStatus.APPROVED))
+        task_obj = MagicMock(status=TaskStatus.SUCCESS.value, task_id=TASK_ID)
+
+        completed, reason = await tournament_manager.is_tourn_task_completed(_task(), task_obj, MagicMock())
+
+        assert completed is True
+        assert reason == "Task completed successfully"

--- a/tests/validator/tournament/test_pre_boss_task.py
+++ b/tests/validator/tournament/test_pre_boss_task.py
@@ -17,6 +17,8 @@ from validator.tournament import constants as t_cst
 from validator.tournament import task_creator
 from validator.tournament import tournament_manager
 from validator.tournament.models import KnockoutRound
+from validator.tournament.models import TaskFailureReviewStatus
+from validator.tournament.models import TournamentTaskFailureReview
 
 
 def _knockout(pairs: list[tuple[str, str]]) -> KnockoutRound:
@@ -182,13 +184,41 @@ class TestPreBossCompletionGate:
     def _patch_trainings(self, monkeypatch, statuses: dict[str, str]):
         monkeypatch.setattr(tournament_manager, "get_training_status_for_task", AsyncMock(return_value=statuses))
 
+    def _patch_failure_reviews(self, monkeypatch, existing=None, newly_opened=True):
+        """Stub the majority-failure review gate's DB access."""
+        reviews = SimpleNamespace(
+            get_task_failure_review=AsyncMock(return_value=existing),
+            insert_task_failure_review=AsyncMock(return_value=newly_opened),
+        )
+        monkeypatch.setattr(tournament_manager, "task_failure_reviews_sql", reviews)
+        monkeypatch.setattr(tournament_manager, "_notify_discord", AsyncMock())
+        return reviews
+
     async def test_both_failed_stalls_for_investigation(self, monkeypatch):
         self._patch_trainings(monkeypatch, {"miner-a": "failure", "miner-b": "failure"})
+        reviews = self._patch_failure_reviews(monkeypatch)
         completed, reason = await tournament_manager.is_tourn_task_completed(
             self._tournament_task(), self._task_obj(TaskStatus.SUCCESS.value), self._config()
         )
         assert completed is False
-        assert reason == "More than half of the trainings failed"
+        assert reason == "More than half of the trainings failed - awaiting manual review"
+        reviews.insert_task_failure_review.assert_awaited_once()
+
+    async def test_both_failed_completes_once_manually_approved(self, monkeypatch):
+        # A human confirmed the failures are the miners' own, so the round is allowed through.
+        self._patch_trainings(monkeypatch, {"miner-a": "failure", "miner-b": "failure"})
+        approved = TournamentTaskFailureReview(
+            task_id="task-1",
+            tournament_id="tourn",
+            round_id="round-3",
+            status=TaskFailureReviewStatus.APPROVED,
+        )
+        self._patch_failure_reviews(monkeypatch, existing=approved)
+        completed, reason = await tournament_manager.is_tourn_task_completed(
+            self._tournament_task(), self._task_obj(TaskStatus.SUCCESS.value), self._config()
+        )
+        assert completed is True
+        assert reason == "Task completed successfully"
 
     async def test_single_failure_keeps_normal_completion(self, monkeypatch):
         # One survivor: round completes normally and the survivor challenges the boss.

--- a/validator/db/constants.py
+++ b/validator/db/constants.py
@@ -41,6 +41,7 @@ BENCHMARK_TASK_COPIES_TABLE = "benchmark_task_copies"
 TOURNAMENT_TASK_HOTKEY_TRAININGS_TABLE = "tournament_task_hotkey_trainings"
 PVP_PAIR_RESULTS_TABLE = "pvp_pair_results"
 TOURNAMENT_DEDUP_REVIEWS_TABLE = "tournament_dedup_reviews"
+TOURNAMENT_TASK_FAILURE_REVIEWS_TABLE = "tournament_task_failure_reviews"
 PVP_INDIVIDUAL_SCORES_TABLE = "pvp_individual_scores"
 
 # Continuous-SFT lineage state (one row per lineage slug): the monotonic train_index cursor passed

--- a/validator/db/migrations/20260810234500_add_tournament_task_failure_reviews.sql
+++ b/validator/db/migrations/20260810234500_add_tournament_task_failure_reviews.sql
@@ -1,0 +1,29 @@
+-- migrate:up
+-- Stores the majority-training-failure review gate for a tournament task.
+-- One row per guarded task. While status = 'pending_review' the task is not treated as
+-- complete, so the round does not advance; a human approves by updating the row.
+--
+-- Before this gate existed, a task whose trainings were >50% failed could never complete:
+-- the failures are terminal so the ratio never improved, the round wedged forever, and the
+-- Discord warning re-fired every cycle. Now the block is explicit and a human can clear it.
+CREATE TABLE IF NOT EXISTS tournament_task_failure_reviews (
+    task_id UUID PRIMARY KEY REFERENCES tasks(task_id) ON DELETE CASCADE,
+    tournament_id TEXT NOT NULL REFERENCES tournaments(tournament_id) ON DELETE CASCADE,
+    round_id TEXT NOT NULL,
+    -- pending_review: gate active, task not treated as complete
+    -- approved:       failures accepted as legitimate, task completes and the round advances
+    status TEXT NOT NULL DEFAULT 'pending_review',
+    failed_hotkeys JSONB NOT NULL DEFAULT '[]'::jsonb,
+    total_trainings INTEGER NOT NULL DEFAULT 0,
+    notes TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    reviewed_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_tournament_task_failure_reviews_tournament
+    ON tournament_task_failure_reviews(tournament_id);
+CREATE INDEX IF NOT EXISTS idx_tournament_task_failure_reviews_status
+    ON tournament_task_failure_reviews(status);
+
+-- migrate:down
+DROP TABLE IF EXISTS tournament_task_failure_reviews;

--- a/validator/db/sql/task_failure_reviews.py
+++ b/validator/db/sql/task_failure_reviews.py
@@ -1,0 +1,104 @@
+"""DB access for the majority-training-failure review gate."""
+
+import json
+from datetime import datetime
+from datetime import timezone
+from typing import Any
+from uuid import UUID
+
+import validator.db.constants as cst
+from core.logging import get_logger
+from validator.db.database import PSQLDB
+from validator.tournament.models import TaskFailureReviewStatus
+from validator.tournament.models import TournamentTaskFailureReview
+
+
+logger = get_logger(__name__)
+
+
+def _loads(value: Any) -> Any:
+    return json.loads(value) if isinstance(value, str) else value
+
+
+def _row_to_review(row: Any) -> TournamentTaskFailureReview:
+    return TournamentTaskFailureReview(
+        task_id=str(row["task_id"]),
+        tournament_id=row["tournament_id"],
+        round_id=row["round_id"],
+        status=TaskFailureReviewStatus(row["status"]),
+        failed_hotkeys=_loads(row["failed_hotkeys"]) or [],
+        total_trainings=row["total_trainings"],
+        notes=row["notes"],
+        created_at=row["created_at"],
+        reviewed_at=row["reviewed_at"],
+    )
+
+
+async def insert_task_failure_review(review: TournamentTaskFailureReview, psql_db: PSQLDB) -> bool:
+    """Open the gate for a task. Returns True only when this call created the row, so the
+    caller can alert once rather than on every cycle."""
+    async with await psql_db.connection() as connection:
+        row = await connection.fetchrow(
+            f"""
+            INSERT INTO {cst.TOURNAMENT_TASK_FAILURE_REVIEWS_TABLE}
+                (task_id, tournament_id, round_id, status, failed_hotkeys, total_trainings, notes)
+            VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7)
+            ON CONFLICT (task_id) DO NOTHING
+            RETURNING task_id
+            """,
+            UUID(review.task_id),
+            review.tournament_id,
+            review.round_id,
+            review.status.value,
+            json.dumps(review.failed_hotkeys),
+            review.total_trainings,
+            review.notes,
+        )
+    created = row is not None
+    if created:
+        logger.info(
+            f"Opened majority-failure review for task {review.task_id} "
+            f"({len(review.failed_hotkeys)}/{review.total_trainings} trainings failed)"
+        )
+    return created
+
+
+async def get_task_failure_review(task_id: str, psql_db: PSQLDB) -> TournamentTaskFailureReview | None:
+    async with await psql_db.connection() as connection:
+        row = await connection.fetchrow(
+            f"SELECT * FROM {cst.TOURNAMENT_TASK_FAILURE_REVIEWS_TABLE} WHERE task_id = $1", UUID(task_id)
+        )
+        return _row_to_review(row) if row else None
+
+
+async def approve_task_failure_review(task_id: str, psql_db: PSQLDB, notes: str | None = None) -> bool:
+    """Clear the gate for a task. Returns True if a pending row was approved."""
+    async with await psql_db.connection() as connection:
+        row = await connection.fetchrow(
+            f"""
+            UPDATE {cst.TOURNAMENT_TASK_FAILURE_REVIEWS_TABLE}
+            SET status = $2, reviewed_at = $3, notes = COALESCE($4, notes)
+            WHERE task_id = $1
+            RETURNING task_id
+            """,
+            UUID(task_id),
+            TaskFailureReviewStatus.APPROVED.value,
+            datetime.now(timezone.utc),
+            notes,
+        )
+    approved = row is not None
+    if approved:
+        logger.info(f"Approved majority-failure review for task {task_id}")
+    return approved
+
+
+async def get_pending_task_failure_reviews(psql_db: PSQLDB) -> list[TournamentTaskFailureReview]:
+    async with await psql_db.connection() as connection:
+        rows = await connection.fetch(
+            f"""
+            SELECT * FROM {cst.TOURNAMENT_TASK_FAILURE_REVIEWS_TABLE}
+            WHERE status = $1 ORDER BY created_at
+            """,
+            TaskFailureReviewStatus.PENDING_REVIEW.value,
+        )
+        return [_row_to_review(row) for row in rows]

--- a/validator/tournament/models.py
+++ b/validator/tournament/models.py
@@ -709,6 +709,29 @@ class DedupReviewStatus(str, Enum):
     SKIPPED = "skipped"
 
 
+class TaskFailureReviewStatus(str, Enum):
+    PENDING_REVIEW = "pending_review"
+    APPROVED = "approved"
+
+
+class TournamentTaskFailureReview(BaseModel):
+    """Manual gate for a task whose trainings mostly failed.
+
+    Held at PENDING_REVIEW until a human confirms the failures are the miners' own and not
+    an infrastructure fault, at which point the task is allowed to complete.
+    """
+
+    task_id: str
+    tournament_id: str
+    round_id: str
+    status: TaskFailureReviewStatus = TaskFailureReviewStatus.PENDING_REVIEW
+    failed_hotkeys: list[str] = []
+    total_trainings: int = 0
+    notes: str | None = None
+    created_at: datetime | None = None
+    reviewed_at: datetime | None = None
+
+
 class IntegrityVerdict(BaseModel):
     flagged: bool
     confidence: float = 0.0

--- a/validator/tournament/tournament_manager.py
+++ b/validator/tournament/tournament_manager.py
@@ -23,6 +23,7 @@ from validator.app.config import Config
 from validator.db.database import PSQLDB
 from validator.db.sql import tasks as task_sql
 from validator.db.sql.continuous_sft import advance_continuous_sft_state
+from validator.db.sql import task_failure_reviews as task_failure_reviews_sql
 from validator.db.sql.nodes import get_all_nodes
 from validator.db.sql.nodes import get_node_by_hotkey
 from validator.db.sql.tournaments import add_tournament_participants
@@ -74,6 +75,7 @@ from validator.tournament.models import GroupRound
 from validator.tournament.models import KnockoutRound
 from validator.tournament.models import RespondingNode
 from validator.tournament.models import Round
+from validator.tournament.models import TaskFailureReviewStatus
 from validator.tournament.models import RoundStatus
 from validator.tournament.models import RoundType
 from validator.tournament.models import TournamentData
@@ -81,6 +83,7 @@ from validator.tournament.models import TournamentParticipant
 from validator.tournament.models import TournamentRoundData
 from validator.tournament.models import TournamentStatus
 from validator.tournament.models import TournamentTask
+from validator.tournament.models import TournamentTaskFailureReview
 from validator.tournament.models import TournamentType
 from validator.tournament.models import generate_round_id
 from validator.tournament.models import generate_tournament_id
@@ -1374,25 +1377,63 @@ async def _notify_discord(message: str, config: Config) -> None:
             logger.error(f"Failed to send Discord notification: {e}")
 
 
-async def _more_than_half_failures(tournament_task: TournamentTask, config: Config) -> bool:
-    """
-    Check if more than half of the trainings failed and handle Discord notification.
+async def _majority_failure_blocks_completion(tournament_task: TournamentTask, config: Config) -> bool:
+    """Hold a mostly-failed task behind a manual review gate.
 
-    Returns True if majority failure detected, False otherwise.
+    Returns True while the task must not be treated as complete.
+
+    The failed trainings are terminal, so the failure ratio never improves on its own. Without
+    a gate the round wedges forever and the Discord warning re-fires every cycle. Instead we
+    open one review row per task and alert once; a human decides whether the failures are the
+    miners' own (approve, and the round advances) or an infrastructure fault (reset the
+    trainings instead, and the gate clears itself once they pass).
     """
     trainings = await get_training_status_for_task(tournament_task.task_id, config.psql_db)
-    is_more_than_half_failure = exceeds_failure_threshold(trainings)
+    if not exceeds_failure_threshold(trainings):
+        return False
 
-    if is_more_than_half_failure:
-        logger.info(f"More than half of the trainings for task {tournament_task.task_id} failed. Please investigate.")
-        message = (
-            f"Warning: Task {tournament_task.task_id} in Tournament Round {tournament_task.round_id} "
-            f"has more than half tasks failed, please investigate."
+    review = await task_failure_reviews_sql.get_task_failure_review(tournament_task.task_id, config.psql_db)
+    if review and review.status == TaskFailureReviewStatus.APPROVED:
+        logger.info(
+            f"Task {tournament_task.task_id} has majority training failures but was manually approved "
+            f"at {review.reviewed_at}; allowing it to complete."
         )
-        await _notify_discord(message, config)
-        return True
+        return False
 
-    return False
+    failed_hotkeys = [
+        hotkey
+        for hotkey, status in trainings.items()
+        if status in {TaskStatus.FAILURE.value, TaskStatus.PREP_TASK_FAILURE.value}
+    ]
+    logger.info(
+        f"More than half of the trainings for task {tournament_task.task_id} failed "
+        f"({len(failed_hotkeys)}/{len(trainings)}); awaiting manual review."
+    )
+
+    newly_opened = await task_failure_reviews_sql.insert_task_failure_review(
+        TournamentTaskFailureReview(
+            task_id=tournament_task.task_id,
+            tournament_id=tournament_task.tournament_id,
+            round_id=tournament_task.round_id,
+            failed_hotkeys=failed_hotkeys,
+            total_trainings=len(trainings),
+        ),
+        config.psql_db,
+    )
+
+    # Only ping on the cycle that opened the gate; it is re-checked every ~60s thereafter.
+    if newly_opened:
+        await _notify_discord(
+            f"Warning: Task {tournament_task.task_id} in Tournament Round {tournament_task.round_id} "
+            f"has more than half tasks failed, please investigate.\n"
+            f"Failed {len(failed_hotkeys)}/{len(trainings)}: {', '.join(hk[:8] for hk in failed_hotkeys)}\n"
+            f"The round will NOT advance until this is reviewed. If the failures are legitimate, approve with:\n"
+            f"UPDATE tournament_task_failure_reviews SET status='approved', reviewed_at=now() "
+            f"WHERE task_id='{tournament_task.task_id}';",
+            config,
+        )
+
+    return True
 
 
 async def is_tourn_task_completed(
@@ -1409,8 +1450,8 @@ async def is_tourn_task_completed(
     """
 
     if task_obj.status == TaskStatus.SUCCESS.value:
-        if await _more_than_half_failures(tournament_task, config):
-            return False, "More than half of the trainings failed"
+        if await _majority_failure_blocks_completion(tournament_task, config):
+            return False, "More than half of the trainings failed - awaiting manual review"
         return True, "Task completed successfully"
 
     elif task_obj.status == TaskStatus.FAILURE.value:


### PR DESCRIPTION
## Problem

`is_tourn_task_completed` refuses to complete a task whose trainings are >50% failed, even when the task's own status is `success`:

```python
if task_obj.status == TaskStatus.SUCCESS.value:
    if await _more_than_half_failures(tournament_task, config):
        return False, "More than half of the trainings failed"
```

Those failures are terminal, so the ratio never improves. The round can never complete, the tournament can never advance, and the Discord warning re-fires every cycle with no way to clear it.

Env task `46e18d06` hit this tonight. Three of its five trainings failed on their own merits — one crashed at ~9 minutes across three different GPUs, two overran a 1.5h budget — so the block was right to raise but impossible to satisfy. It warned 18 times in 18 minutes and would not have stopped.

## Change

Keep the block, make it reviewable — following the existing dedup-gate precedent.

The first cycle to detect majority failure opens one `tournament_task_failure_reviews` row (`pending_review`) and pings Discord **once**, including the failed hotkeys and the SQL to clear it. The task stays incomplete while that row is pending. A human then either:

- **approves** — the failures were the miners' own, the task completes and the round advances, or
- **resets the trainings** — the gate clears itself once the ratio drops below the threshold.

Approval is deliberately manual; nothing auto-passes.

```bash
python -m ops.tools.tournament.approve_task_failure_review --list
python -m ops.tools.tournament.approve_task_failure_review --task-id <uuid> --notes "..."
```

The tool prints the per-hotkey training detail (status, attempts, trainer) and requires typing the task_id to confirm.

Behaviour is unchanged for tasks below the threshold. `PERCENTAGE_OF_TASKS_SHOULD_BE_SUCCESS` is untouched at 0.5.

## Deploy

Needs `dbmate up` for the new table before the new code runs.

## Testing

6 new tests in `tests/validator/tournament/test_majority_failure_gate.py` covering block-and-open, approved-passes, pending-does-not-re-alert, and below-threshold. `173 passed` across `tests/validator/tournament/`.

`test_pre_boss_task.py::test_both_failed_stalls_for_investigation` needed updating — it asserted the old reason string and passed a bare `MagicMock` db. Its intent (majority failure stalls the round) is preserved; added a companion test for the approved path.