### PR TITLE
Require the boss to be beaten in whichever group it played

### DIFF
--- a/tests/validator/tournament/test_env_boss_retains.py
+++ b/tests/validator/tournament/test_env_boss_retains.py
@@ -1,0 +1,128 @@
+"""The boss must be beaten to be got past, in whichever group it was drawn into.
+
+Regression cover for tourn_10592fcefa2f37ad_20260810 round 1 group 1: three of the four
+challengers failed training, and the lone survivor advanced on 0.0 having lost both
+environments to the boss (78-94 clobber, 11-18 othello). The old rule only let the boss retain
+when the round had a single group, so with three groups it did not apply and the survivor went
+through on attrition rather than merit.
+"""
+
+from unittest.mock import AsyncMock
+from unittest.mock import patch
+
+import pytest
+
+from validator.scoring.constants import EMISSION_BURN_HOTKEY
+from validator.tournament.models import RoundStatus
+from validator.tournament.models import RoundType
+from validator.tournament.models import TournamentRoundData
+from validator.tournament.models import TournamentTask
+from validator.tournament.round_results import get_environment_group_winners
+
+
+MODULE = "validator.tournament.round_results"
+
+CHALLENGER = "5EgpWgYvChallenger"
+OTHER = "5D7iEJm5Other"
+BOSS = EMISSION_BURN_HOTKEY
+
+
+def _round() -> TournamentRoundData:
+    return TournamentRoundData(
+        round_id="tourn_test_round_001",
+        tournament_id="tourn_test",
+        round_number=1,
+        round_type=RoundType.GROUP,
+        is_final_round=False,
+        status=RoundStatus.COMPLETED,
+    )
+
+
+def _task(group_id: str, task_id: str) -> TournamentTask:
+    return TournamentTask(
+        tournament_id="tourn_test", round_id="tourn_test_round_001", task_id=task_id, group_id=group_id
+    )
+
+
+def _members(*hotkeys: str):
+    return [AsyncMock(hotkey=hk) for hk in hotkeys]
+
+
+def _scored(scores: dict[str, float]):
+    """Ranked results as calculate_miner_ranking_and_scores would return them."""
+    return [AsyncMock(hotkey=hk, adjusted_loss=score) for hk, score in scores.items()]
+
+
+@pytest.fixture
+def env_group():
+    with (
+        patch(f"{MODULE}.get_tournament_group_members", new_callable=AsyncMock) as members,
+        patch(f"{MODULE}.get_task_results_for_ranking", new_callable=AsyncMock) as results,
+        patch(f"{MODULE}.calculate_miner_ranking_and_scores") as ranked,
+    ):
+        results.return_value = [object()]
+        yield members, results, ranked
+
+
+class TestBossRetains:
+    async def test_lone_survivor_beaten_by_boss_does_not_advance(self, env_group):
+        """The production case: one challenger left, it lost to the boss, it stays out."""
+        members, _results, ranked = env_group
+        members.return_value = _members(CHALLENGER)
+        ranked.return_value = _scored({BOSS: 1.0, CHALLENGER: 0.0})
+
+        winners = await get_environment_group_winners(_round(), [_task("g1", "t1")], AsyncMock(), None)
+
+        assert winners == []
+
+    async def test_boss_retains_on_a_tie(self, env_group):
+        members, _results, ranked = env_group
+        members.return_value = _members(CHALLENGER)
+        ranked.return_value = _scored({BOSS: 0.5, CHALLENGER: 0.5})
+
+        assert await get_environment_group_winners(_round(), [_task("g1", "t1")], AsyncMock(), None) == []
+
+    async def test_challenger_that_beats_the_boss_advances(self, env_group):
+        members, _results, ranked = env_group
+        members.return_value = _members(CHALLENGER)
+        ranked.return_value = _scored({CHALLENGER: 1.0, BOSS: 0.0})
+
+        assert await get_environment_group_winners(_round(), [_task("g1", "t1")], AsyncMock(), None) == [CHALLENGER]
+
+    async def test_multi_group_round_still_gates_the_boss_group(self, env_group):
+        """Three groups, boss drawn into the first. Previously single_group=False skipped the
+        gate entirely and the beaten challenger advanced alongside the other groups' winners."""
+        members, _results, ranked = env_group
+        members.side_effect = [_members(CHALLENGER), _members("5AAA", "5BBB"), _members("5CCC", "5DDD")]
+        ranked.side_effect = [
+            _scored({BOSS: 1.0, CHALLENGER: 0.0}),   # boss group: nobody advances
+            _scored({"5AAA": 0.9, "5BBB": 0.1}),
+            _scored({"5CCC": 0.8, "5DDD": 0.2}),
+        ]
+
+        winners = await get_environment_group_winners(
+            _round(), [_task("g1", "t1"), _task("g2", "t2"), _task("g3", "t3")], AsyncMock(), None
+        )
+
+        assert winners == ["5AAA", "5CCC"]
+        assert CHALLENGER not in winners
+
+    async def test_groups_without_the_boss_are_unaffected(self, env_group):
+        """boss_score is None where the boss never played, so the gate cannot suppress them."""
+        members, _results, ranked = env_group
+        members.return_value = _members(CHALLENGER, OTHER)
+        ranked.return_value = _scored({CHALLENGER: 0.667, OTHER: 0.5})
+
+        winners = await get_environment_group_winners(_round(), [_task("g2", "t2")], AsyncMock(), None)
+
+        assert winners == [CHALLENGER]
+
+    async def test_ties_at_the_cutoff_still_advance_together(self, env_group):
+        """Group 3 tonight advanced two miners tied on 0.833; that must not regress."""
+        members, _results, ranked = env_group
+        members.return_value = _members("5AAA", "5BBB", "5CCC", "5DDD")
+        ranked.return_value = _scored({"5AAA": 0.833, "5BBB": 0.833, "5CCC": 0.167, "5DDD": 0.167})
+
+        winners = await get_environment_group_winners(_round(), [_task("g3", "t3")], AsyncMock(), None)
+
+        assert sorted(winners) == ["5AAA", "5BBB"]

--- a/validator/tournament/round_results.py
+++ b/validator/tournament/round_results.py
@@ -675,7 +675,6 @@ async def get_environment_group_winners(
         logger.warning(f"No tasks found for environment round {completed_round.round_id}")
         return []
 
-    single_group = len(round_tasks) == 1
     all_winners: list[str] = []
 
     for task in round_tasks:
@@ -710,13 +709,21 @@ async def get_environment_group_winners(
         boss_score = participant_scores.get(boss_hotkey)
         non_boss_sorted = [(hotkey, score) for hotkey, score in sorted_participants if hotkey != boss_hotkey]
 
-        # Boss retains only when down to a single group and boss wins/ties
-        if single_group and boss_score is not None and non_boss_sorted:
+        # Wherever the boss actually played, it must be beaten to get past it. Advancing a
+        # challenger the boss just beat sends someone to the next round on survivorship rather
+        # than merit - in tourn_10592fcefa2f37ad_20260810 round 1 that promoted a miner who lost
+        # both environments to the boss (78-94 clobber, 11-18 othello) and scored 0.0, purely
+        # because the other three in its group failed training. A tie keeps the incumbent, as
+        # everywhere else in the boss-round logic.
+        #
+        # This only bites in the one group the boss was drawn into; groups it never played have
+        # boss_score None and are unaffected.
+        if boss_score is not None and non_boss_sorted:
             top_challenger_score = non_boss_sorted[0][1]
             if boss_score >= top_challenger_score:
                 logger.info(
-                    f"Environment group {group_id}: boss score {boss_score} >= top challenger {top_challenger_score} "
-                    f"— single group, boss retains"
+                    f"Environment group {group_id}: boss score {boss_score} >= top challenger "
+                    f"{top_challenger_score} — boss retains, group advances nobody"
                 )
                 continue
 


### PR DESCRIPTION
The boss-retains rule was gated on the round having a single group, so in a multi-group round it never applied. A challenger the boss had just beaten advanced anyway, purely for being the last one standing in its group.

tourn_10592fcefa2f37ad_20260810 round 1 group 1: three of the four challengers failed training, and the survivor lost both environments to the boss (78-94 clobber, 11-18 othello) for a score of 0.0. It advanced to round 2 while two miners who won environments outright in other groups - one of whom swept othello 3-0 - were eliminated on 0.5. Advancement had no absolute floor, only a relative one, so an emptied group promotes by survivorship.

Drop the single_group condition: wherever the boss actually played, it has to be beaten to be got past. A tie keeps the incumbent, matching the rest of the boss-round logic. Groups the boss was never drawn into have boss_score None and are unaffected, so this only ever gates the one group it played in.

If every group ends up advancing nobody, advance_tournament already treats an empty winner set as the boss retaining the tournament.