### PR TITLE
Oversample 2026+ models into one R1 and one boss-round task

### DIFF
--- a/core/oversampled_later_models.json
+++ b/core/oversampled_later_models.json
@@ -1,0 +1,17 @@
+{
+  "_comment": "Temporary in-repo pool of 2026+ base models that text tournaments oversample — one guaranteed R1 task and one boss-round instruct task play on a model drawn from here. The content service does not serve these yet (its /get_random_models pool only goes up to 2025), so we keep the list here and sample it directly. Move to the content service and delete this file once it can filter by release date. Every entry is verified ungated, safetensors-only, no auto_map / no .py in the repo (so trust_remote_code=False loads it), no quantization_config, <14B params, and its model_type is in transformers 5.12.x MODEL_FOR_CAUSAL_LM_MAPPING_NAMES.",
+  "models": [
+    {"model_id": "Qwen/Qwen3.5-0.8B", "params_b": 0.87, "model_type": "qwen3_5"},
+    {"model_id": "Qwen/Qwen3.5-2B", "params_b": 2.27, "model_type": "qwen3_5"},
+    {"model_id": "Qwen/Qwen3.5-4B", "params_b": 4.66, "model_type": "qwen3_5"},
+    {"model_id": "Qwen/Qwen3.5-9B", "params_b": 9.65, "model_type": "qwen3_5"},
+    {"model_id": "google/gemma-4-E2B-it", "params_b": 5.12, "model_type": "gemma4"},
+    {"model_id": "google/gemma-4-E4B-it", "params_b": 8.0, "model_type": "gemma4"},
+    {"model_id": "LiquidAI/LFM2.5-1.2B-Instruct", "params_b": 1.17, "model_type": "lfm2"},
+    {"model_id": "LiquidAI/LFM2.5-2.6B", "params_b": 2.7, "model_type": "lfm2"},
+    {"model_id": "LiquidAI/LFM2.5-8B-A1B", "params_b": 8.47, "model_type": "lfm2_moe"},
+    {"model_id": "ibm-granite/granite-4.1-3b", "params_b": 3.4, "model_type": "granite"},
+    {"model_id": "ibm-granite/granite-4.1-8b", "params_b": 8.79, "model_type": "granite"},
+    {"model_id": "openbmb/MiniCPM5-1B", "params_b": 1.08, "model_type": "llama"}
+  ]
+}

--- a/core/oversampled_later_models.py
+++ b/core/oversampled_later_models.py
@@ -1,0 +1,47 @@
+import json
+import random
+from pathlib import Path
+
+from pydantic import BaseModel
+from pydantic import ConfigDict
+
+
+_POOL_PATH = Path(__file__).parent / "oversampled_later_models.json"
+
+
+class OversampledLaterModel(BaseModel):
+    """A 2026+ base model the text tournament oversamples into a guaranteed task slot.
+
+    params_b is the safetensors parameter count at the time of listing — informational only,
+    task sizing still reads the live count from the hub (get_model_num_params).
+    """
+
+    model_config = ConfigDict(protected_namespaces=())
+
+    model_id: str
+    params_b: float
+    model_type: str
+
+
+class OversampledLaterModelPool(BaseModel):
+    comment: str
+    models: list[OversampledLaterModel]
+
+
+def _load() -> OversampledLaterModelPool:
+    raw = json.loads(_POOL_PATH.read_text())
+    return OversampledLaterModelPool(comment=raw["_comment"], models=raw["models"])
+
+
+# Ordered pool, sampled uniformly (see sample_oversampled_later_model). Kept in-repo until the
+# content service can serve models by release date — see the JSON's _comment.
+OVERSAMPLED_LATER_MODELS: list[OversampledLaterModel] = _load().models
+
+
+def sample_oversampled_later_model(rng: random.Random | None = None) -> str:
+    """Pick one model id from the pool, uniformly.
+
+    Pass a seeded rng where the choice must survive a retry — tournament task creation is
+    resumable, so re-running a partially created round has to land on the same model.
+    """
+    return (rng or random).choice(OVERSAMPLED_LATER_MODELS).model_id

--- a/tests/validator/scoring/test_tournament_scoring_pipeline.py
+++ b/tests/validator/scoring/test_tournament_scoring_pipeline.py
@@ -22,6 +22,7 @@ from validator.scoring.tournaments import individual_scores_to_pairwise
 from validator.scoring.tournaments import pvp_results_to_pairwise
 from validator.scoring.tournaments import tournament_scores_to_weights
 from validator.scoring.weights import apply_tournament_weights
+from validator.tournament.models import ContinuousSftLineageOutcome
 from validator.tournament.models import EnvironmentWeight
 from validator.tournament.models import PairwiseOutcome
 from validator.tournament.models import TournamentResultsWithWinners
@@ -434,49 +435,78 @@ class TestDetermineBossRoundWinnerEnv:
         assert determine_boss_round_winner(winners, "boss", TournamentType.TEXT) == "challenger"
 
 
+def _won(lineage: str, hotkey: str) -> ContinuousSftLineageOutcome:
+    return ContinuousSftLineageOutcome(lineage=lineage, winner_hotkey=hotkey)
+
+
+def _drew(lineage: str) -> ContinuousSftLineageOutcome:
+    return ContinuousSftLineageOutcome(lineage=lineage, is_draw=True)
+
+
+def _no_result(lineage: str) -> ContinuousSftLineageOutcome:
+    return ContinuousSftLineageOutcome(lineage=lineage)
+
+
 class TestDetermineBossRoundWinnerContinuousSft:
-    """Text boss round with continuous-SFT tasks: on top of the overall 5/6 threshold, the
-    challenger must win EVERY continuous-SFT task to dethrone. num_continuous_sft_tasks is the
-    total continuous-SFT tasks in the round; continuous_sft_winners are the decided ones.
+    """Text boss round with continuous-SFT lineages: on top of the overall 5/6 threshold, the
+    challenger must satisfy EVERY lineage to dethrone.
+
+    Satisfied means won it or drew it. A draw is the task failing to separate the two models rather
+    than the challenger failing to beat the boss, so it should not cost the crown. A loss, or no
+    result at all, blocks — the latter because absence of evidence is not parity.
     """
 
     OVERALL_5_OF_6 = ["challenger"] * 5 + ["boss"]
 
     def test_wins_overall_and_all_continuous_dethrones(self):
         assert determine_boss_round_winner(
-            self.OVERALL_5_OF_6, "boss", TournamentType.TEXT, ["challenger", "challenger"], 2
+            self.OVERALL_5_OF_6, "boss", TournamentType.TEXT, [_won("a", "challenger"), _won("b", "challenger")]
         ) == "challenger"
 
     def test_wins_overall_but_loses_one_continuous_boss_retains(self):
         assert determine_boss_round_winner(
-            self.OVERALL_5_OF_6, "boss", TournamentType.TEXT, ["challenger", "boss"], 2
+            self.OVERALL_5_OF_6, "boss", TournamentType.TEXT, [_won("a", "challenger"), _won("b", "boss")]
         ) == "boss"
 
     def test_wins_overall_but_loses_both_continuous_boss_retains(self):
         assert determine_boss_round_winner(
-            self.OVERALL_5_OF_6, "boss", TournamentType.TEXT, ["boss", "boss"], 2
+            self.OVERALL_5_OF_6, "boss", TournamentType.TEXT, [_won("a", "boss"), _won("b", "boss")]
         ) == "boss"
 
     def test_wins_all_continuous_but_fails_overall_boss_retains(self):
         winners = ["challenger"] * 4 + ["boss", "boss"]  # only 4/6
-        assert determine_boss_round_winner(winners, "boss", TournamentType.TEXT, ["challenger", "challenger"], 2) == "boss"
+        assert determine_boss_round_winner(
+            winners, "boss", TournamentType.TEXT, [_won("a", "challenger"), _won("b", "challenger")]
+        ) == "boss"
 
     def test_skipped_continuous_task_counts_against_challenger(self):
-        # Only one of two continuous tasks produced a decided winner -> count 1 != 2 -> boss retains.
-        assert determine_boss_round_winner(self.OVERALL_5_OF_6, "boss", TournamentType.TEXT, ["challenger"], 2) == "boss"
+        # One lineage produced no comparison at all -> not satisfied -> boss retains.
+        assert determine_boss_round_winner(
+            self.OVERALL_5_OF_6, "boss", TournamentType.TEXT, [_won("a", "challenger"), _no_result("b")]
+        ) == "boss"
+
+    def test_drawn_continuous_task_does_not_count_against_challenger(self):
+        # A draw is not a skip: both sides were scored and came out level, which satisfies the gate.
+        assert determine_boss_round_winner(
+            self.OVERALL_5_OF_6, "boss", TournamentType.TEXT, [_won("a", "challenger"), _drew("b")]
+        ) == "challenger"
 
     def test_six_of_six_with_both_continuous_dethrones(self):
         assert determine_boss_round_winner(
-            ["challenger"] * 6, "boss", TournamentType.TEXT, ["challenger", "challenger"], 2
+            ["challenger"] * 6, "boss", TournamentType.TEXT, [_won("a", "challenger"), _won("b", "challenger")]
         ) == "challenger"
 
     def test_no_continuous_tasks_falls_back_to_overall_rule(self):
-        # num_continuous_sft_tasks=0 (e.g. image rounds / back-compat) leaves the rule untouched.
-        assert determine_boss_round_winner(self.OVERALL_5_OF_6, "boss", TournamentType.IMAGE, [], 0) == "challenger"
+        # No lineages (e.g. image rounds / back-compat) leaves the rule untouched.
+        assert determine_boss_round_winner(self.OVERALL_5_OF_6, "boss", TournamentType.IMAGE, []) == "challenger"
 
     def test_single_continuous_task_must_be_won(self):
-        assert determine_boss_round_winner(self.OVERALL_5_OF_6, "boss", TournamentType.TEXT, ["challenger"], 1) == "challenger"
-        assert determine_boss_round_winner(self.OVERALL_5_OF_6, "boss", TournamentType.TEXT, ["boss"], 1) == "boss"
+        assert determine_boss_round_winner(
+            self.OVERALL_5_OF_6, "boss", TournamentType.TEXT, [_won("a", "challenger")]
+        ) == "challenger"
+        assert determine_boss_round_winner(
+            self.OVERALL_5_OF_6, "boss", TournamentType.TEXT, [_won("a", "boss")]
+        ) == "boss"
 
 
 # --- 1j: get_real_winner_hotkey ---

--- a/tests/validator/tournament/test_boss_round_draw_deciders.py
+++ b/tests/validator/tournament/test_boss_round_draw_deciders.py
@@ -12,21 +12,32 @@ import numpy as np
 import pytest
 from pydantic import ValidationError
 
+from core.constants.environments import TrainingStartPoint
 from core.models.task_models import TaskType
 from core.models.tournament_models import TournamentType
 from validator.tournament import constants as t_cst
 from validator.tournament import round_results
 from validator.tournament import tournament_manager
 from validator.tournament.models import BossRoundDrawResolution
+from validator.tournament.models import BossRoundTaskVerdict
 from validator.tournament.models import ContinuousSftLineageOutcome
 from validator.tournament.models import RoundStatus
 from validator.tournament.models import RoundType
 from validator.tournament.models import TournamentData
 from validator.tournament.models import TournamentRoundData
 from validator.tournament.models import TournamentTask
+from validator.tournament.models import TrainingStatus
 from validator.tournament.round_results import _resolve_boss_round_draws
 from validator.tournament.round_results import determine_boss_round_winner
 from validator.tournament.thresholds import compare_paired_losses
+
+
+async def _async(value):
+    return value
+
+
+async def _async_none(**_kwargs):
+    return None
 
 
 BOSS = "boss_hotkey"
@@ -359,3 +370,86 @@ async def test_orphaned_task_defers_the_round_instead_of_scoring_it(monkeypatch)
     assert outcome.is_deferred is True
     assert outcome.unassigned_task_ids == [orphan_id]
     assert outcome.winners == []
+
+
+@pytest.mark.asyncio
+async def test_a_skipped_continuous_task_still_blocks_the_dethrone(monkeypatch):
+    """A continuous-SFT task that produced no comparison must stay in its own gate.
+
+    Registration used to ride on the award path, but several branches bail out with a bare
+    `continue` - "both evaluation failed or both succeeded but missing results" among them - so the
+    lineage never entered the outcomes dict, the gate's count fell to zero, and the strictest rule in
+    the tournament switched itself off. Driven through get_knockout_winners rather than
+    determine_boss_round_winner directly, because the defect was in what the caller collected, not
+    in the arithmetic over it - which is exactly why unit-testing the arithmetic alone missed it.
+    """
+    csft_task, instruct_task = _round_tasks(2)
+
+    def _result(hotkey, adjusted_loss):
+        return SimpleNamespace(hotkey=hotkey, adjusted_loss=adjusted_loss)
+
+    # Neither side has a usable loss on the continuous-SFT task, and both trained successfully, so
+    # it lands in the "both evaluation failed" branch and is skipped without ever being awarded.
+    results = {
+        csft_task.task_id: [_result(BOSS, None), _result(CHALLENGER, None)],
+        instruct_task.task_id: [_result(BOSS, 0.5), _result(CHALLENGER, 0.4)],
+    }
+    tasks = {
+        csft_task.task_id: SimpleNamespace(
+            task_id=csft_task.task_id,
+            task_type=TaskType.CHATTASK,
+            training_start_point=TrainingStartPoint.CONTINUOUS_SFT,
+            ds="continuous-sft:qwen:chunk",
+        ),
+        instruct_task.task_id: SimpleNamespace(
+            task_id=instruct_task.task_id,
+            task_type=TaskType.INSTRUCTTEXTTASK,
+            training_start_point=None,
+            ds="some/dataset",
+        ),
+    }
+    captured: dict = {}
+
+    async def _tournament(_tournament_id, _psql_db):
+        return TournamentData(tournament_id="tourn_1", tournament_type=TournamentType.TEXT)
+
+    async def _nodes(_task_id, _psql_db):
+        return ["node_boss", "node_challenger"]
+
+    async def _resolve(task_id, **_kwargs):
+        assert task_id != csft_task.task_id, "the continuous-SFT task should have been skipped"
+        return BossRoundTaskVerdict(winner_hotkey=CHALLENGER)
+
+    async def _training_status(_task_id, _hotkeys, _psql_db):
+        return {BOSS: TrainingStatus.SUCCESS, CHALLENGER: TrainingStatus.SUCCESS}
+
+    def _winner(_task_winners, boss_hotkey, _tournament_type, outcomes=None, **_kwargs):
+        captured["outcomes"] = outcomes
+        return boss_hotkey
+
+    monkeypatch.setattr(round_results, "EMISSION_BURN_HOTKEY", BOSS)
+    monkeypatch.setattr(round_results, "get_tournament", _tournament)
+    monkeypatch.setattr(round_results, "get_nodes_assigned_to_task", _nodes)
+    monkeypatch.setattr(round_results, "get_task", lambda task_id, _psql_db: _async(tasks[task_id]))
+    monkeypatch.setattr(round_results, "get_task_results_for_ranking", lambda tid, _db: _async(results[tid]))
+    monkeypatch.setattr(round_results, "calculate_miner_ranking_and_scores", lambda ranked: ranked)
+    monkeypatch.setattr(round_results, "get_training_status_for_task_and_hotkeys", _training_status)
+    monkeypatch.setattr(round_results, "_resolve_boss_round_task_winner", _resolve)
+    monkeypatch.setattr(round_results, "update_threshold_adjusted_quality_scores_for_task", _async_none)
+    monkeypatch.setattr(round_results, "determine_boss_round_winner", _winner)
+
+    completed_round = TournamentRoundData(
+        round_id="tourn_1_round_004",
+        tournament_id="tourn_1",
+        round_number=4,
+        round_type=RoundType.KNOCKOUT,
+        is_final_round=True,
+        status=RoundStatus.PENDING,
+    )
+
+    await round_results.get_knockout_winners(completed_round, [csft_task, instruct_task], psql_db=None, config=None)
+
+    outcomes = captured["outcomes"]
+    assert [outcome.lineage for outcome in outcomes] == ["qwen"], "the skipped lineage must stay in the gate"
+    assert outcomes[0].satisfied_by(CHALLENGER) is False
+    assert outcomes[0].is_draw is False

--- a/tests/validator/tournament/test_boss_round_draw_deciders.py
+++ b/tests/validator/tournament/test_boss_round_draw_deciders.py
@@ -1,0 +1,194 @@
+"""Boss-round draws leave the dethrone tally and earn the round a replacement task.
+
+A draw is zero decided examples: every held-out example landed inside the tie dead zone, so nothing
+separated the two models. That is a property of the randomly drawn dataset, not of the challenger,
+so it must not consume the one task the challenger is allowed to drop. Each drawn task is instead
+excluded from the tally and replaced, so the round still resolves over a full set of decided results.
+"""
+
+import numpy as np
+import pytest
+
+from core.models.task_models import TaskType
+from core.models.tournament_models import TournamentType
+from validator.tournament import constants as t_cst
+from validator.tournament.models import TournamentTask
+from validator.tournament.round_results import _resolve_boss_round_draws
+from validator.tournament.round_results import determine_boss_round_winner
+from validator.tournament.thresholds import compare_paired_losses
+
+
+BOSS = "boss_hotkey"
+CHALLENGER = "challenger_hotkey"
+TEXT_BOSS_ROUND_SIZE = t_cst.FINAL_ROUND_TEXT_TASKS
+
+
+def _round_tasks(n: int) -> list[TournamentTask]:
+    return [
+        TournamentTask(
+            tournament_id="tourn_1",
+            round_id="tourn_1_round_004",
+            task_id=f"00000000-0000-0000-0000-{i:012d}",
+            pair_id="tourn_1_round_004_pair_001",
+        )
+        for i in range(n)
+    ]
+
+
+def test_all_examples_inside_dead_zone_is_a_draw():
+    """The trigger condition: no example separated the two models by more than the dead zone."""
+    boss = np.random.default_rng(7).uniform(0.02, 0.03, 800)
+    challenger = boss - (t_cst.BOSS_ROUND_TIE_DEADZONE_NATS / 2)
+
+    result = compare_paired_losses(list(boss), list(challenger))
+
+    assert result.n_decided == 0
+    assert result.is_draw is True
+    assert result.challenger_won is False
+
+
+def test_chris_scenario_challenger_takes_the_crown_after_winning_the_decider():
+    """Boss 1, draw 1, challenger 3 -> add a task -> challenger wins it -> challenger is the boss.
+
+    The draw never enters the tally, so the decider brings the decided count back to the boss round's
+    full size and the usual "lose at most one" rule applies over those five.
+    """
+    # The four decided tasks from the original round, plus the decider the challenger then won.
+    decided_winners = [BOSS, CHALLENGER, CHALLENGER, CHALLENGER, CHALLENGER]
+
+    winner = determine_boss_round_winner(
+        decided_winners,
+        BOSS,
+        TournamentType.TEXT,
+        continuous_sft_winners=[CHALLENGER],
+        num_continuous_sft_tasks=1,
+    )
+
+    assert len(decided_winners) == TEXT_BOSS_ROUND_SIZE
+    assert winner == CHALLENGER
+
+
+def test_a_dead_task_never_lowers_the_dethrone_bar():
+    """Reached only when a decider itself draws, leaving four decided tasks instead of five.
+
+    The bar stays pinned at the round's built size, so the challenger must sweep the four that
+    worked rather than getting in on three. Excluding a draw takes it out of the numerator; it must
+    not also shrink the denominator.
+    """
+    three_of_four = determine_boss_round_winner(
+        [BOSS, CHALLENGER, CHALLENGER, CHALLENGER],
+        BOSS,
+        TournamentType.TEXT,
+        continuous_sft_winners=[CHALLENGER],
+        num_continuous_sft_tasks=1,
+        expected_task_count=TEXT_BOSS_ROUND_SIZE,
+    )
+    assert three_of_four == BOSS
+
+    swept_all_four = determine_boss_round_winner(
+        [CHALLENGER, CHALLENGER, CHALLENGER, CHALLENGER],
+        BOSS,
+        TournamentType.TEXT,
+        continuous_sft_winners=[CHALLENGER],
+        num_continuous_sft_tasks=1,
+        expected_task_count=TEXT_BOSS_ROUND_SIZE,
+    )
+    assert swept_all_four == CHALLENGER
+
+
+def test_bar_is_not_pinned_when_nothing_drew():
+    """No draws means no pin, so image and environment boss rounds are untouched by any of this.
+
+    They cannot draw - the paired gate is text-only - and their bar keeps deriving from however many
+    of their own tasks resolved, which is what a failed image task has always relied on.
+    """
+    winner = determine_boss_round_winner(
+        [BOSS, CHALLENGER, CHALLENGER, CHALLENGER],
+        BOSS,
+        TournamentType.IMAGE,
+        expected_task_count=None,
+    )
+
+    assert winner == CHALLENGER
+
+
+def test_draws_earn_one_decider_each_mirroring_the_type_that_drew():
+    resolution = _resolve_boss_round_draws(
+        drawn_task_ids=["task_a", "task_b"],
+        drawn_task_types=[TaskType.DPOTASK, TaskType.INSTRUCTTEXTTASK],
+        drawn_continuous_sft_lineages=[None, None],
+        round_tasks=_round_tasks(TEXT_BOSS_ROUND_SIZE),
+        tournament_type=TournamentType.TEXT,
+    )
+
+    assert resolution.needs_deciders is True
+    assert resolution.decider_task_types == [TaskType.DPOTASK, TaskType.INSTRUCTTEXTTASK]
+
+
+def test_continuous_sft_draw_is_mirrored_by_lineage_not_downgraded():
+    """The dethrone rule needs continuous-SFT tasks *won*, so a draw must be replaced in kind."""
+    resolution = _resolve_boss_round_draws(
+        drawn_task_ids=["task_a"],
+        drawn_task_types=[TaskType.CHATTASK],
+        drawn_continuous_sft_lineages=["qwen"],
+        round_tasks=_round_tasks(TEXT_BOSS_ROUND_SIZE),
+        tournament_type=TournamentType.TEXT,
+    )
+
+    assert resolution.needs_deciders is True
+    assert resolution.decider_task_types == [TaskType.CHATTASK]
+    assert resolution.continuous_sft_lineages == ["qwen"]
+
+
+def test_deciders_are_capped_at_one_round_of_them():
+    """A round already holding more tasks than its type calls for has had its deciders.
+
+    So a decider that itself draws does not spawn another one - it is simply excluded and the round
+    resolves on what was decided.
+    """
+    resolution = _resolve_boss_round_draws(
+        drawn_task_ids=["task_a"],
+        drawn_task_types=[TaskType.INSTRUCTTEXTTASK],
+        drawn_continuous_sft_lineages=[None],
+        round_tasks=_round_tasks(TEXT_BOSS_ROUND_SIZE + 1),
+        tournament_type=TournamentType.TEXT,
+    )
+
+    assert resolution.needs_deciders is False
+    assert resolution.can_add_deciders is False
+    assert resolution.drawn_task_ids == ["task_a"]
+
+
+def test_no_draws_means_nothing_to_do():
+    resolution = _resolve_boss_round_draws(
+        drawn_task_ids=[],
+        drawn_task_types=[],
+        drawn_continuous_sft_lineages=[],
+        round_tasks=_round_tasks(TEXT_BOSS_ROUND_SIZE),
+        tournament_type=TournamentType.TEXT,
+    )
+
+    assert resolution.needs_deciders is False
+    assert resolution.drawn_task_ids == []
+
+
+@pytest.mark.parametrize(
+    "tournament_type,expected",
+    [
+        (TournamentType.TEXT, t_cst.FINAL_ROUND_TEXT_TASKS),
+        # Image and environment cannot draw, so they get 0 and every draw rule stays off for them.
+        (TournamentType.IMAGE, 0),
+        (TournamentType.ENVIRONMENT, 0),
+    ],
+)
+def test_expected_boss_round_task_count(tournament_type, expected):
+    assert t_cst.expected_boss_round_task_count(tournament_type) == expected
+
+
+def test_only_text_task_types_can_draw():
+    """The premise the rest of this rests on: the paired gate, and so draws, are text-only."""
+    assert set(t_cst.PAIRED_BOSS_ROUND_TASK_TYPES) == {
+        TaskType.INSTRUCTTEXTTASK,
+        TaskType.DPOTASK,
+        TaskType.CHATTASK,
+    }

--- a/tests/validator/tournament/test_boss_round_draw_deciders.py
+++ b/tests/validator/tournament/test_boss_round_draw_deciders.py
@@ -17,7 +17,6 @@ from core.models.task_models import TaskType
 from core.models.tournament_models import TournamentType
 from validator.tournament import constants as t_cst
 from validator.tournament import round_results
-from validator.tournament import tournament_manager
 from validator.tournament.models import BossRoundDrawResolution
 from validator.tournament.models import BossRoundTaskVerdict
 from validator.tournament.models import ContinuousSftLineageOutcome
@@ -350,11 +349,11 @@ async def test_orphaned_task_defers_the_round_instead_of_scoring_it(monkeypatch)
     async def fake_get_tournament(_tournament_id, _psql_db):
         return TournamentData(tournament_id="tourn_1", tournament_type=TournamentType.TEXT)
 
-    async def fake_get_nodes_assigned_to_task(task_id, _psql_db):
-        return [] if task_id == orphan_id else ["node_boss", "node_challenger"]
+    async def fake_count_hotkeys_assigned_to_task(task_id, _psql_db):
+        return 0 if task_id == orphan_id else 2
 
     monkeypatch.setattr(round_results, "get_tournament", fake_get_tournament)
-    monkeypatch.setattr(round_results, "get_nodes_assigned_to_task", fake_get_nodes_assigned_to_task)
+    monkeypatch.setattr(round_results, "count_hotkeys_assigned_to_task", fake_count_hotkeys_assigned_to_task)
 
     completed_round = TournamentRoundData(
         round_id="tourn_1_round_004",
@@ -413,8 +412,8 @@ async def test_a_skipped_continuous_task_still_blocks_the_dethrone(monkeypatch):
     async def _tournament(_tournament_id, _psql_db):
         return TournamentData(tournament_id="tourn_1", tournament_type=TournamentType.TEXT)
 
-    async def _nodes(_task_id, _psql_db):
-        return ["node_boss", "node_challenger"]
+    async def _assigned(_task_id, _psql_db):
+        return 2
 
     async def _resolve(task_id, **_kwargs):
         assert task_id != csft_task.task_id, "the continuous-SFT task should have been skipped"
@@ -429,7 +428,7 @@ async def test_a_skipped_continuous_task_still_blocks_the_dethrone(monkeypatch):
 
     monkeypatch.setattr(round_results, "EMISSION_BURN_HOTKEY", BOSS)
     monkeypatch.setattr(round_results, "get_tournament", _tournament)
-    monkeypatch.setattr(round_results, "get_nodes_assigned_to_task", _nodes)
+    monkeypatch.setattr(round_results, "count_hotkeys_assigned_to_task", _assigned)
     monkeypatch.setattr(round_results, "get_task", lambda task_id, _psql_db: _async(tasks[task_id]))
     monkeypatch.setattr(round_results, "get_task_results_for_ranking", lambda tid, _db: _async(results[tid]))
     monkeypatch.setattr(round_results, "calculate_miner_ranking_and_scores", lambda ranked: ranked)
@@ -453,3 +452,62 @@ async def test_a_skipped_continuous_task_still_blocks_the_dethrone(monkeypatch):
     assert [outcome.lineage for outcome in outcomes] == ["qwen"], "the skipped lineage must stay in the gate"
     assert outcomes[0].satisfied_by(CHALLENGER) is False
     assert outcomes[0].is_draw is False
+
+
+@pytest.mark.asyncio
+async def test_a_drawn_continuous_sft_task_with_an_unparseable_lineage_gets_a_buildable_decider(monkeypatch):
+    """The decider type must follow what the task IS, not whether its lineage parsed.
+
+    _lineage_outcome returns None both for "not continuous-SFT" and for "continuous-SFT whose
+    lineage no longer parses" - the latter reachable by editing CONTINUOUS_SFT_LINEAGES between
+    rounds, which is why warn_orphaned_continuous_sft_state exists. Branching on it queued a
+    CHATTASK decider, and _create_single_new_text_task has no route for CHATTASK, so the round
+    retried a task it could never build every 60 seconds forever.
+    """
+    (csft_task,) = _round_tasks(1)
+    orphaned = SimpleNamespace(
+        task_id=csft_task.task_id,
+        task_type=TaskType.CHATTASK,
+        training_start_point=TrainingStartPoint.CONTINUOUS_SFT,
+        ds="continuous-sft-but-unparseable",
+    )
+    assert t_cst.is_continuous_sft_task(orphaned) is True
+    assert t_cst.continuous_sft_lineage_from_ds(orphaned.ds) is None, "premise: the lineage does not parse"
+
+    async def _tournament(_tournament_id, _psql_db):
+        return TournamentData(tournament_id="tourn_1", tournament_type=TournamentType.TEXT)
+
+    async def _resolve(**_kwargs):
+        return BossRoundTaskVerdict(winner_hotkey=BOSS, decided_by="a draw", is_draw=True)
+
+    monkeypatch.setattr(round_results, "EMISSION_BURN_HOTKEY", BOSS)
+    monkeypatch.setattr(round_results, "get_tournament", _tournament)
+    monkeypatch.setattr(round_results, "count_hotkeys_assigned_to_task", lambda _tid, _db: _async(2))
+    monkeypatch.setattr(round_results, "get_task", lambda _tid, _db: _async(orphaned))
+    monkeypatch.setattr(
+        round_results,
+        "get_task_results_for_ranking",
+        lambda _tid, _db: _async([SimpleNamespace(hotkey=BOSS), SimpleNamespace(hotkey=CHALLENGER)]),
+    )
+    monkeypatch.setattr(
+        round_results,
+        "calculate_miner_ranking_and_scores",
+        lambda ranked: [SimpleNamespace(hotkey=r.hotkey, adjusted_loss=0.5) for r in ranked],
+    )
+    monkeypatch.setattr(round_results, "_resolve_boss_round_task_winner", _resolve)
+    monkeypatch.setattr(round_results, "update_threshold_adjusted_quality_scores_for_task", _async_none)
+
+    completed_round = TournamentRoundData(
+        round_id="tourn_1_round_004",
+        tournament_id="tourn_1",
+        round_number=4,
+        round_type=RoundType.KNOCKOUT,
+        is_final_round=True,
+        status=RoundStatus.PENDING,
+    )
+
+    outcome = await round_results.get_knockout_winners(completed_round, [csft_task], psql_db=None, config=None)
+
+    assert outcome.is_deferred is True
+    # CHATTASK here would be a decider nothing can build.
+    assert outcome.draw_resolution.decider_task_types == [TaskType.INSTRUCTTEXTTASK]

--- a/tests/validator/tournament/test_boss_round_draw_deciders.py
+++ b/tests/validator/tournament/test_boss_round_draw_deciders.py
@@ -6,12 +6,23 @@ so it must not consume the one task the challenger is allowed to drop. Each draw
 excluded from the tally and replaced, so the round still resolves over a full set of decided results.
 """
 
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
+from pydantic import ValidationError
 
 from core.models.task_models import TaskType
 from core.models.tournament_models import TournamentType
 from validator.tournament import constants as t_cst
+from validator.tournament import round_results
+from validator.tournament import tournament_manager
+from validator.tournament.models import BossRoundDrawResolution
+from validator.tournament.models import ContinuousSftLineageOutcome
+from validator.tournament.models import RoundStatus
+from validator.tournament.models import RoundType
+from validator.tournament.models import TournamentData
+from validator.tournament.models import TournamentRoundData
 from validator.tournament.models import TournamentTask
 from validator.tournament.round_results import _resolve_boss_round_draws
 from validator.tournament.round_results import determine_boss_round_winner
@@ -60,8 +71,7 @@ def test_chris_scenario_challenger_takes_the_crown_after_winning_the_decider():
         decided_winners,
         BOSS,
         TournamentType.TEXT,
-        continuous_sft_winners=[CHALLENGER],
-        num_continuous_sft_tasks=1,
+        continuous_sft_outcomes=[ContinuousSftLineageOutcome(lineage="qwen", winner_hotkey=CHALLENGER)],
     )
 
     assert len(decided_winners) == TEXT_BOSS_ROUND_SIZE
@@ -79,8 +89,7 @@ def test_a_dead_task_never_lowers_the_dethrone_bar():
         [BOSS, CHALLENGER, CHALLENGER, CHALLENGER],
         BOSS,
         TournamentType.TEXT,
-        continuous_sft_winners=[CHALLENGER],
-        num_continuous_sft_tasks=1,
+        continuous_sft_outcomes=[ContinuousSftLineageOutcome(lineage="qwen", winner_hotkey=CHALLENGER)],
         expected_task_count=TEXT_BOSS_ROUND_SIZE,
     )
     assert three_of_four == BOSS
@@ -89,8 +98,7 @@ def test_a_dead_task_never_lowers_the_dethrone_bar():
         [CHALLENGER, CHALLENGER, CHALLENGER, CHALLENGER],
         BOSS,
         TournamentType.TEXT,
-        continuous_sft_winners=[CHALLENGER],
-        num_continuous_sft_tasks=1,
+        continuous_sft_outcomes=[ContinuousSftLineageOutcome(lineage="qwen", winner_hotkey=CHALLENGER)],
         expected_task_count=TEXT_BOSS_ROUND_SIZE,
     )
     assert swept_all_four == CHALLENGER
@@ -115,8 +123,7 @@ def test_bar_is_not_pinned_when_nothing_drew():
 def test_draws_earn_one_decider_each_mirroring_the_type_that_drew():
     resolution = _resolve_boss_round_draws(
         drawn_task_ids=["task_a", "task_b"],
-        drawn_task_types=[TaskType.DPOTASK, TaskType.INSTRUCTTEXTTASK],
-        drawn_continuous_sft_lineages=[None, None],
+        decider_task_types=[TaskType.DPOTASK, TaskType.INSTRUCTTEXTTASK],
         round_tasks=_round_tasks(TEXT_BOSS_ROUND_SIZE),
         tournament_type=TournamentType.TEXT,
     )
@@ -125,19 +132,61 @@ def test_draws_earn_one_decider_each_mirroring_the_type_that_drew():
     assert resolution.decider_task_types == [TaskType.DPOTASK, TaskType.INSTRUCTTEXTTASK]
 
 
-def test_continuous_sft_draw_is_mirrored_by_lineage_not_downgraded():
-    """The dethrone rule needs continuous-SFT tasks *won*, so a draw must be replaced in kind."""
+def test_continuous_sft_draw_is_stood_in_for_by_an_instruct_task():
+    """A drawn lineage gets a plain instruct task, not a second chunk of itself.
+
+    The lineage has already cleared its own dethrone gate by drawing, so a second continuous-SFT
+    task would buy nothing - while putting two tasks on one sequential train_index and leaving the
+    chain's carry-forward to pick between them. The stand-in only tops the tally back up.
+    """
     resolution = _resolve_boss_round_draws(
         drawn_task_ids=["task_a"],
-        drawn_task_types=[TaskType.CHATTASK],
-        drawn_continuous_sft_lineages=["qwen"],
+        decider_task_types=[TaskType.INSTRUCTTEXTTASK],
         round_tasks=_round_tasks(TEXT_BOSS_ROUND_SIZE),
         tournament_type=TournamentType.TEXT,
     )
 
     assert resolution.needs_deciders is True
-    assert resolution.decider_task_types == [TaskType.CHATTASK]
-    assert resolution.continuous_sft_lineages == ["qwen"]
+    assert resolution.decider_task_types == [TaskType.INSTRUCTTEXTTASK]
+
+
+def test_a_drawn_lineage_satisfies_its_own_gate():
+    """A draw is the task failing to separate the models, not the challenger failing to beat them.
+
+    So it clears the lineage gate. The challenger still has to win the rest of the round - this only
+    stops an undecidable continuous-SFT task costing them the crown on its own.
+    """
+    winner = determine_boss_round_winner(
+        [BOSS, CHALLENGER, CHALLENGER, CHALLENGER, CHALLENGER],
+        BOSS,
+        TournamentType.TEXT,
+        continuous_sft_outcomes=[ContinuousSftLineageOutcome(lineage="qwen", is_draw=True)],
+        expected_task_count=TEXT_BOSS_ROUND_SIZE,
+    )
+    assert winner == CHALLENGER
+
+    # But a draw is not a free pass on the rest: still only 3 of 5 decided won.
+    short_elsewhere = determine_boss_round_winner(
+        [BOSS, BOSS, CHALLENGER, CHALLENGER, CHALLENGER],
+        BOSS,
+        TournamentType.TEXT,
+        continuous_sft_outcomes=[ContinuousSftLineageOutcome(lineage="qwen", is_draw=True)],
+        expected_task_count=TEXT_BOSS_ROUND_SIZE,
+    )
+    assert short_elsewhere == BOSS
+
+
+def test_a_lineage_the_boss_won_still_blocks():
+    """A loss is not a draw: the boss demonstrably held that lineage, so the gate blocks."""
+    winner = determine_boss_round_winner(
+        [CHALLENGER, CHALLENGER, CHALLENGER, CHALLENGER],
+        BOSS,
+        TournamentType.TEXT,
+        continuous_sft_outcomes=[ContinuousSftLineageOutcome(lineage="qwen", winner_hotkey=BOSS)],
+        expected_task_count=TEXT_BOSS_ROUND_SIZE,
+    )
+
+    assert winner == BOSS
 
 
 def test_deciders_are_capped_at_one_round_of_them():
@@ -148,8 +197,7 @@ def test_deciders_are_capped_at_one_round_of_them():
     """
     resolution = _resolve_boss_round_draws(
         drawn_task_ids=["task_a"],
-        drawn_task_types=[TaskType.INSTRUCTTEXTTASK],
-        drawn_continuous_sft_lineages=[None],
+        decider_task_types=[TaskType.INSTRUCTTEXTTASK],
         round_tasks=_round_tasks(TEXT_BOSS_ROUND_SIZE + 1),
         tournament_type=TournamentType.TEXT,
     )
@@ -162,14 +210,95 @@ def test_deciders_are_capped_at_one_round_of_them():
 def test_no_draws_means_nothing_to_do():
     resolution = _resolve_boss_round_draws(
         drawn_task_ids=[],
-        drawn_task_types=[],
-        drawn_continuous_sft_lineages=[],
+        decider_task_types=[],
         round_tasks=_round_tasks(TEXT_BOSS_ROUND_SIZE),
         tournament_type=TournamentType.TEXT,
     )
 
     assert resolution.needs_deciders is False
     assert resolution.drawn_task_ids == []
+
+
+def test_bar_is_clamped_so_it_can_never_be_unreachable():
+    """Two draws outliving the single decider batch left 3 decided against a built size of 5.
+
+    That asked for 4 wins out of 3 - a bar meant to stop draws helping the challenger had turned
+    into draws guaranteeing the boss, the exact inversion this whole rule exists to prevent.
+    Sweeping every task that measured anything is always enough.
+    """
+    winner = determine_boss_round_winner(
+        [CHALLENGER, CHALLENGER, CHALLENGER],
+        BOSS,
+        TournamentType.TEXT,
+        continuous_sft_outcomes=[ContinuousSftLineageOutcome(lineage="qwen", winner_hotkey=CHALLENGER)],
+        expected_task_count=TEXT_BOSS_ROUND_SIZE,
+    )
+    assert winner == CHALLENGER
+
+    # Clamping must not soften the ordinary case: one real loss out of three still fails.
+    lost_one = determine_boss_round_winner(
+        [BOSS, CHALLENGER, CHALLENGER],
+        BOSS,
+        TournamentType.TEXT,
+        continuous_sft_outcomes=[ContinuousSftLineageOutcome(lineage="qwen", winner_hotkey=CHALLENGER)],
+        expected_task_count=TEXT_BOSS_ROUND_SIZE,
+    )
+    assert lost_one == BOSS
+
+
+def test_a_lineage_that_never_decides_blocks_the_dethrone():
+    """A lineage whose task AND decider both drew must not remove itself from its own gate.
+
+    Counting per task and subtracting the drawn ones took the total to zero, which switched the
+    strictest rule in the tournament off exactly when it had the least evidence - the challenger was
+    crowned having won no continuous-SFT task at all. Counted per lineage, an undecided lineage is a
+    None entry that fails the "won every lineage" check.
+    """
+    winner = determine_boss_round_winner(
+        [CHALLENGER, CHALLENGER, CHALLENGER, CHALLENGER],
+        BOSS,
+        TournamentType.TEXT,
+        continuous_sft_outcomes=[ContinuousSftLineageOutcome(lineage="qwen")],  # no result at all
+        expected_task_count=TEXT_BOSS_ROUND_SIZE,
+    )
+
+    assert winner == BOSS
+
+
+def test_a_decider_settles_the_lineage_its_predecessor_drew():
+    """The flip side: winning the lineage's decider does satisfy the gate."""
+    winner = determine_boss_round_winner(
+        [CHALLENGER, CHALLENGER, CHALLENGER, CHALLENGER, CHALLENGER],
+        BOSS,
+        TournamentType.TEXT,
+        continuous_sft_outcomes=[ContinuousSftLineageOutcome(lineage="qwen", winner_hotkey=CHALLENGER)],
+        expected_task_count=TEXT_BOSS_ROUND_SIZE,
+    )
+
+    assert winner == CHALLENGER
+
+
+def test_draw_resolution_rejects_unknown_fields():
+    """A mistyped field name silently dropped the decider types and stayed inert only by luck."""
+    with pytest.raises(ValidationError):
+        BossRoundDrawResolution(drawn_task_ids=["a"], drawn_task_types=[TaskType.DPOTASK])
+
+
+def test_capped_resolution_still_reports_what_drew():
+    """The capped path must carry its decider types, not silently blank them.
+
+    It was passing them under the wrong keyword, which pydantic dropped - inert only because the
+    capped path short-circuits before anything reads the field.
+    """
+    resolution = _resolve_boss_round_draws(
+        drawn_task_ids=["task_a"],
+        decider_task_types=[TaskType.INSTRUCTTEXTTASK],
+        round_tasks=_round_tasks(TEXT_BOSS_ROUND_SIZE + 1),
+        tournament_type=TournamentType.TEXT,
+    )
+
+    assert resolution.can_add_deciders is False
+    assert resolution.decider_task_types == [TaskType.INSTRUCTTEXTTASK]
 
 
 @pytest.mark.parametrize(
@@ -192,3 +321,41 @@ def test_only_text_task_types_can_draw():
         TaskType.DPOTASK,
         TaskType.CHATTASK,
     }
+
+
+@pytest.mark.asyncio
+async def test_orphaned_task_defers_the_round_instead_of_scoring_it(monkeypatch):
+    """A boss-round task with no assigned nodes never ran, so it must not be scored against anyone.
+
+    One gets here when a decider is created but the round never makes it back to PENDING - a crash,
+    or a failure partway through creating a batch. The old path fell through to "no valid results ->
+    winner is base contestant", charging the challenger a loss on a task that never happened, while
+    the decider cap (round now holds more tasks than its built size) blocked any repair. Deferring
+    sends the round back for node assignment instead.
+    """
+    round_tasks = _round_tasks(TEXT_BOSS_ROUND_SIZE + 1)
+    orphan_id = round_tasks[-1].task_id
+
+    async def fake_get_tournament(_tournament_id, _psql_db):
+        return TournamentData(tournament_id="tourn_1", tournament_type=TournamentType.TEXT)
+
+    async def fake_get_nodes_assigned_to_task(task_id, _psql_db):
+        return [] if task_id == orphan_id else ["node_boss", "node_challenger"]
+
+    monkeypatch.setattr(round_results, "get_tournament", fake_get_tournament)
+    monkeypatch.setattr(round_results, "get_nodes_assigned_to_task", fake_get_nodes_assigned_to_task)
+
+    completed_round = TournamentRoundData(
+        round_id="tourn_1_round_004",
+        tournament_id="tourn_1",
+        round_number=4,
+        round_type=RoundType.KNOCKOUT,
+        is_final_round=True,
+        status=RoundStatus.PENDING,
+    )
+
+    outcome = await round_results.get_knockout_winners(completed_round, round_tasks, psql_db=None, config=None)
+
+    assert outcome.is_deferred is True
+    assert outcome.unassigned_task_ids == [orphan_id]
+    assert outcome.winners == []

--- a/tests/validator/tournament/test_boss_round_task_resolution.py
+++ b/tests/validator/tournament/test_boss_round_task_resolution.py
@@ -31,7 +31,7 @@ def stub_vectors(monkeypatch):
 
 
 async def _resolve(task_type: TaskType, boss_loss: float, challenger_loss: float) -> str:
-    winner, _basis = await round_results._resolve_boss_round_task_winner(
+    verdict = await round_results._resolve_boss_round_task_winner(
         task_id=TASK_ID,
         task_object=StubTask(task_type=task_type),
         boss_hotkey=BOSS,
@@ -41,7 +41,7 @@ async def _resolve(task_type: TaskType, boss_loss: float, challenger_loss: float
         threshold_percentage=0.01,
         psql_db=None,
     )
-    return winner
+    return verdict.winner_hotkey
 
 
 def _paired(gap: float, n: int = 1000, seed: int = 0, noise: float = 0.0):
@@ -144,12 +144,16 @@ async def test_continuous_sft_chat_tasks_use_the_paired_gate(stub_vectors):
 
 @pytest.mark.asyncio
 async def test_all_in_dead_zone_is_reported_as_a_draw(stub_vectors):
-    """The defender holds the task, but the recorded basis says draw rather than claiming a win."""
+    """The defender holds the score row, but the verdict is flagged a draw rather than a win.
+
+    is_draw is what takes the task out of the dethrone tally and earns the round a decider, so it
+    has to be set structurally - not just mentioned in the reason text.
+    """
     boss = np.random.default_rng(30).uniform(0.02, 0.03, 1000)
     challenger = boss - 0.002  # every gap inside the dead zone
     stub_vectors({BOSS: (list(boss), "fp"), CHALLENGER: (list(challenger), "fp")})
 
-    winner, basis = await round_results._resolve_boss_round_task_winner(
+    verdict = await round_results._resolve_boss_round_task_winner(
         task_id=TASK_ID,
         task_object=StubTask(task_type=TaskType.DPOTASK),
         boss_hotkey=BOSS,
@@ -160,5 +164,6 @@ async def test_all_in_dead_zone_is_reported_as_a_draw(stub_vectors):
         psql_db=None,
     )
 
-    assert winner == BOSS
-    assert "draw" in basis.lower()
+    assert verdict.winner_hotkey == BOSS
+    assert verdict.is_draw is True
+    assert "draw" in verdict.decided_by.lower()

--- a/tests/validator/tournament/test_oversampled_later_models.py
+++ b/tests/validator/tournament/test_oversampled_later_models.py
@@ -1,0 +1,226 @@
+"""Text tournaments oversample the 2026+ model pool into two guaranteed slots.
+
+Round 1: exactly one task across all groups plays on a model from OVERSAMPLED_LATER_MODELS,
+whatever the group count is. Boss round: the first of the two instruct tasks does.
+
+Both slots are drawn from a round_id-seeded rng, so a partially created round that gets retried
+resumes onto the same slot and the same model rather than minting a second oversampled task.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+import pytest
+
+from core.models.task_models import TaskType
+from core.oversampled_later_models import OVERSAMPLED_LATER_MODELS
+from core.oversampled_later_models import sample_oversampled_later_model
+from validator.tournament import constants as t_cst
+from validator.tournament import task_creator
+from validator.tournament.models import Group
+from validator.tournament.models import GroupRound
+
+
+POOL_IDS = {m.model_id for m in OVERSAMPLED_LATER_MODELS}
+
+
+def _group_round(num_groups: int, members_per_group: int = 12, round_number: int = 1) -> GroupRound:
+    return GroupRound(
+        round_id="tourn_round_001",
+        round_number=round_number,
+        groups=[
+            Group(member_ids=[f"miner-{g}-{m}" for m in range(members_per_group)])
+            for g in range(num_groups)
+        ],
+    )
+
+
+def _patch_seams(monkeypatch, existing: list | None = None) -> AsyncMock:
+    """Stub pool generators, DB lookups and registration; return the instruct-creation mock."""
+    for name in ("_get_text_models", "_get_instruct_text_datasets", "_get_dpo_datasets"):
+        monkeypatch.setattr(task_creator, name, lambda *a, **k: MagicMock())
+    monkeypatch.setattr(
+        task_creator, "_get_existing_tasks_by_identifier", AsyncMock(return_value=existing or [])
+    )
+    monkeypatch.setattr(task_creator, "_get_existing_tasks", AsyncMock(return_value=[]))
+    monkeypatch.setattr(task_creator, "_create_and_register_tournament_task", AsyncMock())
+
+    instruct_mock = AsyncMock(
+        return_value=SimpleNamespace(task_id="task", task_type=TaskType.INSTRUCTTEXTTASK)
+    )
+    monkeypatch.setattr(task_creator, "create_synthetic_instruct_text_task", instruct_mock)
+    return instruct_mock
+
+
+def _overrides(instruct_mock: AsyncMock) -> list[str | None]:
+    return [call.kwargs.get("model_id_override") for call in instruct_mock.call_args_list]
+
+
+@pytest.mark.parametrize("num_groups", [2, 3, 8])
+async def test_round_one_gives_exactly_one_task_an_oversampled_model(monkeypatch, num_groups):
+    instruct_mock = _patch_seams(monkeypatch)
+
+    await task_creator._create_group_text_tasks(
+        _group_round(num_groups), "tourn", MagicMock(), is_final_round=False
+    )
+
+    overrides = _overrides(instruct_mock)
+    assert len(overrides) == num_groups * t_cst.TEXT_TASKS_PER_GROUP
+    picked = [o for o in overrides if o is not None]
+    assert len(picked) == 1
+    assert picked[0] in POOL_IDS
+
+
+async def test_small_tournament_round_one_still_gets_exactly_one(monkeypatch):
+    """A single group in the small band plays SMALL_TOURNAMENT_GROUP_TASKS matches — still one
+    oversampled task in total, not one per match."""
+    instruct_mock = _patch_seams(monkeypatch)
+
+    await task_creator._create_group_text_tasks(
+        _group_round(1, members_per_group=8), "tourn", MagicMock(), is_final_round=False
+    )
+
+    overrides = _overrides(instruct_mock)
+    assert len(overrides) == t_cst.SMALL_TOURNAMENT_GROUP_TASKS
+    picked = [o for o in overrides if o is not None]
+    assert len(picked) == 1
+    assert picked[0] in POOL_IDS
+
+
+async def test_round_one_skips_when_the_round_already_has_a_pool_model_task(monkeypatch):
+    """Whatever mints an extra task mid-round, R1 never hands out a second oversampled slot."""
+    instruct_mock = _patch_seams(monkeypatch)
+    monkeypatch.setattr(
+        task_creator, "_round_already_has_oversampled_task", AsyncMock(return_value=True)
+    )
+
+    await task_creator._create_group_text_tasks(_group_round(3), "tourn", MagicMock(), is_final_round=False)
+
+    assert _overrides(instruct_mock) == [None, None, None]
+
+
+async def test_later_group_rounds_do_not_oversample(monkeypatch):
+    instruct_mock = _patch_seams(monkeypatch)
+
+    await task_creator._create_group_text_tasks(
+        _group_round(3, round_number=2), "tourn", MagicMock(), is_final_round=False
+    )
+
+    assert _overrides(instruct_mock) == [None, None, None]
+
+
+async def test_round_one_pick_is_stable_across_retries(monkeypatch):
+    """A round re-created from scratch lands on the same slot and the same model."""
+    first = _patch_seams(monkeypatch)
+    await task_creator._create_group_text_tasks(_group_round(5), "tourn", MagicMock(), is_final_round=False)
+    second = _patch_seams(monkeypatch)
+    await task_creator._create_group_text_tasks(_group_round(5), "tourn", MagicMock(), is_final_round=False)
+
+    assert _overrides(first) == _overrides(second)
+
+
+def _patch_boss_seams(monkeypatch) -> AsyncMock:
+    monkeypatch.setattr(task_creator, "_get_existing_tasks_by_identifier", AsyncMock(return_value=[]))
+    for name in ("_get_text_models", "_get_instruct_text_datasets", "_get_dpo_datasets"):
+        monkeypatch.setattr(task_creator, name, lambda *a, **k: MagicMock())
+    monkeypatch.setattr(task_creator, "warn_orphaned_continuous_sft_state", AsyncMock())
+    monkeypatch.setattr(task_creator, "_create_continuous_sft_boss_task", AsyncMock(return_value=MagicMock()))
+    created = AsyncMock(side_effect=lambda task_type, *a, **k: SimpleNamespace(task_id="t", task_type=task_type))
+    monkeypatch.setattr(task_creator, "_create_single_new_text_task", created)
+    return created
+
+
+async def test_boss_round_gives_exactly_one_task_an_oversampled_model(monkeypatch):
+    created = _patch_boss_seams(monkeypatch)
+
+    await task_creator._create_new_text_boss_round_tasks("tourn", "tourn_round_009", MagicMock())
+
+    overrides = [c.kwargs.get("model_id_override") for c in created.call_args_list]
+    assert len(overrides) == sum(t_cst.FINAL_ROUND_TEXT_TASK_DISTRIBUTION.values())
+    picked = [o for o in overrides if o is not None]
+    assert len(picked) == 1
+    assert picked[0] in POOL_IDS
+
+
+async def test_boss_round_oversampled_slot_is_not_always_instruct(monkeypatch):
+    """The slot is drawn over instruct/dpo/grpo, not pinned to instruct."""
+    seen: set[TaskType] = set()
+    for round_number in range(40):
+        created = _patch_boss_seams(monkeypatch)
+        await task_creator._create_new_text_boss_round_tasks(
+            "tourn", f"tourn_round_{round_number:03d}", MagicMock()
+        )
+        seen.update(
+            call.args[0] for call in created.call_args_list if call.kwargs.get("model_id_override")
+        )
+
+    assert seen == set(t_cst.FINAL_ROUND_TEXT_TASK_DISTRIBUTION)
+
+
+@pytest.mark.parametrize(
+    "existing_model_id, expected_picks",
+    [
+        (next(iter(POOL_IDS)), 0),  # the oversampled task already exists -> don't mint a second
+        ("Qwen/Qwen2.5-7B-Instruct", 1),  # a normal draw exists -> the round still owes one
+    ],
+)
+async def test_boss_round_resume_keeps_exactly_one_oversampled_task(
+    monkeypatch, existing_model_id, expected_picks
+):
+    """A partially created round is completed by looking at what it already plays, not at how many
+    tasks have been created."""
+    existing = [SimpleNamespace(task_id="existing")]
+    monkeypatch.setattr(task_creator, "_get_existing_tasks_by_identifier", AsyncMock(return_value=existing))
+    monkeypatch.setattr(
+        task_creator.task_sql,
+        "get_task",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                task_id="existing", task_type=TaskType.INSTRUCTTEXTTASK, ds="ds", model_id=existing_model_id
+            )
+        ),
+    )
+    monkeypatch.setattr(t_cst, "is_continuous_sft_task", lambda task: False)
+    for name in ("_get_text_models", "_get_instruct_text_datasets", "_get_dpo_datasets"):
+        monkeypatch.setattr(task_creator, name, lambda *a, **k: MagicMock())
+    monkeypatch.setattr(task_creator, "warn_orphaned_continuous_sft_state", AsyncMock())
+    monkeypatch.setattr(task_creator, "_create_continuous_sft_boss_task", AsyncMock(return_value=MagicMock()))
+    created = AsyncMock(side_effect=lambda task_type, *a, **k: SimpleNamespace(task_id="t", task_type=task_type))
+    monkeypatch.setattr(task_creator, "_create_single_new_text_task", created)
+
+    await task_creator._create_new_text_boss_round_tasks("tourn", "tourn_round_009", MagicMock())
+
+    instruct_calls = [c for c in created.call_args_list if c.args[0] == TaskType.INSTRUCTTEXTTASK]
+    assert len(instruct_calls) == 1  # the round had one already
+    picks = [c for c in created.call_args_list if c.kwargs.get("model_id_override") in POOL_IDS]
+    assert len(picks) == expected_picks
+
+
+async def test_draw_deciders_never_get_an_oversampled_model(monkeypatch):
+    """A decider restores a decided result on the drawn task's type — it is not a second chance to
+    put the boss round on a pool model, however many tasks draw."""
+    for name in ("_get_text_models", "_get_instruct_text_datasets", "_get_dpo_datasets"):
+        monkeypatch.setattr(task_creator, name, lambda *a, **k: MagicMock())
+    created = AsyncMock(side_effect=lambda task_type, *a, **k: SimpleNamespace(task_id="t", task_type=task_type))
+    monkeypatch.setattr(task_creator, "_create_single_new_text_task", created)
+
+    await task_creator.create_boss_round_decider_tasks(
+        "tourn",
+        "tourn_round_009",
+        MagicMock(),
+        [TaskType.INSTRUCTTEXTTASK, TaskType.INSTRUCTTEXTTASK, TaskType.DPOTASK],
+    )
+
+    assert [c.kwargs.get("model_id_override") for c in created.call_args_list] == [None, None, None]
+
+
+def test_pool_is_sampled_uniformly_and_is_seedable():
+    import random
+
+    seeded = random.Random("tourn_round_001:oversampled_model")
+    assert sample_oversampled_later_model(seeded) == sample_oversampled_later_model(
+        random.Random("tourn_round_001:oversampled_model")
+    )
+    drawn = {sample_oversampled_later_model(random.Random(i)) for i in range(500)}
+    assert drawn == POOL_IDS

--- a/validator/db/sql/tasks.py
+++ b/validator/db/sql/tasks.py
@@ -347,6 +347,28 @@ async def get_nodes_assigned_to_task(task_id: str, psql_db: PSQLDB) -> list[Node
         return [Node(**{k: v for k, v in dict(row).items() if k != cst.TRUST}) for row in rows]
 
 
+async def count_hotkeys_assigned_to_task(task_id: str, psql_db: PSQLDB) -> int:
+    """How many hotkeys are assigned to a task, read from task_nodes alone.
+
+    Deliberately does not join nodes, unlike get_nodes_assigned_to_task: migrate_nodes_to_history
+    DELETEs every row for the netuid on each metagraph refresh and reinserts only currently
+    registered ones, so a competitor that deregisters mid-tournament loses its nodes row for good
+    and the joined query then reports its tasks as never assigned. Callers asking "did this task
+    ever get participants" need the assignment record, which survives, not the node's current
+    registration, which does not.
+    """
+    async with await psql_db.connection() as connection:
+        connection: Connection
+        return await connection.fetchval(
+            f"""
+            SELECT COUNT(*) FROM {cst.TASK_NODES_TABLE}
+            WHERE {cst.TASK_ID} = $1 AND {cst.NETUID} = $2
+            """,
+            task_id,
+            NETUID,
+        )
+
+
 async def get_tasks_with_status(
     status: TaskStatus,
     psql_db: PSQLDB,

--- a/validator/db/sql/tournaments.py
+++ b/validator/db/sql/tournaments.py
@@ -421,6 +421,7 @@ async def get_tournament_tasks(round_id: str, psql_db: PSQLDB) -> list[Tournamen
             SELECT {cst.TOURNAMENT_ID}, {cst.ROUND_ID}, {cst.TASK_ID}, {cst.GROUP_ID}, {cst.PAIR_ID}
             FROM {cst.TOURNAMENT_TASKS_TABLE}
             WHERE {cst.ROUND_ID} = $1
+            ORDER BY {cst.CREATED_AT}, {cst.TASK_ID}
         """
         results = await connection.fetch(query, round_id)
         return [

--- a/validator/tasks/synthetics/scheduler.py
+++ b/validator/tasks/synthetics/scheduler.py
@@ -416,11 +416,17 @@ async def get_dataset(
 @retry_with_backoff
 async def create_synthetic_dpo_task(
     config: Config,
-    models: AsyncGenerator[str, None],
+    models: AsyncGenerator[str, None] | None,
     datasets: AsyncGenerator[Dataset, None],
+    model_id_override: str | None = None,
 ) -> RawTask:
+    """models may be None only with model_id_override set (the pool is never drawn from then)."""
     logger.info("DPO task")
-    model_id = await anext(models)
+    if model_id_override:
+        model_id = model_id_override
+    else:
+        assert models is not None, "a models pool is required when model_id_override is not set"
+        model_id = await anext(models)
     logger.info(f"We picked {model_id}")
 
     dataset = await get_dataset(datasets, task_type=TaskType.DPOTASK, keypair=config.keypair, psql_db=config.psql_db)
@@ -498,10 +504,16 @@ def _randomize_reward_weights(reward_functions: list[RewardFunction]) -> list[Re
 @retry_with_backoff
 async def create_synthetic_grpo_task(
     config: Config,
-    models: AsyncGenerator[str, None],
+    models: AsyncGenerator[str, None] | None,
     datasets: AsyncGenerator[Dataset, None],
+    model_id_override: str | None = None,
 ) -> RawTask:
-    model_id = await anext(models)
+    """models may be None only with model_id_override set (the pool is never drawn from then)."""
+    if model_id_override:
+        model_id = model_id_override
+    else:
+        assert models is not None, "a models pool is required when model_id_override is not set"
+        model_id = await anext(models)
 
     dataset = await get_dataset(
         datasets,

--- a/validator/tournament/constants.py
+++ b/validator/tournament/constants.py
@@ -4,6 +4,7 @@ from core.constants.environments import EnvironmentName
 from core.constants.environments import TrainingStartPoint
 from core.models.image_models import ImageModelType
 from core.models.task_models import TaskType
+from core.models.tournament_models import TournamentType
 
 
 TOURNAMENT_INTERVAL_HOURS = 120
@@ -304,6 +305,21 @@ BOSS_ROUND_BOOTSTRAP_SEED = 20260808
 # evaluator - and they carry the "challenger must win EVERY continuous-SFT task" dethrone gate, so
 # leaving them on the relative margin would leave the strictest rule resting on the weakest test.
 PAIRED_BOSS_ROUND_TASK_TYPES = (TaskType.INSTRUCTTEXTTASK, TaskType.DPOTASK, TaskType.CHATTASK)
+
+def expected_boss_round_task_count(tournament_type: TournamentType) -> int:
+    """How many tasks a boss round is built with, for the types that can draw. 0 for the rest.
+
+    Only text qualifies: PAIRED_BOSS_ROUND_TASK_TYPES is text-only, so image and environment boss
+    rounds are decided on the relative margin, which has no draw. They return 0 and every
+    draw-related rule keyed off this value stays switched off for them - in particular the dethrone
+    bar keeps deriving from their own resolved task count, unchanged by any of this.
+
+    Two uses, both needing the round's *built* size rather than its current one: capping deciders
+    (a round holding more tasks than this has already had them, and prep-failure replacement swaps
+    tasks without changing the count), and pinning the dethrone bar so a drawn task cannot lower it.
+    """
+    return FINAL_ROUND_TEXT_TASKS if tournament_type == TournamentType.TEXT else 0
+
 
 # Obfuscation detection constants
 OBFUSCATION_DETECTION_PATH = "./validator/tournament/obfuscation_detection/anti_obfuscation"

--- a/validator/tournament/models.py
+++ b/validator/tournament/models.py
@@ -405,10 +405,38 @@ class BossRoundTaskVerdict(BaseModel):
     somebody to hold the task.
     """
 
+    # A mistyped field name on this model silently dropped a value that only stayed harmless because
+    # the one consumer short-circuited before reading it. These carry crowning decisions; a typo
+    # should fail loudly at construction.
+    model_config = ConfigDict(extra="forbid")
+
     winner_hotkey: str
     # What decided it, for the persisted score_reason. None when the relative margin decided it.
     decided_by: str | None = None
     is_draw: bool = False
+
+
+class ContinuousSftLineageOutcome(BaseModel):
+    """How one continuous-SFT lineage went in a boss round, for the dethrone gate.
+
+    The gate asks the challenger to win every lineage, with one deliberate exception: a draw counts
+    as satisfying it. Nothing separated the two models on that task, which is not the challenger
+    failing to beat the boss - it is the task failing to tell them apart, and the challenger should
+    not lose the crown to it. A loss is different: the boss demonstrably held that lineage.
+
+    ``is_draw`` and a ``winner_hotkey`` of None are also different. A draw means both sides were
+    scored and came out level; None means the task produced no comparison at all (failed, skipped,
+    unpairable vectors), which is absence of evidence and keeps blocking as it always has.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    lineage: str
+    winner_hotkey: str | None = None
+    is_draw: bool = False
+
+    def satisfied_by(self, challenger_hotkey: str | None) -> bool:
+        return self.is_draw or (challenger_hotkey is not None and self.winner_hotkey == challenger_hotkey)
 
 
 class BossRoundDrawResolution(BaseModel):
@@ -422,12 +450,15 @@ class BossRoundDrawResolution(BaseModel):
     round still resolves on the full number of decided results.
     """
 
+    model_config = ConfigDict(extra="forbid")
+
     drawn_task_ids: list[str] = Field(default_factory=list)
-    # Task types to add, one per drawn task, mirroring what drew. Continuous-SFT draws mirror as
-    # continuous-SFT (keyed by lineage in continuous_sft_lineages) because the dethrone rule
-    # requires the challenger to *win* every continuous-SFT task - a draw cannot satisfy it.
+    # Task types to add, one per drawn task, mirroring what drew - except continuous-SFT, which is
+    # stood in for by a plain instruct task on a fresh dataset pull. A drawn lineage has already
+    # cleared its own dethrone gate (a draw satisfies it), so its decider exists only to top the
+    # tally back up; adding a second continuous-SFT task on that lineage would instead put two
+    # tasks on one sequential train_index and leave the chain's carry-forward ambiguous.
     decider_task_types: list[TaskType] = Field(default_factory=list)
-    continuous_sft_lineages: list[str | None] = Field(default_factory=list)
     # False once deciders have already been added for this round, which caps them at one per drawn
     # task. A decider that itself draws is simply excluded and the round resolves on what is left.
     can_add_deciders: bool = True
@@ -441,14 +472,22 @@ class BossRoundDrawResolution(BaseModel):
 class RoundOutcome(BaseModel):
     """Result of resolving a completed round.
 
-    ``deferred_reason`` is set when the round cannot be resolved yet because tasks were added to it
-    (a boss-round draw decider). The caller must not advance on a deferred outcome: ``winners`` is
-    empty then, and an empty winner list otherwise means the boss retained by default.
+    ``deferred_reason`` is set when the round cannot be resolved yet, either because tasks are about
+    to be added to it (a boss-round draw decider) or because tasks are already on it that never got
+    nodes. The caller must not advance on a deferred outcome: ``winners`` is empty then, and an empty
+    winner list otherwise means the boss retained by default.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     winners: list[str] = Field(default_factory=list)
     deferred_reason: str | None = None
     draw_resolution: BossRoundDrawResolution | None = None
+    # Round tasks with no assigned nodes, so they cannot have run. Resolving around them would score
+    # a task that never happened against whoever the tally charges it to; the round goes back to
+    # PENDING instead so node assignment picks them up. Populated when a decider was created but the
+    # round never made it back to PENDING - a crash, or a failure partway through creating a batch.
+    unassigned_task_ids: list[str] = Field(default_factory=list)
 
     @property
     def is_deferred(self) -> bool:

--- a/validator/tournament/models.py
+++ b/validator/tournament/models.py
@@ -396,6 +396,65 @@ class PairedLossComparison(BaseModel):
     required_mean_gap_nats: float
 
 
+class BossRoundTaskVerdict(BaseModel):
+    """How one boss-round task resolved.
+
+    ``is_draw`` is carried separately from ``winner_hotkey`` because a draw is not a result: nothing
+    separated the two models, so the task tells the dethrone tally nothing and is excluded from it.
+    ``winner_hotkey`` still names the defender on a draw, since the persisted score row needs
+    somebody to hold the task.
+    """
+
+    winner_hotkey: str
+    # What decided it, for the persisted score_reason. None when the relative margin decided it.
+    decided_by: str | None = None
+    is_draw: bool = False
+
+
+class BossRoundDrawResolution(BaseModel):
+    """What the draws in a completed boss round mean for advancing it.
+
+    A boss-round task draws when every held-out example landed inside the tie dead zone (see
+    compare_paired_losses), which happens when the randomly drawn dataset simply does not
+    discriminate between the two models. That is a property of the task, not of the challenger, so
+    it must not consume the one task the challenger is allowed to drop. Instead each drawn task is
+    excluded from the tally and one additional task is added to the round to take its place, so the
+    round still resolves on the full number of decided results.
+    """
+
+    drawn_task_ids: list[str] = Field(default_factory=list)
+    # Task types to add, one per drawn task, mirroring what drew. Continuous-SFT draws mirror as
+    # continuous-SFT (keyed by lineage in continuous_sft_lineages) because the dethrone rule
+    # requires the challenger to *win* every continuous-SFT task - a draw cannot satisfy it.
+    decider_task_types: list[TaskType] = Field(default_factory=list)
+    continuous_sft_lineages: list[str | None] = Field(default_factory=list)
+    # False once deciders have already been added for this round, which caps them at one per drawn
+    # task. A decider that itself draws is simply excluded and the round resolves on what is left.
+    can_add_deciders: bool = True
+    reason: str = ""
+
+    @property
+    def needs_deciders(self) -> bool:
+        return bool(self.drawn_task_ids) and self.can_add_deciders
+
+
+class RoundOutcome(BaseModel):
+    """Result of resolving a completed round.
+
+    ``deferred_reason`` is set when the round cannot be resolved yet because tasks were added to it
+    (a boss-round draw decider). The caller must not advance on a deferred outcome: ``winners`` is
+    empty then, and an empty winner list otherwise means the boss retained by default.
+    """
+
+    winners: list[str] = Field(default_factory=list)
+    deferred_reason: str | None = None
+    draw_resolution: BossRoundDrawResolution | None = None
+
+    @property
+    def is_deferred(self) -> bool:
+        return self.deferred_reason is not None
+
+
 class TaskPerformanceDifference(BaseModel):
     """Performance difference data for a single task"""
 

--- a/validator/tournament/round_results.py
+++ b/validator/tournament/round_results.py
@@ -10,7 +10,7 @@ from validator.db.database import PSQLDB
 from validator.db.sql.submissions_and_scoring import get_eligible_hotkeys_for_task
 from validator.db.sql.submissions_and_scoring import get_per_example_losses
 from validator.db.sql.submissions_and_scoring import get_task_winner
-from validator.db.sql.tasks import get_nodes_assigned_to_task
+from validator.db.sql.tasks import count_hotkeys_assigned_to_task
 from validator.db.sql.tasks import get_task
 from validator.db.sql.tournaments import get_tournament
 from validator.db.sql.tournaments import get_tournament_group_members
@@ -619,6 +619,13 @@ async def get_knockout_winners(
             outcome = _lineage_outcome(task_obj)
             if outcome is not None:
                 outcome.is_draw = True
+            # Branch on what the task IS, not on whether its lineage parsed. _lineage_outcome
+            # returns None for both "not continuous-SFT" and "continuous-SFT whose lineage is no
+            # longer recognised" - a state warn_orphaned_continuous_sft_state exists to flag, and
+            # one an edit to CONTINUOUS_SFT_LINEAGES between rounds produces. Treating the second as
+            # the first queues a CHATTASK decider, which has no creation route, so the round retries
+            # a task it can never build every 60 seconds forever.
+            if _is_continuous_sft(task_obj):
                 decider_task_types.append(TaskType.INSTRUCTTEXTTASK)
             else:
                 decider_task_types.append(task_obj.task_type)
@@ -638,8 +645,15 @@ async def get_knockout_winners(
         # only way one gets here is a decider that was created but never made it back to PENDING for
         # node assignment (a crash, or a failure partway through creating a batch). Defer instead and
         # let the caller return the round to PENDING, which is what assigns them.
+        #
+        # Counted from task_nodes rather than get_nodes_assigned_to_task, which joins nodes: that
+        # table is emptied and rebuilt for the netuid on every metagraph refresh, so a competitor
+        # deregistering mid-tournament would make its tasks read as never assigned. This check would
+        # then send the round back to PENDING, where assignment cannot find the missing node either,
+        # and the round would stall for good - turning a guard against mis-scoring one task into a
+        # wedge on the whole tournament.
         unassigned_task_ids = [
-            task.task_id for task in round_tasks if not await get_nodes_assigned_to_task(task.task_id, psql_db)
+            task.task_id for task in round_tasks if not await count_hotkeys_assigned_to_task(task.task_id, psql_db)
         ]
         if unassigned_task_ids:
             reason = (

--- a/validator/tournament/round_results.py
+++ b/validator/tournament/round_results.py
@@ -587,7 +587,11 @@ async def get_knockout_winners(
             return task_obj is not None and t_cst.is_continuous_sft_task(task_obj)
 
         def _lineage_outcome(task_obj) -> ContinuousSftLineageOutcome | None:
-            """Register this lineage as present in the round, defaulting it to no result."""
+            """Register this lineage as present in the round, defaulting it to no result.
+
+            Idempotent, so it is safe to call unconditionally per task and again when the task is
+            awarded or recorded as a draw.
+            """
             if not _is_continuous_sft(task_obj):
                 return None
             lineage = t_cst.continuous_sft_lineage_from_ds(task_obj.ds)
@@ -650,6 +654,14 @@ async def get_knockout_winners(
             logger.info(f"Processing boss round task {task.task_id}")
 
             task_object = await get_task(task.task_id, psql_db)
+
+            # Register the lineage before anything can skip the task. Several branches below bail
+            # out with a bare `continue` - notably "both evaluation failed" - and if registration
+            # rode on the award path those would leave the lineage out of continuous_sft_outcomes
+            # entirely, taking the gate's count to zero and switching the strictest rule in the
+            # tournament off. A lineage is in its own gate the moment its task exists; all that
+            # varies afterwards is whether it ends up satisfied.
+            _lineage_outcome(task_object)
 
             miner_results = await get_task_results_for_ranking(task.task_id, psql_db)
             if not miner_results:

--- a/validator/tournament/round_results.py
+++ b/validator/tournament/round_results.py
@@ -10,6 +10,7 @@ from validator.db.database import PSQLDB
 from validator.db.sql.submissions_and_scoring import get_eligible_hotkeys_for_task
 from validator.db.sql.submissions_and_scoring import get_per_example_losses
 from validator.db.sql.submissions_and_scoring import get_task_winner
+from validator.db.sql.tasks import get_nodes_assigned_to_task
 from validator.db.sql.tasks import get_task
 from validator.db.sql.tournaments import get_tournament
 from validator.db.sql.tournaments import get_tournament_group_members
@@ -22,6 +23,7 @@ from validator.scoring.tasks import calculate_miner_ranking_and_scores
 from validator.tournament import constants as t_cst
 from validator.tournament.models import BossRoundDrawResolution
 from validator.tournament.models import BossRoundTaskVerdict
+from validator.tournament.models import ContinuousSftLineageOutcome
 from validator.tournament.models import EmptyScoreGroup
 from validator.tournament.models import GroupMatchStanding
 from validator.tournament.models import MatchRanking
@@ -310,8 +312,7 @@ def determine_boss_round_winner(
     task_winners: list[str],
     boss_hotkey: str,
     tournament_type: TournamentType,
-    continuous_sft_winners: list[str] | None = None,
-    num_continuous_sft_tasks: int = 0,
+    continuous_sft_outcomes: list[ContinuousSftLineageOutcome] | None = None,
     expected_task_count: int | None = None,
 ) -> str:
     """
@@ -322,10 +323,11 @@ def determine_boss_round_winner(
             here - nothing separated the two models on them, so they carry no result.
         boss_hotkey: The defending champion's hotkey
         tournament_type: Type of tournament (TEXT or IMAGE)
-        continuous_sft_winners: Hotkeys that won each *decided* continuous-SFT task.
-        num_continuous_sft_tasks: Decided continuous-SFT tasks. When >0 (text boss round), the
-            challenger must win EVERY one to dethrone, on top of the overall threshold — so a
-            failed/skipped continuous-SFT task blocks the dethrone. 0 (image) leaves the rule off.
+        continuous_sft_outcomes: How each continuous-SFT lineage in the round went. When non-empty
+            (text boss round) the challenger must satisfy EVERY one to dethrone, on top of the
+            overall threshold. Satisfied means won it *or* drew it — a draw is the task failing to
+            separate the two models rather than the challenger failing to beat the boss, and should
+            not cost the crown. A loss, or no result at all, blocks. Empty (image) leaves it off.
         expected_task_count: The size the boss round was built to. Sets the bar when draws left
             fewer decided tasks than that, so an undecidable task never *lowers* what it takes to
             dethrone — a challenger with two dead tasks must sweep the four that worked rather than
@@ -356,15 +358,35 @@ def determine_boss_round_winner(
     # requires beating the boss by BOSS_ROUND_WIN_MARGIN. Measured against the round's built size
     # rather than the decided count so draws cannot slide the bar downward - they take a task out of
     # the numerator, and the challenger has to make it up on the ones that did decide.
-    required_wins = max(1, max(total_tasks, expected_task_count or 0) - 1)
+    #
+    # Clamped to the decided count, because the built size can exceed it once draws outlive their
+    # single decider batch: 3 decided against a built size of 5 asked for 4 wins out of 3, which no
+    # challenger could ever satisfy - a bar meant to stop draws helping the challenger had turned
+    # into draws guaranteeing the boss. Sweeping every task that measured anything is always enough.
+    unclamped_required = max(1, max(total_tasks, expected_task_count or 0) - 1)
+    required_wins = min(unclamped_required, total_tasks)
+    if unclamped_required > total_tasks:
+        logger.warning(
+            f"Boss round has only {total_tasks} decided task(s) against a built size of "
+            f"{expected_task_count}; requiring a sweep of all {total_tasks} rather than an "
+            f"unreachable {unclamped_required}. This round measured very little - worth a look at "
+            f"whether the tie dead zone is too wide for the datasets being drawn."
+        )
 
-    # Continuous-SFT gate: challenger must win EVERY continuous-SFT task; only enforced when >0.
-    challenger_continuous_wins = (
-        (continuous_sft_winners or []).count(opponent_hotkey) if opponent_hotkey else 0
-    )
-    continuous_sft_ok = True
-    if num_continuous_sft_tasks > 0:
-        continuous_sft_ok = challenger_continuous_wins == num_continuous_sft_tasks
+    # Continuous-SFT gate: challenger must satisfy EVERY lineage; only enforced when there are any.
+    # Held per lineage rather than counted per task so that dropping a drawn lineage can never take
+    # the total to zero and switch the strictest rule in the tournament off - a lineage stays in its
+    # own gate whatever happened to it, and what varies is only whether it is satisfied.
+    outcomes = continuous_sft_outcomes or []
+    num_continuous_sft_tasks = len(outcomes)
+    challenger_continuous_wins = sum(1 for outcome in outcomes if outcome.satisfied_by(opponent_hotkey))
+    continuous_sft_ok = challenger_continuous_wins == num_continuous_sft_tasks
+    for outcome in outcomes:
+        if not outcome.satisfied_by(opponent_hotkey):
+            logger.info(
+                f"Continuous-SFT lineage {outcome.lineage} not satisfied: "
+                f"winner={outcome.winner_hotkey} is_draw={outcome.is_draw}"
+            )
 
     if opponent_hotkey and opponent_wins >= required_wins and continuous_sft_ok:
         logger.info(
@@ -488,8 +510,7 @@ async def _resolve_knockout_task_winner(task: TournamentTask, psql_db: PSQLDB) -
 
 def _resolve_boss_round_draws(
     drawn_task_ids: list[str],
-    drawn_task_types: list[TaskType],
-    drawn_continuous_sft_lineages: list[str | None],
+    decider_task_types: list[TaskType],
     round_tasks: list[TournamentTask],
     tournament_type: TournamentType,
 ) -> BossRoundDrawResolution:
@@ -510,7 +531,7 @@ def _resolve_boss_round_draws(
     if already_added:
         return BossRoundDrawResolution(
             drawn_task_ids=drawn_task_ids,
-            drawn_task_types=drawn_task_types,
+            decider_task_types=decider_task_types,
             can_add_deciders=False,
             reason=(
                 f"{len(drawn_task_ids)} drawn task(s) excluded from the tally; the round already holds "
@@ -521,13 +542,12 @@ def _resolve_boss_round_draws(
 
     return BossRoundDrawResolution(
         drawn_task_ids=drawn_task_ids,
-        decider_task_types=drawn_task_types,
-        continuous_sft_lineages=drawn_continuous_sft_lineages,
+        decider_task_types=decider_task_types,
         can_add_deciders=True,
         reason=(
             f"{len(drawn_task_ids)} boss-round task(s) drew - nothing separated the two models on "
             f"them - so each is excluded from the tally and gets one replacement task: "
-            f"{[t.value for t in drawn_task_types]}"
+            f"{[t.value for t in decider_task_types]}"
         ),
     )
 
@@ -553,42 +573,51 @@ async def get_knockout_winners(
         boss_hotkey = EMISSION_BURN_HOTKEY
         opponent_hotkey = None
         task_winners = []
-        # Decided continuous-SFT winners + total count, fed to determine_boss_round_winner's
-        # "challenger must win ALL continuous-SFT tasks" dethrone gate.
-        continuous_sft_winners: list[str] = []
-        num_continuous_sft_tasks = 0
+        # How each continuous-SFT lineage went, feeding determine_boss_round_winner's dethrone gate.
+        # Keyed by lineage so a lineage can never drop out of its own gate: what varies is whether
+        # it ends up satisfied, not whether it is counted.
+        continuous_sft_outcomes: dict[str, ContinuousSftLineageOutcome] = {}
         # Tasks that separated nothing. Excluded from every tally below and handed to the caller,
         # which adds one replacement task per draw so the round still resolves on a full set of
         # decided results. See BossRoundDrawResolution.
         drawn_task_ids: list[str] = []
-        drawn_task_types: list[TaskType] = []
-        drawn_continuous_sft_lineages: list[str | None] = []
-        drawn_continuous_sft_task_ids: list[str] = []
+        decider_task_types: list[TaskType] = []
 
         def _is_continuous_sft(task_obj) -> bool:
             return task_obj is not None and t_cst.is_continuous_sft_task(task_obj)
 
+        def _lineage_outcome(task_obj) -> ContinuousSftLineageOutcome | None:
+            """Register this lineage as present in the round, defaulting it to no result."""
+            if not _is_continuous_sft(task_obj):
+                return None
+            lineage = t_cst.continuous_sft_lineage_from_ds(task_obj.ds)
+            if lineage is None:
+                return None
+            return continuous_sft_outcomes.setdefault(lineage, ContinuousSftLineageOutcome(lineage=lineage))
+
         def _award(winner: str | None, task_obj) -> None:
             task_winners.append(winner)
-            if winner is not None and _is_continuous_sft(task_obj):
-                continuous_sft_winners.append(winner)
+            outcome = _lineage_outcome(task_obj)
+            if outcome is not None and winner is not None:
+                outcome.winner_hotkey = winner
 
         def _record_draw(task_id: str, task_obj) -> None:
-            """Take a drawn task out of the tally and queue a replacement of the same kind.
+            """Take a drawn task out of the tally and queue a stand-in for it.
 
-            The replacement mirrors the drawn task's type so the boss round keeps the mix it was
-            built with. Continuous-SFT is mirrored by lineage rather than downgraded to a plain
-            instruct task: the dethrone rule requires the challenger to *win* every continuous-SFT
-            task, and a draw does not satisfy that, so the challenger must be given another
-            continuous-SFT task of that same lineage to win.
+            The stand-in mirrors the drawn task's type so the boss round keeps the mix it was built
+            with, with one exception: a drawn continuous-SFT task is stood in for by a plain instruct
+            task on a fresh dataset pull, not by another chunk of the same lineage. Two tasks on one
+            lineage would share a single sequential train_index and leave the chain's carry-forward
+            picking between them, and the lineage does not need a second attempt anyway - a draw
+            already satisfies its dethrone gate. The stand-in is only there to top the tally back up.
             """
             drawn_task_ids.append(task_id)
-            drawn_task_types.append(task_obj.task_type)
-            if _is_continuous_sft(task_obj):
-                drawn_continuous_sft_task_ids.append(task_id)
-                drawn_continuous_sft_lineages.append(t_cst.continuous_sft_lineage_from_ds(task_obj.ds))
+            outcome = _lineage_outcome(task_obj)
+            if outcome is not None:
+                outcome.is_draw = True
+                decider_task_types.append(TaskType.INSTRUCTTEXTTASK)
             else:
-                drawn_continuous_sft_lineages.append(None)
+                decider_task_types.append(task_obj.task_type)
 
         # Get tournament info to determine the current champion and their consecutive wins
         tournament = await get_tournament(completed_round.tournament_id, psql_db)
@@ -600,14 +629,27 @@ async def get_knockout_winners(
         threshold_percentage = t_cst.BOSS_ROUND_WIN_MARGIN
         logger.info(f"Boss round using {threshold_percentage * 100:.1f}% win margin per task")
 
+        # A task with nobody assigned to it never ran, so it holds no evidence about either side.
+        # Scoring around it would charge somebody a loss on a task that never happened - and the
+        # only way one gets here is a decider that was created but never made it back to PENDING for
+        # node assignment (a crash, or a failure partway through creating a batch). Defer instead and
+        # let the caller return the round to PENDING, which is what assigns them.
+        unassigned_task_ids = [
+            task.task_id for task in round_tasks if not await get_nodes_assigned_to_task(task.task_id, psql_db)
+        ]
+        if unassigned_task_ids:
+            reason = (
+                f"{len(unassigned_task_ids)} boss-round task(s) have no assigned nodes and cannot have "
+                f"run ({unassigned_task_ids}); returning the round to node assignment rather than "
+                f"resolving around them"
+            )
+            logger.error(f"Boss round {completed_round.round_id}: {reason}")
+            return RoundOutcome(deferred_reason=reason, unassigned_task_ids=unassigned_task_ids)
+
         for task in round_tasks:
             logger.info(f"Processing boss round task {task.task_id}")
 
             task_object = await get_task(task.task_id, psql_db)
-
-            # Count even undecided ones, so a failed/skipped continuous-SFT task still blocks the dethrone.
-            if _is_continuous_sft(task_object):
-                num_continuous_sft_tasks += 1
 
             miner_results = await get_task_results_for_ranking(task.task_id, psql_db)
             if not miner_results:
@@ -694,15 +736,9 @@ async def get_knockout_winners(
                 basis=verdict.decided_by,
             )
 
-        # A drawn continuous-SFT task is not one the challenger can be asked to have won - its
-        # replacement is the one that has to be won. Leaving it in the total would make the
-        # "win ALL continuous-SFT tasks" gate unsatisfiable, since only the replacement can be won.
-        num_continuous_sft_tasks -= len(drawn_continuous_sft_task_ids)
-
         draw_resolution = _resolve_boss_round_draws(
             drawn_task_ids=drawn_task_ids,
-            drawn_task_types=drawn_task_types,
-            drawn_continuous_sft_lineages=drawn_continuous_sft_lineages,
+            decider_task_types=decider_task_types,
             round_tasks=round_tasks,
             tournament_type=tournament.tournament_type,
         )
@@ -724,8 +760,7 @@ async def get_knockout_winners(
             task_winners,
             boss_hotkey,
             tournament.tournament_type,
-            continuous_sft_winners,
-            num_continuous_sft_tasks,
+            list(continuous_sft_outcomes.values()),
             expected_task_count=expected_task_count,
         )
 

--- a/validator/tournament/round_results.py
+++ b/validator/tournament/round_results.py
@@ -20,9 +20,12 @@ from validator.evaluation.pvp.models import GameOutcome
 from validator.scoring.constants import EMISSION_BURN_HOTKEY
 from validator.scoring.tasks import calculate_miner_ranking_and_scores
 from validator.tournament import constants as t_cst
+from validator.tournament.models import BossRoundDrawResolution
+from validator.tournament.models import BossRoundTaskVerdict
 from validator.tournament.models import EmptyScoreGroup
 from validator.tournament.models import GroupMatchStanding
 from validator.tournament.models import MatchRanking
+from validator.tournament.models import RoundOutcome
 from validator.tournament.models import RoundType
 from validator.tournament.models import TournamentData
 from validator.tournament.models import TournamentResultsWithWinners
@@ -220,11 +223,12 @@ async def _resolve_boss_round_task_winner(
     opponent_loss: float,
     threshold_percentage: float,
     psql_db: PSQLDB,
-) -> tuple[str, str | None]:
+) -> BossRoundTaskVerdict:
     """Decide one boss-round task, preferring the paired per-example comparison.
 
-    Returns (winner, basis) - basis describes what decided it, for the persisted score_reason, and
-    is None when the relative margin decided it (the caller's default wording already says that).
+    ``decided_by`` describes what decided it, for the persisted score_reason, and is None when the
+    relative margin decided it (the caller's default wording already says that). ``is_draw`` marks
+    the task as carrying no result at all, which excludes it from the dethrone tally.
 
     Instruct and DPO losses are log-likelihoods, where a relative margin is the wrong scale and a
     scalar mean cannot separate a real win from held-out sampling noise. Where both sides have
@@ -258,7 +262,7 @@ async def _resolve_boss_round_task_winner(
                 f"(boss_fingerprint={boss_fingerprint} challenger_fingerprint={opponent_fingerprint} "
                 f"boss_n={len(boss_losses)} challenger_n={len(opponent_losses)}) - not counted as a win"
             )
-            return boss_hotkey, "unpairable per-example vectors"
+            return BossRoundTaskVerdict(winner_hotkey=boss_hotkey, decided_by="unpairable per-example vectors")
         else:
             comparison = compare_paired_losses(boss_losses, opponent_losses)
             # Logged whether the challenger won or lost: the observed win rate across real boss
@@ -275,11 +279,18 @@ async def _resolve_boss_round_task_winner(
             challenger_won, verdict_reason = challenger_takes_paired_task(comparison, boss_loss, opponent_loss)
             if not challenger_won:
                 logger.info(f"Boss round task {task_id}: {verdict_reason}")
-            # A draw is recorded as such. The defender still holds the task for the dethrone tally,
-            # but nobody outperformed anybody and the stored reason should not claim otherwise.
+            # A draw carries no result. The defender is named so the persisted score row has a
+            # holder, but is_draw takes the task out of the dethrone tally entirely and earns the
+            # round an extra task in its place - nothing here separated the two models, and that is
+            # a fact about the dataset rather than about the challenger.
             if comparison.is_draw:
-                return boss_hotkey, f"a draw ({verdict_reason})"
-            return (opponent_hotkey if challenger_won else boss_hotkey), f"per-example win rate ({verdict_reason})"
+                return BossRoundTaskVerdict(
+                    winner_hotkey=boss_hotkey, decided_by=f"a draw ({verdict_reason})", is_draw=True
+                )
+            return BossRoundTaskVerdict(
+                winner_hotkey=(opponent_hotkey if challenger_won else boss_hotkey),
+                decided_by=f"per-example win rate ({verdict_reason})",
+            )
 
     task_winner = (
         opponent_hotkey
@@ -292,7 +303,7 @@ async def _resolve_boss_round_task_winner(
         f"{task_object.task_type} task ({direction}): {winner_label} wins at {threshold_percentage * 100:.1f}% "
         f"margin (boss={boss_loss:.6f}, opponent={opponent_loss:.6f})"
     )
-    return task_winner, None
+    return BossRoundTaskVerdict(winner_hotkey=task_winner)
 
 
 def determine_boss_round_winner(
@@ -301,18 +312,24 @@ def determine_boss_round_winner(
     tournament_type: TournamentType,
     continuous_sft_winners: list[str] | None = None,
     num_continuous_sft_tasks: int = 0,
+    expected_task_count: int | None = None,
 ) -> str:
     """
     Determine the winner of a boss round based on task results and tournament type.
 
     Args:
-        task_winners: List of hotkeys that won each task in the boss round
+        task_winners: List of hotkeys that won each task in the boss round. Drawn tasks are not in
+            here - nothing separated the two models on them, so they carry no result.
         boss_hotkey: The defending champion's hotkey
         tournament_type: Type of tournament (TEXT or IMAGE)
         continuous_sft_winners: Hotkeys that won each *decided* continuous-SFT task.
-        num_continuous_sft_tasks: Total continuous-SFT tasks (decided or not). When >0 (text boss
-            round), the challenger must win EVERY one to dethrone, on top of the overall threshold —
-            so a failed/skipped continuous-SFT task blocks the dethrone. 0 (image) leaves the rule off.
+        num_continuous_sft_tasks: Decided continuous-SFT tasks. When >0 (text boss round), the
+            challenger must win EVERY one to dethrone, on top of the overall threshold — so a
+            failed/skipped continuous-SFT task blocks the dethrone. 0 (image) leaves the rule off.
+        expected_task_count: The size the boss round was built to. Sets the bar when draws left
+            fewer decided tasks than that, so an undecidable task never *lowers* what it takes to
+            dethrone — a challenger with two dead tasks must sweep the four that worked rather than
+            getting in on three. Defaults to however many tasks actually decided.
 
     Returns:
         Hotkey of the boss round winner
@@ -335,9 +352,11 @@ def determine_boss_round_winner(
 
     opponent_wins = win_counts.get(opponent_hotkey, 0) if opponent_hotkey else 0
 
-    # Both IMAGE and TEXT tournaments: challenger may lose at most one
-    # boss-round task. Each task requires beating the boss by BOSS_ROUND_WIN_MARGIN.
-    required_wins = max(1, total_tasks - 1)
+    # Both IMAGE and TEXT tournaments: challenger may lose at most one boss-round task. Each task
+    # requires beating the boss by BOSS_ROUND_WIN_MARGIN. Measured against the round's built size
+    # rather than the decided count so draws cannot slide the bar downward - they take a task out of
+    # the numerator, and the challenger has to make it up on the ones that did decide.
+    required_wins = max(1, max(total_tasks, expected_task_count or 0) - 1)
 
     # Continuous-SFT gate: challenger must win EVERY continuous-SFT task; only enforced when >0.
     challenger_continuous_wins = (
@@ -467,11 +486,62 @@ async def _resolve_knockout_task_winner(task: TournamentTask, psql_db: PSQLDB) -
     return winner
 
 
+def _resolve_boss_round_draws(
+    drawn_task_ids: list[str],
+    drawn_task_types: list[TaskType],
+    drawn_continuous_sft_lineages: list[str | None],
+    round_tasks: list[TournamentTask],
+    tournament_type: TournamentType,
+) -> BossRoundDrawResolution:
+    """Decide whether a boss round's draws earn it replacement tasks.
+
+    One replacement per drawn task, added in a single batch, and only once. The cap needs no state
+    of its own: the boss round is built to a fixed size and prep-failure replacement swaps tasks
+    without changing the count, so a round holding more tasks than its type calls for is a round
+    that has already had its deciders added. A decider that itself draws is therefore just excluded
+    and the round resolves on whatever was decided.
+    """
+    if not drawn_task_ids:
+        return BossRoundDrawResolution(reason="No drawn tasks")
+
+    expected = t_cst.expected_boss_round_task_count(tournament_type)
+    already_added = len(round_tasks) > expected if expected else False
+
+    if already_added:
+        return BossRoundDrawResolution(
+            drawn_task_ids=drawn_task_ids,
+            drawn_task_types=drawn_task_types,
+            can_add_deciders=False,
+            reason=(
+                f"{len(drawn_task_ids)} drawn task(s) excluded from the tally; the round already holds "
+                f"{len(round_tasks)} tasks against an expected {expected}, so its deciders were already "
+                f"added and it resolves on what was decided"
+            ),
+        )
+
+    return BossRoundDrawResolution(
+        drawn_task_ids=drawn_task_ids,
+        decider_task_types=drawn_task_types,
+        continuous_sft_lineages=drawn_continuous_sft_lineages,
+        can_add_deciders=True,
+        reason=(
+            f"{len(drawn_task_ids)} boss-round task(s) drew - nothing separated the two models on "
+            f"them - so each is excluded from the tally and gets one replacement task: "
+            f"{[t.value for t in drawn_task_types]}"
+        ),
+    )
+
+
 async def get_knockout_winners(
     completed_round: TournamentRoundData, round_tasks: list[TournamentTask], psql_db: PSQLDB, config: Config
-) -> list[str]:
-    """Get winners from knockout round."""
+) -> RoundOutcome:
+    """Get winners from knockout round.
+
+    Returns a deferred outcome when a boss round drew tasks and needs replacements added before it
+    can be resolved; the caller must add those tasks rather than advance.
+    """
     winners = []
+    draw_resolution: BossRoundDrawResolution | None = None
 
     if not completed_round.is_final_round:
         for task in round_tasks:
@@ -487,6 +557,13 @@ async def get_knockout_winners(
         # "challenger must win ALL continuous-SFT tasks" dethrone gate.
         continuous_sft_winners: list[str] = []
         num_continuous_sft_tasks = 0
+        # Tasks that separated nothing. Excluded from every tally below and handed to the caller,
+        # which adds one replacement task per draw so the round still resolves on a full set of
+        # decided results. See BossRoundDrawResolution.
+        drawn_task_ids: list[str] = []
+        drawn_task_types: list[TaskType] = []
+        drawn_continuous_sft_lineages: list[str | None] = []
+        drawn_continuous_sft_task_ids: list[str] = []
 
         def _is_continuous_sft(task_obj) -> bool:
             return task_obj is not None and t_cst.is_continuous_sft_task(task_obj)
@@ -496,11 +573,28 @@ async def get_knockout_winners(
             if winner is not None and _is_continuous_sft(task_obj):
                 continuous_sft_winners.append(winner)
 
+        def _record_draw(task_id: str, task_obj) -> None:
+            """Take a drawn task out of the tally and queue a replacement of the same kind.
+
+            The replacement mirrors the drawn task's type so the boss round keeps the mix it was
+            built with. Continuous-SFT is mirrored by lineage rather than downgraded to a plain
+            instruct task: the dethrone rule requires the challenger to *win* every continuous-SFT
+            task, and a draw does not satisfy that, so the challenger must be given another
+            continuous-SFT task of that same lineage to win.
+            """
+            drawn_task_ids.append(task_id)
+            drawn_task_types.append(task_obj.task_type)
+            if _is_continuous_sft(task_obj):
+                drawn_continuous_sft_task_ids.append(task_id)
+                drawn_continuous_sft_lineages.append(t_cst.continuous_sft_lineage_from_ds(task_obj.ds))
+            else:
+                drawn_continuous_sft_lineages.append(None)
+
         # Get tournament info to determine the current champion and their consecutive wins
         tournament = await get_tournament(completed_round.tournament_id, psql_db)
         if not tournament:
             logger.error(f"Could not find tournament {completed_round.tournament_id}")
-            return []
+            return RoundOutcome()
 
         # Challenger must beat the boss by BOSS_ROUND_WIN_MARGIN on each task to win it.
         threshold_percentage = t_cst.BOSS_ROUND_WIN_MARGIN
@@ -574,7 +668,7 @@ async def get_knockout_winners(
 
             logger.info(f"Boss round task {task.task_id}: Boss loss: {boss_loss:.6f}, Opponent loss: {opponent_loss:.6f}")
 
-            task_winner, decided_by = await _resolve_boss_round_task_winner(
+            verdict = await _resolve_boss_round_task_winner(
                 task_id=task.task_id,
                 task_object=task_object,
                 boss_hotkey=boss_hotkey,
@@ -584,24 +678,60 @@ async def get_knockout_winners(
                 threshold_percentage=threshold_percentage,
                 psql_db=psql_db,
             )
-            _award(task_winner, task_object)
+            if verdict.is_draw:
+                _record_draw(task.task_id, task_object)
+            else:
+                _award(verdict.winner_hotkey, task_object)
 
+            # Persisted even for a draw: the score row still needs a holder, and the reason says it
+            # was a draw. Only the dethrone tally ignores it.
             await update_threshold_adjusted_quality_scores_for_task(
                 task_id=task.task_id,
-                winner_hotkey=task_winner,
+                winner_hotkey=verdict.winner_hotkey,
                 threshold_percentage=threshold_percentage,
                 compared_hotkeys=[boss_hotkey, opponent_hotkey],
                 psql_db=psql_db,
-                basis=decided_by,
+                basis=verdict.decided_by,
             )
 
+        # A drawn continuous-SFT task is not one the challenger can be asked to have won - its
+        # replacement is the one that has to be won. Leaving it in the total would make the
+        # "win ALL continuous-SFT tasks" gate unsatisfiable, since only the replacement can be won.
+        num_continuous_sft_tasks -= len(drawn_continuous_sft_task_ids)
+
+        draw_resolution = _resolve_boss_round_draws(
+            drawn_task_ids=drawn_task_ids,
+            drawn_task_types=drawn_task_types,
+            drawn_continuous_sft_lineages=drawn_continuous_sft_lineages,
+            round_tasks=round_tasks,
+            tournament_type=tournament.tournament_type,
+        )
+        if draw_resolution.needs_deciders:
+            logger.info(
+                f"Boss round {completed_round.round_id} deferred: {draw_resolution.reason}"
+            )
+            return RoundOutcome(deferred_reason=draw_resolution.reason, draw_resolution=draw_resolution)
+
+        if draw_resolution.drawn_task_ids:
+            logger.info(f"Boss round {completed_round.round_id}: {draw_resolution.reason}")
+
+        # Pinned only when tasks were actually dropped for drawing, which by construction is text
+        # only. Everything else keeps deriving the bar from its own resolved task count.
+        expected_task_count = (
+            t_cst.expected_boss_round_task_count(tournament.tournament_type) if draw_resolution.drawn_task_ids else None
+        )
         boss_round_winner = determine_boss_round_winner(
-            task_winners, boss_hotkey, tournament.tournament_type, continuous_sft_winners, num_continuous_sft_tasks
+            task_winners,
+            boss_hotkey,
+            tournament.tournament_type,
+            continuous_sft_winners,
+            num_continuous_sft_tasks,
+            expected_task_count=expected_task_count,
         )
 
         winners = [boss_round_winner]
 
-    return winners
+    return RoundOutcome(winners=winners, draw_resolution=draw_resolution)
 
 
 async def find_groups_with_no_valid_scores(
@@ -879,19 +1009,29 @@ async def get_group_winners(
 
     return all_winners
 
-async def get_round_winners(completed_round: TournamentRoundData, psql_db: PSQLDB, config: Config) -> list[str]:
-    """Get winners from the completed round."""
+async def get_round_winners(completed_round: TournamentRoundData, psql_db: PSQLDB, config: Config) -> RoundOutcome:
+    """Get winners from the completed round.
+
+    A deferred outcome means the round gained tasks and is not resolvable yet - the caller must add
+    them and wait, not advance. Distinguishing that from an empty winner list matters: an empty list
+    means the boss retained by default and ends the tournament.
+    """
     round_tasks = await get_tournament_tasks(completed_round.round_id, psql_db)
 
     if completed_round.round_type == RoundType.KNOCKOUT:
-        winners = await get_knockout_winners(completed_round, round_tasks, psql_db, config)
+        outcome = await get_knockout_winners(completed_round, round_tasks, psql_db, config)
     else:
-        winners = await get_group_winners(completed_round, round_tasks, psql_db, config)
+        outcome = RoundOutcome(winners=await get_group_winners(completed_round, round_tasks, psql_db, config))
 
-    unique_winners = list(dict.fromkeys(winners))
-    if len(winners) != len(unique_winners):
-        logger.info(f"Removed {len(winners) - len(unique_winners)} duplicate winners from round {completed_round.round_id}")
-        logger.info(f"Original winners: {winners}")
+    if outcome.is_deferred:
+        return outcome
+
+    unique_winners = list(dict.fromkeys(outcome.winners))
+    if len(outcome.winners) != len(unique_winners):
+        logger.info(
+            f"Removed {len(outcome.winners) - len(unique_winners)} duplicate winners from round {completed_round.round_id}"
+        )
+        logger.info(f"Original winners: {outcome.winners}")
         logger.info(f"Unique winners: {unique_winners}")
 
-    return unique_winners
+    return outcome.model_copy(update={"winners": unique_winners})

--- a/validator/tournament/task_creator.py
+++ b/validator/tournament/task_creator.py
@@ -5,6 +5,8 @@ from core.constants.environments import TrainingStartPoint
 from core.logging import get_logger
 from core.models.image_models import ImageModelType
 from core.models.task_models import TaskType
+from core.oversampled_later_models import OVERSAMPLED_LATER_MODELS
+from core.oversampled_later_models import sample_oversampled_later_model
 from validator.app.config import Config
 from validator.db.sql import tasks as task_sql
 from validator.db.sql.continuous_sft import warn_orphaned_continuous_sft_state
@@ -431,22 +433,37 @@ async def _create_single_image_task_with_retry(
 
 
 async def _create_task_by_type(
-    task_type: TaskType, config: Config, models: list, instruct_datasets: list, dpo_datasets: list
+    task_type: TaskType,
+    config: Config,
+    models: list,
+    instruct_datasets: list,
+    dpo_datasets: list,
+    model_id_override: str | None = None,
 ) -> RawTask:
-    """Create a synthetic task of the specified type."""
+    """Create a synthetic task of the specified type.
+
+    model_id_override applies to instruct tasks only — it is the oversampled-later-model slot,
+    and the other task types draw from the content service pool as usual.
+    """
     if task_type == TaskType.IMAGETASK:
         return await create_synthetic_image_task(config, models)
     elif task_type == TaskType.INSTRUCTTEXTTASK:
-        return await create_synthetic_instruct_text_task(config, models, instruct_datasets, enable_kl=True)
+        return await create_synthetic_instruct_text_task(
+            config, models, instruct_datasets, enable_kl=True, model_id_override=model_id_override
+        )
     elif task_type == TaskType.DPOTASK:
-        return await create_synthetic_dpo_task(config, models, dpo_datasets)
+        return await create_synthetic_dpo_task(config, models, dpo_datasets, model_id_override=model_id_override)
     elif task_type == TaskType.GRPOTASK:
-        return await create_synthetic_grpo_task(config, models, instruct_datasets)
+        return await create_synthetic_grpo_task(
+            config, models, instruct_datasets, model_id_override=model_id_override
+        )
     elif task_type == TaskType.ENVIRONMENTTASK:
         return await create_synthetic_env_task(config, models, instruct_datasets)
     else:
         # Default to instruct text task
-        return await create_synthetic_instruct_text_task(config, models, instruct_datasets, enable_kl=True)
+        return await create_synthetic_instruct_text_task(
+            config, models, instruct_datasets, enable_kl=True, model_id_override=model_id_override
+        )
 
 
 async def _get_existing_tasks(existing_tournament_tasks: list, config: Config) -> list[RawTask]:
@@ -518,6 +535,14 @@ async def _create_group_text_tasks(
     )
     dpo_datasets = _get_dpo_datasets(config.keypair)
 
+    # Exactly one R1 task plays on a 2026+ model from OVERSAMPLED_LATER_MODELS (1 of N, whatever N is).
+    # The slot and the model both come from a round_id-seeded rng so a resumed round lands on the
+    # same choice, and the round is re-checked for an existing pool-model task so a task minted
+    # outside this loop can't lead to a second one.
+    oversampled_slot = _oversampled_model_slot(round_data, tasks_per_group)
+    if oversampled_slot is not None and await _round_already_has_oversampled_task(round_data.round_id, config):
+        oversampled_slot = None
+
     tasks = []
     for i, group in enumerate(round_data.groups):
         logger.info(f"  Group {i + 1} ({len(group.member_ids)} members): creating {tasks_per_group} instruct task(s)")
@@ -532,10 +557,57 @@ async def _create_group_text_tasks(
             dpo_datasets,
             tasks_per_group,
             enable_kl=round_data.round_number != 1,
+            oversampled_model_task_index=(
+                oversampled_slot - i * tasks_per_group if oversampled_slot is not None else None
+            ),
         )
         tasks.extend(group_tasks)
 
     return tasks
+
+
+def _oversampled_boss_task_type(round_id: str) -> TaskType:
+    """Which boss-round task type carries the oversampled model, drawn from a round_id-seeded rng.
+
+    Uniform over the round's task *slots* rather than over types, so with a 2/1/1 instruct/dpo/grpo
+    mix the model lands on an instruct task half the time. Seeded so a resumed round re-picks the
+    same type, and paired with the has-a-pool-task guard so a re-pick cannot add a second one.
+    """
+    slots = [
+        task_type
+        for task_type, count in t_cst.FINAL_ROUND_TEXT_TASK_DISTRIBUTION.items()
+        for _ in range(count)
+    ]
+    return random.Random(f"{round_id}:oversampled_type").choice(slots)
+
+
+async def _round_already_has_oversampled_task(round_id: str, config: Config) -> bool:
+    """Whether this round already plays a task on a model from OVERSAMPLED_LATER_MODELS.
+
+    The guard is the round's own task list rather than a creation-order index, so any task minted
+    outside the main creation loop — a draw decider, a replacement for a failed task — cannot hand
+    out a second oversampled slot.
+    """
+    pool_ids = {model.model_id for model in OVERSAMPLED_LATER_MODELS}
+    for tourn_task in await _get_existing_tasks_by_identifier(round_id, config):
+        task_obj = await task_sql.get_task(tourn_task.task_id, config.psql_db)
+        if task_obj and task_obj.model_id in pool_ids:
+            return True
+    return False
+
+
+def _oversampled_model_slot(round_data: GroupRound, tasks_per_group: int) -> int | None:
+    """Index of the single R1 task that plays on an oversampled later model, across all groups.
+
+    None outside round 1: a large tournament can still be in a group round later on, and the
+    oversampled-model slot is a round-1-only rule.
+    """
+    if round_data.round_number != 1:
+        return None
+    total_tasks = len(round_data.groups) * tasks_per_group
+    if total_tasks == 0:
+        return None
+    return random.Random(f"{round_data.round_id}:oversampled_slot").randrange(total_tasks)
 
 
 async def _create_single_group_text_tasks(
@@ -549,7 +621,10 @@ async def _create_single_group_text_tasks(
     dpo_datasets: list,
     tasks_per_group: int,
     enable_kl: bool,
+    oversampled_model_task_index: int | None = None,
 ) -> list[RawTask]:
+    """oversampled_model_task_index is this group's task index that plays on an oversampled later
+    model, or None/out-of-range when the round's single slot belongs to another group."""
     group_id = f"{round_id}_group_{group_index + 1:03d}"
 
     existing_tasks = await _get_existing_tasks_by_identifier(round_id, config, group_id=group_id)
@@ -560,9 +635,22 @@ async def _create_single_group_text_tasks(
         return await _get_existing_tasks(existing_tasks, config)
 
     created: list[RawTask] = await _get_existing_tasks(existing_tasks, config)
-    for _ in range(tasks_per_group - existing_count):
+    for task_index in range(existing_count, tasks_per_group):
         logger.info(f"    Group {group_index + 1} has {len(created)}/{tasks_per_group} task(s), creating 1 more")
-        task = await create_synthetic_instruct_text_task(config, models, instruct_datasets, enable_kl=enable_kl)
+        model_id_override = (
+            sample_oversampled_later_model(random.Random(f"{round_id}:oversampled_model"))
+            if task_index == oversampled_model_task_index
+            else None
+        )
+        if model_id_override:
+            logger.info(f"    Group {group_index + 1} task {task_index + 1} uses oversampled later model {model_id_override}")
+        task = await create_synthetic_instruct_text_task(
+            config,
+            models,
+            instruct_datasets,
+            enable_kl=enable_kl,
+            model_id_override=model_id_override,
+        )
         await _create_and_register_tournament_task(task, tournament_id, round_id, config, group_id=group_id)
         created.append(task)
 
@@ -738,10 +826,26 @@ async def _create_new_text_boss_round_tasks(tournament_id: str, round_id: str, c
         tasks.append(task_obj)
 
     # Fixed mix: 2 instruct + 1 dpo + 1 grpo (FINAL_ROUND_TEXT_TASK_DISTRIBUTION) + continuous-SFT.
+    # One of those tasks — any type, drawn uniformly over the slots — plays on a 2026+ model from
+    # OVERSAMPLED_LATER_MODELS. The gate is "this round has no pool-model task yet", not a
+    # creation-order index, so a task minted outside this loop (draw decider, replacement) cannot
+    # produce a second one. Continuous-SFT is excluded: its model is the carried lineage winner.
+    oversampled_done = await _round_already_has_oversampled_task(round_id, config)
+    oversampled_type = _oversampled_boss_task_type(round_id)
     for task_type, target_count in t_cst.FINAL_ROUND_TEXT_TASK_DISTRIBUTION.items():
         already = existing_task_type_counts.get(task_type.value, 0)
         for _ in range(target_count - already):
             models = big_models if random.random() < t_cst.PROBABILITY_OF_A_BIG_TEXT_MODEL else standard_models
+            model_id_override = (
+                sample_oversampled_later_model(random.Random(f"{round_id}:oversampled_model"))
+                if task_type == oversampled_type and not oversampled_done
+                else None
+            )
+            if model_id_override:
+                oversampled_done = True
+                logger.info(
+                    f"Boss round {task_type.value} task uses oversampled later model {model_id_override}"
+                )
             task = await _create_single_new_text_task(
                 task_type,
                 tournament_id,
@@ -751,6 +855,7 @@ async def _create_new_text_boss_round_tasks(tournament_id: str, round_id: str, c
                 models,
                 instruct_datasets,
                 dpo_datasets,
+                model_id_override=model_id_override,
             )
             if task:
                 tasks.append(task)
@@ -865,6 +970,7 @@ async def _create_single_new_text_task(
     models: list,
     instruct_datasets: list,
     dpo_datasets: list,
+    model_id_override: str | None = None,
 ) -> RawTask | None:
     """Create a single new synthetic text task of a specific type."""
     try:
@@ -872,7 +978,9 @@ async def _create_single_new_text_task(
             logger.error(f"Unknown task type {task_type} for boss round text task")
             return None
 
-        task = await _create_task_by_type(task_type, config, models, instruct_datasets, dpo_datasets)
+        task = await _create_task_by_type(
+            task_type, config, models, instruct_datasets, dpo_datasets, model_id_override=model_id_override
+        )
         await _create_and_register_tournament_task(
             task, tournament_id, round_id, config, pair_id=pair_id
         )

--- a/validator/tournament/task_creator.py
+++ b/validator/tournament/task_creator.py
@@ -773,7 +773,6 @@ async def create_boss_round_decider_tasks(
     round_id: str,
     config: Config,
     decider_task_types: list[TaskType],
-    continuous_sft_lineages: list[str | None],
 ) -> list[RawTask]:
     """Add one replacement task per drawn boss-round task.
 
@@ -782,15 +781,21 @@ async def create_boss_round_decider_tasks(
     us whether the tie dead zone is set too wide. It is simply excluded from the dethrone tally, and
     these tasks restore the count of decided results the tally runs over.
 
-    Each decider mirrors the type that drew, so the boss round keeps the mix it was built with.
-    Continuous-SFT draws get another continuous-SFT task of the same lineage rather than a plain
-    instruct task, because the dethrone rule requires the challenger to *win* every continuous-SFT
-    task and a draw cannot satisfy that.
+    Each decider mirrors the type that drew, so the boss round keeps the mix it was built with -
+    except a drawn continuous-SFT task, which the caller maps to a plain instruct task on a fresh
+    dataset pull. A drawn lineage has already cleared its own dethrone gate, so a second chunk of it
+    would buy nothing while putting two tasks on one sequential train_index.
 
     Nodes are deliberately not copied from the drawn task: the round returns to PENDING and
     assign_nodes_to_tournament_tasks assigns both sides afresh, which gives each decider its own
     expected_repo_name. Copying the drawn task's name would point evaluation at the model that was
     already trained and uploaded for it.
+
+    All-or-nothing. Each decider is registered in tournament_tasks as it is created, so a failure
+    partway through would otherwise leave the round holding tasks nobody will ever assign nodes to -
+    and since the decider cap keys off the round's task count, that surplus permanently blocks the
+    retry from completing the batch, leaving a task that never ran to be scored against somebody.
+    On failure the partial batch is deleted so the count is restored and the next cycle starts clean.
     """
     standard_models = _get_text_models(config.keypair)
     big_models = _get_text_models(config.keypair, smallest_size_b=12.0, largest_size_b=71.0)
@@ -799,26 +804,33 @@ async def create_boss_round_decider_tasks(
     pair_id = f"{round_id}_pair_001"
 
     tasks: list[RawTask] = []
-    for task_type, lineage in zip(decider_task_types, continuous_sft_lineages):
-        if lineage is not None:
-            seed_model = t_cst.continuous_sft_seed_repo(lineage)
-            if not seed_model:
-                raise ValueError(f"Cannot create a decider for unknown continuous-SFT lineage {lineage!r}")
-            logger.info(f"Creating continuous-SFT boss-round decider for lineage {lineage}")
-            tasks.append(await _create_continuous_sft_boss_task(tournament_id, round_id, pair_id, config, lineage, seed_model))
-            continue
-
-        models = big_models if random.random() < t_cst.PROBABILITY_OF_A_BIG_TEXT_MODEL else standard_models
-        logger.info(f"Creating {task_type.value} boss-round decider")
-        task = await _create_single_new_text_task(
-            task_type, tournament_id, round_id, pair_id, config, models, instruct_datasets, dpo_datasets
-        )
-        # _create_single_new_text_task swallows its errors and returns None. A missing decider would
-        # leave the round one decided result short and resolve it on a smaller field than intended,
-        # so raise instead and let the next cycle retry with the round still deferred.
-        if task is None:
-            raise RuntimeError(f"Failed to create {task_type.value} boss-round decider for round {round_id}")
-        tasks.append(task)
+    try:
+        for task_type in decider_task_types:
+            models = big_models if random.random() < t_cst.PROBABILITY_OF_A_BIG_TEXT_MODEL else standard_models
+            logger.info(f"Creating {task_type.value} boss-round decider")
+            task = await _create_single_new_text_task(
+                task_type, tournament_id, round_id, pair_id, config, models, instruct_datasets, dpo_datasets
+            )
+            # _create_single_new_text_task swallows its errors and returns None. A missing decider
+            # would leave the round one decided result short and resolve it on a smaller field than
+            # intended, so raise instead and let the next cycle retry the whole batch.
+            if task is None:
+                raise RuntimeError(f"Failed to create {task_type.value} boss-round decider for round {round_id}")
+            tasks.append(task)
+    except Exception:
+        for created in tasks:
+            try:
+                # Cascades to the tournament_tasks row, which is what restores the count.
+                await task_sql.delete_task(created.task_id, config.psql_db)
+                logger.info(f"Rolled back partially-created decider task {created.task_id}")
+            except Exception as cleanup_error:
+                logger.error(
+                    f"Could not roll back decider task {created.task_id} for round {round_id}: {cleanup_error}. "
+                    f"The round now holds a task that will never be assigned nodes - resolution will "
+                    f"refuse to advance until it is removed.",
+                    exc_info=True,
+                )
+        raise
 
     logger.info(f"Created {len(tasks)} boss-round decider task(s) for round {round_id}")
     return tasks

--- a/validator/tournament/task_creator.py
+++ b/validator/tournament/task_creator.py
@@ -768,6 +768,62 @@ async def _create_new_text_boss_round_tasks(tournament_id: str, round_id: str, c
     return tasks
 
 
+async def create_boss_round_decider_tasks(
+    tournament_id: str,
+    round_id: str,
+    config: Config,
+    decider_task_types: list[TaskType],
+    continuous_sft_lineages: list[str | None],
+) -> list[RawTask]:
+    """Add one replacement task per drawn boss-round task.
+
+    Additive, not a replacement in the replace_tournament_task sense: the drawn task keeps its
+    training, its eval rows and its per-example loss vectors, which are the only data that can tell
+    us whether the tie dead zone is set too wide. It is simply excluded from the dethrone tally, and
+    these tasks restore the count of decided results the tally runs over.
+
+    Each decider mirrors the type that drew, so the boss round keeps the mix it was built with.
+    Continuous-SFT draws get another continuous-SFT task of the same lineage rather than a plain
+    instruct task, because the dethrone rule requires the challenger to *win* every continuous-SFT
+    task and a draw cannot satisfy that.
+
+    Nodes are deliberately not copied from the drawn task: the round returns to PENDING and
+    assign_nodes_to_tournament_tasks assigns both sides afresh, which gives each decider its own
+    expected_repo_name. Copying the drawn task's name would point evaluation at the model that was
+    already trained and uploaded for it.
+    """
+    standard_models = _get_text_models(config.keypair)
+    big_models = _get_text_models(config.keypair, smallest_size_b=12.0, largest_size_b=71.0)
+    instruct_datasets = _get_instruct_text_datasets(config.keypair)
+    dpo_datasets = _get_dpo_datasets(config.keypair)
+    pair_id = f"{round_id}_pair_001"
+
+    tasks: list[RawTask] = []
+    for task_type, lineage in zip(decider_task_types, continuous_sft_lineages):
+        if lineage is not None:
+            seed_model = t_cst.continuous_sft_seed_repo(lineage)
+            if not seed_model:
+                raise ValueError(f"Cannot create a decider for unknown continuous-SFT lineage {lineage!r}")
+            logger.info(f"Creating continuous-SFT boss-round decider for lineage {lineage}")
+            tasks.append(await _create_continuous_sft_boss_task(tournament_id, round_id, pair_id, config, lineage, seed_model))
+            continue
+
+        models = big_models if random.random() < t_cst.PROBABILITY_OF_A_BIG_TEXT_MODEL else standard_models
+        logger.info(f"Creating {task_type.value} boss-round decider")
+        task = await _create_single_new_text_task(
+            task_type, tournament_id, round_id, pair_id, config, models, instruct_datasets, dpo_datasets
+        )
+        # _create_single_new_text_task swallows its errors and returns None. A missing decider would
+        # leave the round one decided result short and resolve it on a smaller field than intended,
+        # so raise instead and let the next cycle retry with the round still deferred.
+        if task is None:
+            raise RuntimeError(f"Failed to create {task_type.value} boss-round decider for round {round_id}")
+        tasks.append(task)
+
+    logger.info(f"Created {len(tasks)} boss-round decider task(s) for round {round_id}")
+    return tasks
+
+
 async def _create_continuous_sft_boss_task(
     tournament_id: str, round_id: str, pair_id: str, config: Config, lineage: str, seed_model: str
 ) -> RawTask:

--- a/validator/tournament/tournament_manager.py
+++ b/validator/tournament/tournament_manager.py
@@ -75,6 +75,7 @@ from validator.tournament.models import GroupRound
 from validator.tournament.models import KnockoutRound
 from validator.tournament.models import RespondingNode
 from validator.tournament.models import Round
+from validator.tournament.models import RoundOutcome
 from validator.tournament.models import TaskFailureReviewStatus
 from validator.tournament.models import RoundStatus
 from validator.tournament.models import RoundType
@@ -98,6 +99,7 @@ from validator.tournament.reports import generate_diff_report_and_notify_tournam
 from validator.tournament.round_results import determine_env_tournament_winner
 from validator.tournament.round_results import find_groups_with_no_valid_scores
 from validator.tournament.round_results import get_round_winners
+from validator.tournament.task_creator import create_boss_round_decider_tasks
 from validator.tournament.task_creator import create_environment_tournament_tasks
 from validator.tournament.task_creator import create_image_tournament_tasks
 from validator.tournament.task_creator import create_text_tournament_tasks
@@ -347,7 +349,13 @@ async def _carry_forward_continuous_sft(
     """After a TEXT boss round, carry each lineage's lowest-eval-loss winner forward as its next base
     and advance continuous_sft_state (idempotent on source_round_id, so reprocessing can't double-advance).
     """
-    found = False
+    # A lineage can hold more than one task in a round: a drawn continuous-SFT task is excluded from
+    # the dethrone tally and given a replacement of the same lineage, so both sit here. The last one
+    # created is the one that decided the lineage, and advance_continuous_sft_state is idempotent on
+    # source_round_id - so without picking deliberately, whichever the query returned first would
+    # win and the lineage could carry forward the drawn task's model. get_tournament_tasks orders by
+    # created_at for exactly this reason.
+    latest_task_per_lineage: dict[str, str] = {}
     for round_task in round_tasks:
         task_obj = await task_sql.get_task(round_task.task_id, psql_db)
         if not task_obj:
@@ -360,20 +368,26 @@ async def _carry_forward_continuous_sft(
                 f"Continuous-SFT task {round_task.task_id} has no lineage in ds={task_obj.ds}; skipping carry-forward"
             )
             continue
-        found = True
+        if lineage in latest_task_per_lineage:
+            logger.info(
+                f"Continuous-SFT lineage {lineage} has an earlier task {latest_task_per_lineage[lineage]} in this "
+                f"round (a draw that was given a decider); carrying forward from {round_task.task_id} instead"
+            )
+        latest_task_per_lineage[lineage] = round_task.task_id
 
+    found = bool(latest_task_per_lineage)
+    for lineage, task_id in latest_task_per_lineage.items():
         # Carried as-is (a LoRA winner is flattened by next round's model-prep); None when the week
         # had no scored winner, in which case advance preserves the prior repo.
-        winner_repo = await task_sql.get_lowest_loss_repo_for_task(round_task.task_id, psql_db)
+        winner_repo = await task_sql.get_lowest_loss_repo_for_task(task_id, psql_db)
         logger.info(
-            f"Continuous-SFT carry-forward: lineage={lineage} task={round_task.task_id} "
-            f"carried_winner={winner_repo}"
+            f"Continuous-SFT carry-forward: lineage={lineage} task={task_id} carried_winner={winner_repo}"
         )
         try:
             await advance_continuous_sft_state(lineage, winner_repo, source_round_id, psql_db)
         except Exception as e:
             logger.error(
-                f"Failed to advance continuous_sft_state[{lineage}] for task {round_task.task_id}: {e}", exc_info=True
+                f"Failed to advance continuous_sft_state[{lineage}] for task {task_id}: {e}", exc_info=True
             )
 
     if not found:
@@ -607,7 +621,16 @@ async def advance_tournament(tournament: TournamentData, completed_round: Tourna
             await _alert_empty_score_groups(tournament, completed_round, empty_score_groups, config)
             return
 
-        winners = await get_round_winners(completed_round, psql_db, config)
+        outcome = await get_round_winners(completed_round, psql_db, config)
+
+        # A boss-round task that separated nothing is excluded from the dethrone tally and earns the
+        # round one extra task in its place, so the tally still runs over a full set of decided
+        # results. Adding those tasks puts the round back to PENDING; it advances on a later pass.
+        if outcome.is_deferred:
+            await _add_boss_round_deciders(tournament, completed_round, outcome, config, psql_db)
+            return
+
+        winners = outcome.winners
         logger.info(f"Round winners: {winners}")
         logger.info(f"Number of winners: {len(winners)}")
 
@@ -1328,6 +1351,62 @@ async def process_active_tournaments(config: Config):
             logger.error(f"Error processing active tournaments: {e}", exc_info=True)
         finally:
             await asyncio.sleep(t_cst.TOURNAMENT_ACTIVE_CYCLE_INTERVAL)
+
+
+async def _add_boss_round_deciders(
+    tournament: TournamentData,
+    completed_round: TournamentRoundData,
+    outcome: RoundOutcome,
+    config: Config,
+    psql_db: PSQLDB,
+) -> None:
+    """Add the boss round's decider tasks and put the round back to PENDING.
+
+    PENDING is what gets the tasks trained: process_pending_rounds assigns nodes to anything in the
+    round without them (giving each decider its own expected_repo_name) and flips it back to ACTIVE,
+    after which the round completes and advances normally. Boss-round task creation is idempotent on
+    the task count, so the pending pass will not add a second set.
+
+    Failure to create leaves the round COMPLETED and unadvanced, so the next cycle retries.
+    """
+    resolution = outcome.draw_resolution
+    if resolution is None:
+        logger.error(f"Round {completed_round.round_id} deferred with no draw resolution attached; not advancing")
+        return
+
+    logger.info(
+        f"Boss round {completed_round.round_id} drew {len(resolution.drawn_task_ids)} task(s) "
+        f"({resolution.drawn_task_ids}); adding deciders before it can be resolved"
+    )
+
+    try:
+        tasks = await create_boss_round_decider_tasks(
+            tournament.tournament_id,
+            completed_round.round_id,
+            config,
+            resolution.decider_task_types,
+            resolution.continuous_sft_lineages,
+        )
+    except Exception as e:
+        logger.error(
+            f"Failed to create boss-round decider tasks for round {completed_round.round_id}: {e}. "
+            f"Round stays completed and unadvanced; retrying next cycle.",
+            exc_info=True,
+        )
+        return
+
+    await update_round_status(completed_round.round_id, RoundStatus.PENDING, psql_db)
+    logger.info(f"Round {completed_round.round_id} returned to PENDING with {len(tasks)} decider task(s)")
+
+    await _notify_discord(
+        f"Boss round extended - drawn task(s)\n"
+        f"Tournament: {tournament.tournament_id} ({tournament.tournament_type.value})\n"
+        f"Round: {completed_round.round_id}\n"
+        f"{resolution.reason}\n"
+        f"Added {len(tasks)} task(s): {[str(task.task_id) for task in tasks]}\n"
+        f"The drawn task(s) keep their results but do not count toward the dethrone tally.",
+        config,
+    )
 
 
 async def _alert_empty_score_groups(

--- a/validator/tournament/tournament_manager.py
+++ b/validator/tournament/tournament_manager.py
@@ -111,6 +111,9 @@ logger = get_logger(__name__)
 # Rounds we have already pinged Discord about for having zero-score groups. Process-local on
 # purpose: a restart re-alerts, which is the right behaviour for a condition needing a human.
 _EMPTY_SCORE_ROUNDS_ALERTED: set[str] = set()
+# Rounds already pinged about a failed draw-decider creation. Same reason as the set above: the
+# retry runs on a 60s loop and would otherwise hammer the webhook until someone intervenes.
+_DECIDER_CREATION_FAILED_ROUNDS: set[str] = set()
 
 
 def exceeds_failure_threshold(trainings: dict[str, str]) -> bool:
@@ -349,13 +352,12 @@ async def _carry_forward_continuous_sft(
     """After a TEXT boss round, carry each lineage's lowest-eval-loss winner forward as its next base
     and advance continuous_sft_state (idempotent on source_round_id, so reprocessing can't double-advance).
     """
-    # A lineage can hold more than one task in a round: a drawn continuous-SFT task is excluded from
-    # the dethrone tally and given a replacement of the same lineage, so both sit here. The last one
-    # created is the one that decided the lineage, and advance_continuous_sft_state is idempotent on
-    # source_round_id - so without picking deliberately, whichever the query returned first would
-    # win and the lineage could carry forward the drawn task's model. get_tournament_tasks orders by
-    # created_at for exactly this reason.
-    latest_task_per_lineage: dict[str, str] = {}
+    # Exactly one task per lineage, which is why this can carry forward the first it finds. A drawn
+    # continuous-SFT task is stood in for by a plain instruct task rather than a second chunk of the
+    # same lineage, precisely so that stays true: two tasks sharing one sequential train_index would
+    # leave this picking between them, with advance_continuous_sft_state idempotent on
+    # source_round_id so whichever came first would silently win.
+    found = False
     for round_task in round_tasks:
         task_obj = await task_sql.get_task(round_task.task_id, psql_db)
         if not task_obj:
@@ -368,26 +370,20 @@ async def _carry_forward_continuous_sft(
                 f"Continuous-SFT task {round_task.task_id} has no lineage in ds={task_obj.ds}; skipping carry-forward"
             )
             continue
-        if lineage in latest_task_per_lineage:
-            logger.info(
-                f"Continuous-SFT lineage {lineage} has an earlier task {latest_task_per_lineage[lineage]} in this "
-                f"round (a draw that was given a decider); carrying forward from {round_task.task_id} instead"
-            )
-        latest_task_per_lineage[lineage] = round_task.task_id
+        found = True
 
-    found = bool(latest_task_per_lineage)
-    for lineage, task_id in latest_task_per_lineage.items():
         # Carried as-is (a LoRA winner is flattened by next round's model-prep); None when the week
         # had no scored winner, in which case advance preserves the prior repo.
-        winner_repo = await task_sql.get_lowest_loss_repo_for_task(task_id, psql_db)
+        winner_repo = await task_sql.get_lowest_loss_repo_for_task(round_task.task_id, psql_db)
         logger.info(
-            f"Continuous-SFT carry-forward: lineage={lineage} task={task_id} carried_winner={winner_repo}"
+            f"Continuous-SFT carry-forward: lineage={lineage} task={round_task.task_id} "
+            f"carried_winner={winner_repo}"
         )
         try:
             await advance_continuous_sft_state(lineage, winner_repo, source_round_id, psql_db)
         except Exception as e:
             logger.error(
-                f"Failed to advance continuous_sft_state[{lineage}] for task {task_id}: {e}", exc_info=True
+                f"Failed to advance continuous_sft_state[{lineage}] for task {round_task.task_id}: {e}", exc_info=True
             )
 
     if not found:
@@ -1367,8 +1363,29 @@ async def _add_boss_round_deciders(
     after which the round completes and advances normally. Boss-round task creation is idempotent on
     the task count, so the pending pass will not add a second set.
 
-    Failure to create leaves the round COMPLETED and unadvanced, so the next cycle retries.
+    Failure to create leaves the round COMPLETED and unadvanced, so the next cycle retries. The
+    partial batch is rolled back by the creator, so the retry starts from the same state this one did.
     """
+    # Nothing to create - the round already holds tasks that never got nodes (a crash between
+    # creating deciders and this status flip). PENDING is the whole fix: node assignment picks them
+    # up and the round runs them.
+    if outcome.unassigned_task_ids:
+        await update_round_status(completed_round.round_id, RoundStatus.PENDING, psql_db)
+        logger.warning(
+            f"Round {completed_round.round_id} returned to PENDING to assign nodes to "
+            f"{len(outcome.unassigned_task_ids)} orphaned task(s): {outcome.unassigned_task_ids}"
+        )
+        await _notify_discord(
+            f"Boss round returned for node assignment\n"
+            f"Tournament: {tournament.tournament_id} ({tournament.tournament_type.value})\n"
+            f"Round: {completed_round.round_id}\n"
+            f"{outcome.deferred_reason}\n"
+            f"Most likely a crash between creating a draw decider and returning the round to PENDING. "
+            f"No action needed unless it repeats.",
+            config,
+        )
+        return
+
     resolution = outcome.draw_resolution
     if resolution is None:
         logger.error(f"Round {completed_round.round_id} deferred with no draw resolution attached; not advancing")
@@ -1385,13 +1402,26 @@ async def _add_boss_round_deciders(
             completed_round.round_id,
             config,
             resolution.decider_task_types,
-            resolution.continuous_sft_lineages,
         )
     except Exception as e:
         logger.error(
             f"Failed to create boss-round decider tasks for round {completed_round.round_id}: {e}. "
             f"Round stays completed and unadvanced; retrying next cycle.",
             exc_info=True,
+        )
+        # Some causes retry out of it (a flaky content service), some never will - an unknown
+        # continuous-SFT lineage, or a drawn task whose type has no creation route. Those spin
+        # silently on a 60s loop forever, so say so once, as every other blocking path here does.
+        await _alert_once(
+            completed_round.round_id,
+            _DECIDER_CREATION_FAILED_ROUNDS,
+            f"Boss round decider creation FAILED\n"
+            f"Tournament: {tournament.tournament_id} ({tournament.tournament_type.value})\n"
+            f"Round: {completed_round.round_id}\n"
+            f"Error: {e}\n"
+            f"Types requested: {[t.value for t in resolution.decider_task_types]}\n"
+            f"The round will retry every cycle but will NOT advance until this succeeds.",
+            config,
         )
         return
 
@@ -1429,11 +1459,9 @@ async def _alert_empty_score_groups(
         f"{len(empty_score_groups)} group(s) finished with no valid scores.\n{detail}"
     )
 
-    if completed_round.round_id in _EMPTY_SCORE_ROUNDS_ALERTED:
-        return
-    _EMPTY_SCORE_ROUNDS_ALERTED.add(completed_round.round_id)
-
-    await _notify_discord(
+    await _alert_once(
+        completed_round.round_id,
+        _EMPTY_SCORE_ROUNDS_ALERTED,
         f"Tournament advancement BLOCKED\n"
         f"Tournament: {tournament.tournament_id} ({tournament.tournament_type.value})\n"
         f"Round: {completed_round.round_id}\n"
@@ -1442,6 +1470,14 @@ async def _alert_empty_score_groups(
         f"Evaluation data is missing for these groups — fix the scores, then the cycle will advance on its own.",
         config,
     )
+
+
+async def _alert_once(round_id: str, already_alerted: set[str], message: str, config: Config) -> None:
+    """Ping Discord once per round per process for a condition that retries on a 60s loop."""
+    if round_id in already_alerted:
+        return
+    already_alerted.add(round_id)
+    await _notify_discord(message, config)
 
 
 async def _notify_discord(message: str, config: Config) -> None:

--- a/validator/tournament/tournament_manager.py
+++ b/validator/tournament/tournament_manager.py
@@ -21,9 +21,9 @@ from core.models.payload_models import TrainingRepoResponse
 from core.models.task_models import TaskStatus
 from validator.app.config import Config
 from validator.db.database import PSQLDB
+from validator.db.sql import task_failure_reviews as task_failure_reviews_sql
 from validator.db.sql import tasks as task_sql
 from validator.db.sql.continuous_sft import advance_continuous_sft_state
-from validator.db.sql import task_failure_reviews as task_failure_reviews_sql
 from validator.db.sql.nodes import get_all_nodes
 from validator.db.sql.nodes import get_node_by_hotkey
 from validator.db.sql.tournaments import add_tournament_participants
@@ -76,9 +76,9 @@ from validator.tournament.models import KnockoutRound
 from validator.tournament.models import RespondingNode
 from validator.tournament.models import Round
 from validator.tournament.models import RoundOutcome
-from validator.tournament.models import TaskFailureReviewStatus
 from validator.tournament.models import RoundStatus
 from validator.tournament.models import RoundType
+from validator.tournament.models import TaskFailureReviewStatus
 from validator.tournament.models import TournamentData
 from validator.tournament.models import TournamentParticipant
 from validator.tournament.models import TournamentRoundData

--- a/validator/tournament/utils.py
+++ b/validator/tournament/utils.py
@@ -21,6 +21,7 @@ from validator.tournament.participants import get_latest_commit_hash_from_github
 from validator.tournament.participants import get_latest_tournament_winner_participant
 from validator.tournament.reports import generate_diff_report_and_notify_tournament_completed
 from validator.tournament.reports import generate_diff_report_for_result
+from validator.tournament.round_results import _resolve_boss_round_draws
 from validator.tournament.round_results import determine_boss_round_winner
 from validator.tournament.round_results import determine_env_tournament_winner
 from validator.tournament.round_results import did_winner_change
@@ -38,6 +39,7 @@ from validator.tournament.thresholds import update_threshold_adjusted_quality_sc
 __all__ = [
     "_get_final_round_participants",
     "_get_scores_for_task",
+    "_resolve_boss_round_draws",
     "deduplicate_by_github_account",
     "deduplicate_by_ip_address",
     "determine_boss_round_winner",


### PR DESCRIPTION
Stacked on #1352 — the boss-round slot has to know about draw deciders, so this targets `boss-round-draw-deciders` rather than `main`.

## Why

The content service's `/get_random_models` pool only goes up to 2025. Every text task in prod plays on a 2023–2025 model; the only 2026 models the DB has ever seen are customer-submitted organic tasks, which are outside the competition. Until the content service can filter by release date, this keeps a verified pool in-repo and samples it directly.

## The pool

`core/oversampled_later_models.json`, 12 models. Each verified against the live HF API:

- created 2026+, ungated, safetensors present, under 14B
- **no** `auto_map` and no `.py` in the repo, so `trust_remote_code=False` loads it (which is what `trainer/model_prep/entrypoint.py`, `validator/evaluation/common.py` and `core/pvp/sglang_launch.py` all enforce)
- no `quantization_config`
- `model_type` present in `MODEL_FOR_CAUSAL_LM_MAPPING_NAMES` for transformers 5.12.1 — the version `ops/docker/trainer-downloader.dockerfile` pins and the axolotl v5 base ships

| model | params | arch |
|---|---|---|
| `Qwen/Qwen3.5-0.8B` / `-2B` / `-4B` / `-9B` | 0.87–9.65B | qwen3_5 |
| `google/gemma-4-E2B-it` / `-E4B-it` | 5.12B / 8.0B | gemma4 |
| `LiquidAI/LFM2.5-1.2B-Instruct` / `-2.6B` / `-8B-A1B` | 1.17–8.47B | lfm2, lfm2_moe (MoE) |
| `ibm-granite/granite-4.1-3b` / `-8b` | 3.4B / 8.79B | granite |
| `openbmb/MiniCPM5-1B` | 1.08B | llama |

Notable rejects: `nvidia/NVIDIA-Nemotron-3-Nano-4B`, `tencent/Hy-MT2-*`, `Nanbeige/Nanbeige4.2-3B`, `openbmb/NOSA-8B` (all need remote code); `ibm-granite/granite-switch-*`, `granite-swash-*`, `tencent/HiLS-Attention-7B` (arch not in tf 5.12).

## The two slots

- **Round 1** — exactly one task across all groups, whether the round is the normal one-task-per-group format or the small-tournament three-match one.
- **Boss round** — one task, with its type drawn over the instruct/dpo/grpo slots rather than pinned to instruct. `create_synthetic_dpo_task` and `create_synthetic_grpo_task` gain `model_id_override`, matching what the instruct creator already had.

Both draws are seeded on the round id, so a resumed round lands on the same slot and the same model. Both are gated on *"this round has no pool-model task yet"* rather than a creation-order index — that gate is what stops a draw decider (which mirrors the drawn task's type) or a replacement task from being a free second roll. Continuous-SFT tasks are excluded; their model is the carried lineage winner.

## Worth knowing before this runs

- **Qwen3.5 repos are `Qwen3_5ForConditionalGeneration`** — unified text+vision checkpoints tagged `image-text-to-text`. `qwen3_5` is in the causal-LM auto-mapping so `AutoModelForCausalLM` resolves, but the weights carry a vision tower, so the param count is above what the name suggests. Axolotl text SFT on a unified checkpoint is the one thing not verifiable from repo metadata.
- **`lfm2` / `lfm2_moe` are hybrid conv/attention.** In-mapping with no remote code; the risk is axolotl's packing/flash-attn paths, not transformers.
- Recommend a smoke run (one train + eval per new arch) before this rides a real tournament.

## Tests

`tests/validator/tournament/test_oversampled_later_models.py` — one-per-R1 across 2/3/8 groups and the small format, one-per-boss-round, the slot type varying across instruct/dpo/grpo, resume not minting a second, and deciders never drawing from the pool.

`tests/validator/tournament` is green (208 passed). Four pre-existing failures elsewhere in `tests/validator` (`test_basilica_cleanup` ×3, `test_training_hours::test_floor_for_tiny_tasks`) reproduce on `boss-round-draw-deciders` without these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)